### PR TITLE
feat: Disable branch protection for solo development

### DIFF
--- a/BRANCH_PROTECTION.md
+++ b/BRANCH_PROTECTION.md
@@ -1,0 +1,62 @@
+# Branch Protection Configuration
+
+This document explains the branch protection settings for the vTeam repository.
+
+## Current Configuration
+
+The `main` branch has minimal protection rules optimized for solo development:
+
+- ✅ **Admin enforcement enabled** - Ensures consistency in protection rules
+- ❌ **Required PR reviews disabled** - Allows self-merging of PRs
+- ❌ **Status checks disabled** - No CI/CD requirements (can be added later)
+- ❌ **Restrictions disabled** - No user/team restrictions on merging
+
+## Rationale
+
+This configuration is designed for **solo development** scenarios where:
+
+1. **Jeremy is the primary/only developer** - Self-review doesn't add value
+2. **Maintains Git history** - PRs are still encouraged for tracking changes
+3. **Removes friction** - No waiting for external approvals
+4. **Preserves flexibility** - Can easily revert when team grows
+
+## Usage Patterns
+
+### Recommended Workflow
+1. Create feature branches for significant changes
+2. Create PRs for change documentation and review history
+3. Self-merge PRs when ready (no approval needed)
+4. Use direct pushes only for hotfixes or minor updates
+
+### When to Use PRs vs Direct Push
+- **PRs**: New features, architecture changes, documentation updates
+- **Direct Push**: Typo fixes, quick configuration changes, emergency hotfixes
+
+## Future Considerations
+
+When the team grows beyond solo development, consider re-enabling:
+
+```bash
+# Re-enable required reviews (example)
+gh api --method PUT repos/red-hat-data-services/vTeam/branches/main/protection \
+  --field required_status_checks=null \
+  --field enforce_admins=true \
+  --field required_pull_request_reviews='{"required_approving_review_count":1,"dismiss_stale_reviews":true,"require_code_owner_reviews":false}' \
+  --field restrictions=null
+```
+
+## Commands Used
+
+To disable branch protection (current state):
+```bash
+gh api --method PUT repos/red-hat-data-services/vTeam/branches/main/protection \
+  --field required_status_checks=null \
+  --field enforce_admins=true \
+  --field required_pull_request_reviews=null \
+  --field restrictions=null
+```
+
+To check current protection status:
+```bash
+gh api repos/red-hat-data-services/vTeam/branches/main/protection
+```


### PR DESCRIPTION
## Summary
Remove required PR reviews from main branch protection to enable self-merging of PRs during solo development phase.

## Changes Made
- **Branch Protection API**: Disabled required PR reviews via GitHub API
- **Documentation**: Added BRANCH_PROTECTION.md explaining the configuration
- **Admin Enforcement**: Maintained admin enforcement for consistency

## Rationale
- Jeremy is currently the solo developer on this project
- Required reviews add friction without value in single-developer scenarios  
- PRs are still encouraged for change tracking and documentation
- Easy to revert when team expands

## Testing
This PR will test the new branch protection settings by attempting self-merge.

## Configuration Applied
```bash
gh api --method PUT repos/red-hat-data-services/vTeam/branches/main/protection \
  --field required_status_checks=null \
  --field enforce_admins=true \
  --field required_pull_request_reviews=null \
  --field restrictions=null
```

🤖 Generated with [Claude Code](https://claude.ai/code)