### PR TITLE
Rename umbrella repository terminology to spec repository

### DIFF
--- a/components/frontend/README.md
+++ b/components/frontend/README.md
@@ -127,7 +127,7 @@ curl -i http://localhost:3000/api/projects/my-project/agentic-sessions \
 #### 📊 Sessions Dashboard (T011)
 - **`SessionsDashboard.tsx`**: Live session management
   - Real-time WebSocket connections for session updates
-  - Grouped PR display (umbrella + submodule PRs)
+  - Grouped PR display (spec repo + submodule PRs)
   - Live message streaming with partial reassembly
   - Visual status indicators for all session states
   - Multi-runner support (Claude, OpenAI, local execution)
@@ -147,7 +147,7 @@ curl -i http://localhost:3000/api/projects/my-project/agentic-sessions \
 
 ### Key Features
 - **Live Session Monitoring**: WebSocket connections with automatic reconnection
-- **Multi-repo PR Management**: Handle umbrella and submodule PRs separately
+- **Multi-repo PR Management**: Handle spec repo and submodule PRs separately
 - **GitHub App Integration**: Streamlined per-user installation flow
 - **Repository Browsing**: Full file tree navigation with content preview
 - **Runner Support**: Claude Code, OpenAI, and local execution runners

--- a/components/frontend/src/app/projects/[name]/rfe/[id]/rfe-workspace-card.tsx
+++ b/components/frontend/src/app/projects/[name]/rfe/[id]/rfe-workspace-card.tsx
@@ -33,7 +33,7 @@ export function RfeWorkspaceCard({
           <FolderTree className="h-5 w-5" />
           Workspace & Repositories
         </CardTitle>
-        <CardDescription>Shared workspace for this workflow and optional repos</CardDescription>
+        <CardDescription>Shared workspace with spec repository (specs, planning docs, agent configs) and optional supporting repos</CardDescription>
       </CardHeader>
       <CardContent>
         <div className="text-sm text-muted-foreground">Workspace: {workflowWorkspace}</div>
@@ -63,7 +63,7 @@ export function RfeWorkspaceCard({
             {workflow.umbrellaRepo && (
               <div className="text-sm space-y-1">
                 <div>
-                  <span className="font-medium">Umbrella:</span> {workflow.umbrellaRepo.url}
+                  <span className="font-medium">Spec Repo:</span> {workflow.umbrellaRepo.url}
                 </div>
                 {workflow.umbrellaRepo.branch && (
                   <div className="ml-4 text-muted-foreground">
@@ -98,10 +98,10 @@ export function RfeWorkspaceCard({
         {!isSeeded && !seedingStatus.checking && workflow.umbrellaRepo && (
           <Alert variant="destructive" className="mt-4">
             <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Umbrella Repository Not Seeded</AlertTitle>
+            <AlertTitle>Spec Repository Not Seeded</AlertTitle>
             <AlertDescription className="mt-2">
               <p className="mb-3">
-                Before you can start working on phases, the umbrella repository needs to be seeded.
+                Before you can start working on phases, the spec repository needs to be seeded.
                 This will:
               </p>
               <ul className="list-disc list-inside space-y-1 mb-3 text-sm">

--- a/components/frontend/src/app/projects/[name]/rfe/new/page.tsx
+++ b/components/frontend/src/app/projects/[name]/rfe/new/page.tsx
@@ -289,6 +289,9 @@ export default function ProjectNewRFEWorkflowPage() {
                           <FormControl>
                             <Input placeholder="https://github.com/org/repo.git" {...field} />
                           </FormControl>
+                          <FormDescription>
+                            The spec repository contains your feature specifications, planning documents, and agent configurations for this RFE workspace
+                          </FormDescription>
                           <FormMessage />
                         </FormItem>
                       )}


### PR DESCRIPTION
Update terminology throughout the frontend to clarify that the 'umbrella' repository is actually a specification repository containing feature specs, planning documents, and agent configurations. This improves clarity for users about the purpose of this repository in RFE workflows.