### PR TITLE
Fixes Issue #199: Remove redundant back buttons from RFE and session pages

### DIFF
--- a/components/frontend/src/app/projects/[name]/rfe/[id]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/rfe/[id]/page.tsx
@@ -251,7 +251,6 @@ export default function ProjectRFEDetailPage() {
         />
         <RfeHeader
           workflow={workflow}
-          projectName={project}
           deleting={deleteWorkflowMutation.isPending}
           onDelete={deleteWorkflow}
         />

--- a/components/frontend/src/app/projects/[name]/rfe/[id]/rfe-header.tsx
+++ b/components/frontend/src/app/projects/[name]/rfe/[id]/rfe-header.tsx
@@ -1,31 +1,21 @@
 "use client";
 
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
+import { Loader2, Trash2 } from "lucide-react";
 import type { RFEWorkflow } from "@/types/agentic-session";
 
 type RfeHeaderProps = {
   workflow: RFEWorkflow;
-  projectName: string;
   deleting: boolean;
   onDelete: () => Promise<void>;
 };
 
-export function RfeHeader({ workflow, projectName, deleting, onDelete }: RfeHeaderProps) {
+export function RfeHeader({ workflow, deleting, onDelete }: RfeHeaderProps) {
   return (
     <div className="flex items-start justify-between">
-      <div className="flex items-center gap-4">
-        <Link href={`/projects/${encodeURIComponent(projectName)}/rfe`}>
-          <Button variant="ghost" size="sm">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to RFE Workspaces
-          </Button>
-        </Link>
-        <div>
-          <h1 className="text-3xl font-bold">{workflow.title}</h1>
-          <p className="text-muted-foreground mt-1">{workflow.description}</p>
-        </div>
+      <div>
+        <h1 className="text-3xl font-bold">{workflow.title}</h1>
+        <p className="text-muted-foreground mt-1">{workflow.description}</p>
       </div>
       <Button variant="destructive" size="sm" onClick={onDelete} disabled={deleting}>
         {deleting ? (

--- a/components/frontend/src/app/projects/[name]/rfe/new/page.tsx
+++ b/components/frontend/src/app/projects/[name]/rfe/new/page.tsx
@@ -6,7 +6,7 @@ import { useForm, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import Link from 'next/link';
-import { ArrowLeft, Loader2, GitBranch } from 'lucide-react';
+import { Loader2, GitBranch } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -164,17 +164,9 @@ export default function ProjectNewRFEWorkflowPage() {
           ]}
           className="mb-4"
         />
-        <div className="flex items-center gap-4 mb-8">
-          <Link href={`/projects/${encodeURIComponent(projectName)}/rfe`}>
-            <Button variant="ghost" size="sm">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to RFE Workspaces
-            </Button>
-          </Link>
-          <div>
-            <h1 className="text-3xl font-bold">Create RFE Workspace</h1>
-            <p className="text-muted-foreground">Set up a new Request for Enhancement workflow with AI agents</p>
-          </div>
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold">Create RFE Workspace</h1>
+          <p className="text-muted-foreground">Set up a new Request for Enhancement workflow with AI agents</p>
         </div>
 
         {/* Error state from mutation */}

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -702,14 +702,6 @@ export default function ProjectSessionDetailPage({
         ]}
         className="mb-4"
       />
-      <div className="flex items-center justify-start mb-6">
-        <Link href={backHref || `/projects/${encodeURIComponent(projectName)}/sessions`}>
-          <Button variant="ghost" size="sm">
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            {backLabel || "Back to Sessions"}
-          </Button>
-        </Link>
-      </div>
 
       <div className="space-y-6">
         {/* Header */}

--- a/components/frontend/src/app/projects/[name]/sessions/new/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/new/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -200,14 +200,6 @@ export default function NewProjectSessionPage({ params }: { params: Promise<{ na
         ]}
         className="mb-4"
       />
-      <div className="flex items-center mb-6">
-        <Link href={`/projects/${encodeURIComponent(projectName)}/sessions`}>
-          <Button variant="ghost" size="sm">
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Sessions
-          </Button>
-        </Link>
-      </div>
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
Remove redundant "Back" navigation buttons from RFE workspace and session pages. The breadcrumb navigation and sidebar already provide sufficient hierarchical navigation, making these explicit back buttons redundant.

Changes:
- Remove back button from RFE create page (rfe/new/page.tsx)
- Remove back button from session create page (sessions/new/page.tsx)
- Remove back button from session detail page (sessions/[sessionName]/page.tsx)
- Left-align headings by simplifying flex container layouts
- Clean up unused imports (ArrowLeft icon)

This creates a cleaner, more consistent UI while preserving all necessary navigation functionality through breadcrumbs, sidebar, and browser back button.

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)