### PR TITLE
jira integration updates

### DIFF
--- a/components/runners/claude-code-runner/main.py
+++ b/components/runners/claude-code-runner/main.py
@@ -408,7 +408,7 @@ class SimpleClaudeRunner:
                         logger.info(f"Inbox message: {msg}")
                         text = str(msg.get("content", ""))
                         norm = text.strip().lower()
-                        if norm in ("/end"):
+                        if "/end" in norm:
                             # Graceful end of interactive session
                             try:
                                 self._append_message("User requested session end")


### PR DESCRIPTION
AFAICT with this PR:
* Can upload and resync to Jira from `specify`, `plan`, and `tasks` but don't upload jira from `ideate` phase
* Can now delete RFE-workload from UI
* `ideate` phase optional - if no `rfe.md` then specify will use the RFE description instead. 