### PR TITLE
Rebrand frontend to Ambient Code Platform

### DIFF
--- a/components/frontend/src/app/layout.tsx
+++ b/components/frontend/src/app/layout.tsx
@@ -10,9 +10,9 @@ import { env } from "@/lib/env";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Ambient Agentic Runner",
+  title: "Ambient Code Platform",
   description:
-    "Kubernetes application for running automated agentic sessions with Ambient AI",
+    "ACP is an AI-native agentic-powered enterprise software development platform",
 };
 
 export default function RootLayout({

--- a/components/frontend/src/components/navigation.tsx
+++ b/components/frontend/src/components/navigation.tsx
@@ -25,7 +25,7 @@ export function Navigation() {
         <div className="flex h-16 items-center justify-between gap-4">
           <div className="flex items-center gap-6">
             <Link href="/" className="text-xl font-bold">
-              Ambient Agentic Runner
+              Ambient Code Platform
             </Link>
           </div>
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Rebrands the frontend from "Ambient Agentic Runner" to "Ambient Code Platform" to reflect the platform's new identity and positioning.

- Updates navigation header title
- Updates page metadata (browser tab title and SEO description)
- New description emphasizes AI-native agentic SDLC capabilities

## Changes

- `components/frontend/src/components/navigation.tsx`: Header text updated
- `components/frontend/src/app/layout.tsx`: Page title and meta description updated

## Test Plan

- [ ] Verify navigation header displays "Ambient Code Platform"
- [ ] Verify browser tab shows "Ambient Code Platform"
- [ ] Verify meta description is accurate for SEO/social previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)