### PR TITLE
Fix UI component import restrictions and async coroutine issues

### DIFF
--- a/demos/rfe-builder/src/agents.py
+++ b/demos/rfe-builder/src/agents.py
@@ -18,33 +18,15 @@ from src.prompts import get_prompt, PROMPT_NAMES
 async def stream_structured_predict(
     output_cls, prompt_template, persona: str, **prompt_args
 ):
-    """Simple streaming with UI events every 50 chars"""
+    """Non-streaming structured predict to avoid coroutine issues"""
     try:
-        stream_generator = Settings.llm.astream_structured_predict(
+        # Use non-streaming version to avoid async generator coroutine warnings
+        response = await Settings.llm.astructured_predict(
             output_cls, prompt_template, **prompt_args
         )
-
-        accumulated_text = ""
-        char_count = 0
-        final_response = None
-
-        async for partial_response in stream_generator:
-            # Get text content
-            current_text = (
-                getattr(partial_response, "analysis", "")
-                or getattr(partial_response, "synthesis", "")
-                or str(partial_response)
-            )
-
-            if len(current_text) > len(accumulated_text):
-                char_count += len(current_text) - len(accumulated_text)
-                accumulated_text = current_text
-
-            final_response = partial_response
-
-        return final_response
+        return response
     except Exception as e:
-        print(f"Error in stream_structured_predict for {persona}: {e}")
+        print(f"Error in structured_predict for {persona}: {e}")
         # Return a basic response object
         return output_cls(analysis=f"Error during analysis: {str(e)}", persona=persona)
 

--- a/demos/rfe-builder/test_async_patterns.py
+++ b/demos/rfe-builder/test_async_patterns.py
@@ -1,0 +1,201 @@
+"""Test async patterns to catch coroutine and async/await issues."""
+
+import pytest
+import ast
+import asyncio
+import inspect
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+
+class TestAsyncPatterns:
+    """Test suite to prevent async/await and coroutine issues."""
+    
+    def test_workflow_methods_handle_async_properly(self):
+        """Test that workflow methods properly handle async operations."""
+        from src.rfe_builder_workflow import RFEBuilderWorkflow
+        
+        workflow = RFEBuilderWorkflow()
+        
+        # Check that streaming methods use non-streaming alternatives when needed
+        assert hasattr(workflow.llm, 'acomplete'), "LLM should have acomplete method for non-streaming"
+        assert hasattr(workflow.llm, 'astream_complete'), "LLM should have astream_complete method for streaming"
+    
+    @pytest.mark.asyncio
+    async def test_llm_acomplete_returns_awaitable(self):
+        """Test that LLM acomplete method returns proper awaitable."""
+        from src.rfe_builder_workflow import RFEBuilderWorkflow
+        from llama_index.core.llms.mock import MockLLM
+        
+        # Use mock LLM to test async pattern
+        mock_llm = MockLLM()
+        workflow = RFEBuilderWorkflow()
+        workflow.llm = mock_llm
+        
+        # Test that acomplete is awaitable
+        response = await workflow.llm.acomplete("test prompt")
+        assert hasattr(response, 'text'), "Response should have text attribute"
+    
+    def test_no_unawaited_coroutines_in_workflow_files(self):
+        """Test workflow files for patterns that could cause unawaited coroutines."""
+        workflow_files = [
+            "src/rfe_builder_workflow.py",
+            "src/jira_rfe_to_architecture_workflow.py", 
+            "src/enhanced_rfe_workflow.py"
+        ]
+        
+        for file_path in workflow_files:
+            if not Path(file_path).exists():
+                continue
+                
+            with open(file_path, 'r') as f:
+                content = f.read()
+            
+            # Check for potentially problematic patterns
+            problematic_patterns = [
+                # Direct assignment of async methods without await
+                r'=\s*\w+\.astream_complete\(',
+                r'=\s*\w+\.astructured_predict\(',
+                # Function calls that might return coroutines without await
+                r'\.span\([^)]*\)\s*$',  # Dispatcher.span calls
+            ]
+            
+            import re
+            for pattern in problematic_patterns:
+                if re.search(pattern, content, re.MULTILINE):
+                    # Check if it's properly awaited in context
+                    lines = content.split('\n')
+                    for i, line in enumerate(lines):
+                        if re.search(pattern, line):
+                            # Look for 'await' in the same line or assignment context
+                            if 'await' not in line and '=' in line:
+                                pytest.fail(
+                                    f"File {file_path} line {i+1} may have unawaited coroutine: {line.strip()}"
+                                )
+    
+    def test_write_event_to_stream_usage_patterns(self):
+        """Test that write_event_to_stream is used correctly."""
+        workflow_files = [
+            "src/rfe_builder_workflow.py",
+            "src/jira_rfe_to_architecture_workflow.py",
+            "src/enhanced_rfe_workflow.py"
+        ]
+        
+        for file_path in workflow_files:
+            if not Path(file_path).exists():
+                continue
+                
+            with open(file_path, 'r') as f:
+                content = f.read()
+            
+            # Check write_event_to_stream usage
+            import re
+            stream_calls = re.findall(r'ctx\.write_event_to_stream\([^)]+\)', content, re.DOTALL)
+            
+            for call in stream_calls:
+                # Ensure UIEvent is properly constructed
+                if 'UIEvent(' not in call and 'ArtifactEvent(' not in call:
+                    pytest.fail(
+                        f"File {file_path} has write_event_to_stream call without proper event type: {call[:100]}..."
+                    )
+    
+    @pytest.mark.asyncio
+    async def test_agent_manager_async_methods(self):
+        """Test that agent manager async methods work correctly."""
+        from src.agents import RFEAgentManager, get_agent_personas
+        
+        agent_manager = RFEAgentManager()
+        
+        # Test that global function exists and is async
+        assert asyncio.iscoroutinefunction(get_agent_personas), \
+            "get_agent_personas should be async"
+        
+        # Test that methods return expected types
+        personas = await get_agent_personas()
+        assert isinstance(personas, dict), "get_agent_personas should return dict"
+        
+        # Test agent manager has the expected methods
+        assert hasattr(agent_manager, 'load_agent_configurations'), "Manager should have load_agent_configurations"
+        assert hasattr(agent_manager, 'agent_configs'), "Manager should have agent_configs"
+    
+    def test_async_generator_typing(self):
+        """Test that async generators are properly typed."""
+        # Check plugin interface files for proper AsyncGenerator typing
+        plugin_files = [
+            "plugins/base/plugin_interface.py",
+            "plugins/base/orchestrator.py"
+        ]
+        
+        for file_path in plugin_files:
+            if not Path(file_path).exists():
+                continue
+                
+            with open(file_path, 'r') as f:
+                content = f.read()
+            
+            # Look for AsyncGenerator usage
+            if 'AsyncGenerator' in content:
+                # Ensure proper typing imports
+                assert 'from typing import' in content and 'AsyncGenerator' in content, \
+                    f"File {file_path} uses AsyncGenerator but may not import it properly"
+
+
+class TestStreamingPatterns:
+    """Test streaming and event patterns for async correctness."""
+    
+    def test_streaming_methods_use_async_for(self):
+        """Test that streaming methods properly use async for loops."""
+        workflow_files = [
+            "src/rfe_builder_workflow.py",
+            "src/jira_rfe_to_architecture_workflow.py"
+        ]
+        
+        for file_path in workflow_files:
+            if not Path(file_path).exists():
+                continue
+                
+            with open(file_path, 'r') as f:
+                content = f.read()
+            
+            # Check for astream usage patterns
+            import re
+            if 'astream' in content:
+                # Look for 'async for' patterns when using astream
+                astream_lines = [line for line in content.split('\n') if 'astream' in line]
+                
+                for line in astream_lines:
+                    if '=' in line and 'await' not in line and 'async for' not in line:
+                        # This might be problematic - astream methods should typically be used with async for
+                        pytest.fail(
+                            f"File {file_path} may use astream incorrectly: {line.strip()}"
+                        )
+    
+    @pytest.mark.asyncio
+    async def test_workflow_event_streaming(self):
+        """Test that workflow event streaming works without coroutine warnings."""
+        from src.rfe_builder_workflow import RFEBuilderWorkflow
+        from llama_index.core.workflow import Context, StartEvent
+        from llama_index.core.llms.mock import MockLLM
+        
+        # Setup mock workflow
+        workflow = RFEBuilderWorkflow()
+        workflow.llm = MockLLM()
+        
+        # Mock context
+        ctx = MagicMock()
+        ctx.write_event_to_stream = MagicMock()
+        
+        # Test that start event handling doesn't raise coroutine warnings
+        start_event = StartEvent(user_msg="Test RFE request")
+        
+        try:
+            result = await workflow.start_rfe_builder(ctx, start_event)
+            # Should return an event without raising warnings
+            assert result is not None
+        except Exception as e:
+            if "coroutine" in str(e).lower():
+                pytest.fail(f"Workflow raised coroutine-related error: {e}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/demos/rfe-builder/test_rfe_builder.py
+++ b/demos/rfe-builder/test_rfe_builder.py
@@ -7,6 +7,10 @@ import os
 import pytest
 from dotenv import load_dotenv
 
+# Import our new test modules to include them in the test suite
+from test_ui_imports import TestUIComponentImports, TestUIComponentDependencies
+from test_async_patterns import TestAsyncPatterns, TestStreamingPatterns
+
 # Import workflows
 from src.rfe_builder_workflow import create_rfe_builder_workflow
 # from src.artifact_editor_workflow import create_artifact_editor_workflow  # Not available

--- a/demos/rfe-builder/test_ui_imports.py
+++ b/demos/rfe-builder/test_ui_imports.py
@@ -1,0 +1,148 @@
+"""Test UI component imports to catch restricted import issues."""
+
+import pytest
+import ast
+import os
+from pathlib import Path
+
+
+class TestUIComponentImports:
+    """Test suite to prevent UI component import issues in LlamaIndex environment."""
+    
+    def test_ui_components_use_allowed_imports_only(self):
+        """Test that UI components only use allowed import libraries."""
+        allowed_imports = {
+            # React core
+            "react",
+            # Shadcn UI components
+            "@/components/ui/card", "@/components/ui/button", "@/components/ui/textarea",
+            "@/components/ui/alert", "@/components/ui/tabs", "@/components/ui/checkbox",
+            "@/components/ui/label", "@/components/ui/badge", "@/components/ui/tooltip",
+            "@/components/ui/select", "@/components/ui/input", "@/components/ui/dialog",
+            "@/components/ui/dropdown-menu", "@/components/ui/popover", "@/components/ui/sheet",
+            "@/components/ui/scroll-area", "@/components/ui/separator", "@/components/ui/progress",
+            # Shadcn utilities
+            "@/lib/utils",
+            # LlamaIndex chat-ui (allowed)
+            "llamaindex/chat-ui",
+            # Lucide React icons (allowed)
+            "lucide-react",
+            # Zod validation (allowed)
+            "zod"
+        }
+        
+        ui_components_dir = Path("ui/components")
+        if not ui_components_dir.exists():
+            pytest.skip("UI components directory not found")
+        
+        jsx_files = list(ui_components_dir.glob("*.jsx"))
+        js_files = list(ui_components_dir.glob("*.js"))
+        
+        for file_path in jsx_files + js_files:
+            with open(file_path, 'r') as f:
+                content = f.read()
+            
+            # Extract import statements using regex
+            import re
+            import_pattern = r'import\s+.*?\s+from\s+["\']([^"\']+)["\']'
+            imports = re.findall(import_pattern, content)
+            
+            for imported_module in imports:
+                # Skip relative imports to other UI components (these cause the main issue)
+                # Exception: index.js files are allowed to have relative imports for re-exports
+                if (imported_module.startswith('./') or imported_module.startswith('../')) and file_path.name != 'index.js':
+                    pytest.fail(
+                        f"File {file_path} contains relative import '{imported_module}' "
+                        f"which is not allowed in LlamaIndex environment. "
+                        f"Use absolute imports or inline the component."
+                    )
+                
+                # Check if import is in allowed list (skip relative imports since they're handled above)
+                if not (imported_module.startswith('./') or imported_module.startswith('../')) and not any(allowed in imported_module for allowed in allowed_imports):
+                    pytest.fail(
+                        f"File {file_path} imports '{imported_module}' which is not allowed. "
+                        f"Only these imports are supported: {', '.join(sorted(allowed_imports))}"
+                    )
+    
+    def test_no_custom_component_exports_in_index(self):
+        """Test that index.js doesn't export components that use restricted imports."""
+        index_file = Path("ui/components/index.js")
+        if not index_file.exists():
+            pytest.skip("UI components index.js not found")
+        
+        # List of components known to have import issues
+        problematic_components = [
+            "FrameworkSelector",
+            "EnhancedRFEBuilder", 
+            "MultiFrameworkProgress"
+        ]
+        
+        with open(index_file, 'r') as f:
+            content = f.read()
+        
+        for component in problematic_components:
+            if component in content:
+                pytest.fail(
+                    f"index.js exports '{component}' which has restricted import issues. "
+                    f"This component should be refactored to use only allowed imports "
+                    f"or moved to a different environment."
+                )
+    
+    def test_jsx_files_have_valid_syntax(self):
+        """Test that all JSX files have valid syntax."""
+        ui_components_dir = Path("ui/components")
+        if not ui_components_dir.exists():
+            pytest.skip("UI components directory not found")
+        
+        jsx_files = list(ui_components_dir.glob("*.jsx"))
+        
+        for jsx_file in jsx_files:
+            with open(jsx_file, 'r') as f:
+                content = f.read()
+            
+            # Basic syntax check - look for common JSX issues
+            if 'export' not in content:
+                pytest.fail(f"File {jsx_file} may have syntax issues - no export found")
+            
+            # Check for proper export syntax
+            if content.count('export') > 0:
+                # Look for either 'export function' or 'export default'
+                valid_exports = ['export function', 'export default', 'export {', 'export const']
+                if not any(export_type in content for export_type in valid_exports):
+                    pytest.fail(f"File {jsx_file} has invalid export syntax")
+
+
+class TestUIComponentDependencies:
+    """Test UI component file dependencies and structure."""
+    
+    def test_ui_components_directory_structure(self):
+        """Test that UI components follow expected directory structure."""
+        ui_dir = Path("ui")
+        components_dir = Path("ui/components")
+        
+        if ui_dir.exists():
+            assert components_dir.exists(), "ui/components directory should exist if ui/ exists"
+            
+            # Check for index file
+            index_files = list(components_dir.glob("index.*"))
+            assert len(index_files) > 0, "UI components should have an index file"
+    
+    def test_no_circular_imports_in_components(self):
+        """Test that components don't have circular import dependencies."""
+        ui_components_dir = Path("ui/components")
+        if not ui_components_dir.exists():
+            pytest.skip("UI components directory not found")
+        
+        js_files = list(ui_components_dir.glob("*.js")) + list(ui_components_dir.glob("*.jsx"))
+        
+        for file_path in js_files:
+            with open(file_path, 'r') as f:
+                content = f.read()
+            
+            # Check for imports that could create cycles
+            if './index' in content and file_path.name != 'index.js':
+                pytest.fail(f"Component {file_path} imports from index, which could create circular dependency")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fixes UI component import errors that occur in LlamaIndex environment
- Resolves runtime coroutine warnings from async streaming operations
- Adds comprehensive test suite to catch these issues in the future

## Problem
The system was experiencing two related issues:
1. **UI Component Import Error**: `Module not found` errors for relative imports like `./framework_selector` in LlamaIndex environment
2. **Runtime Coroutine Warning**: `RuntimeWarning: coroutine 'Dispatcher.span.<locals>.async_wrapper' was never awaited`

## Solution
### 1. UI Import Fixes
- Main branch already had clean component index without problematic imports
- Added comprehensive test suite to catch restricted imports
- Tests validate only allowed libraries: Shadcn UI, LlamaIndex chat-ui, Lucide React, Zod

### 2. Async Pattern Fixes  
- Fixed `stream_structured_predict` to use `astructured_predict` instead of streaming version
- Main workflow already fixed to use `llm.acomplete()` instead of streaming
- Added async pattern tests to detect unawaited coroutines

### 3. Test Coverage
- **UI Import Tests**: Detect relative imports and restricted libraries
- **Async Pattern Tests**: Catch coroutine issues and streaming problems
- **Integration**: Tests included in main test suite for continuous validation

## Test Results
```
29 passed, 12 warnings in 20.60s
```
All tests pass. Warnings are from LlamaIndex library deprecations, not our code.

## Files Changed
- `src/agents.py`: Fix streaming function to avoid coroutine issues
- `test_ui_imports.py`: Comprehensive UI component import validation
- `test_async_patterns.py`: Async pattern and coroutine testing
- `test_rfe_builder.py`: Include new tests in main suite

🤖 Generated with [Claude Code](https://claude.ai/code)