### PR TITLE
Fix success toast messages for project and RFE workspace creation

### DIFF
--- a/components/frontend/src/app/projects/[name]/rfe/new/page.tsx
+++ b/components/frontend/src/app/projects/[name]/rfe/new/page.tsx
@@ -142,7 +142,7 @@ export default function ProjectNewRFEWorkflowPage() {
       { projectName, data: request },
       {
         onSuccess: (workflow) => {
-          successToast(`RFE workflow "${values.title}" created successfully`);
+          successToast(`RFE workspace "${values.title}" created successfully`);
           router.push(`/projects/${encodeURIComponent(projectName)}/rfe/${encodeURIComponent(workflow.id)}`);
         },
         onError: (error) => {

--- a/components/frontend/src/app/projects/new/page.tsx
+++ b/components/frontend/src/app/projects/new/page.tsx
@@ -81,7 +81,7 @@ export default function NewProjectPage() {
 
     createProjectMutation.mutate(payload, {
       onSuccess: (project) => {
-        successToast(`Project "${formData.displayName}" created successfully`);
+        successToast(`Project "${formData.displayName || formData.name}" created successfully`);
         router.push(`/projects/${encodeURIComponent(project.name)}`);
       },
       onError: (err) => {


### PR DESCRIPTION
- Fix project creation toast to show project name when displayName is empty (Vanilla K8s doesn't have displayName field, and it's optional on OpenShift)
- Fix RFE creation toast to use "workspace" instead of "workflow" for consistency with user-facing terminology