### PR TITLE
docs(constitution): Add constitution template to documentation

### DIFF
--- a/docs/reference/constitution.md
+++ b/docs/reference/constitution.md
@@ -1,0 +1,50 @@
+# [PROJECT_NAME] Constitution
+<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+
+## Core Principles
+
+### [PRINCIPLE_1_NAME]
+<!-- Example: I. Library-First -->
+[PRINCIPLE_1_DESCRIPTION]
+<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+
+### [PRINCIPLE_2_NAME]
+<!-- Example: II. CLI Interface -->
+[PRINCIPLE_2_DESCRIPTION]
+<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+
+### [PRINCIPLE_3_NAME]
+<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
+[PRINCIPLE_3_DESCRIPTION]
+<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+
+### [PRINCIPLE_4_NAME]
+<!-- Example: IV. Integration Testing -->
+[PRINCIPLE_4_DESCRIPTION]
+<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+
+### [PRINCIPLE_5_NAME]
+<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
+[PRINCIPLE_5_DESCRIPTION]
+<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+
+## [SECTION_2_NAME]
+<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+
+[SECTION_2_CONTENT]
+<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+
+## [SECTION_3_NAME]
+<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+
+[SECTION_3_CONTENT]
+<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+
+## Governance
+<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
+
+[GOVERNANCE_RULES]
+<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+
+**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
+<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Lab 1 - Your First Agentic Session: labs/basic/lab-1-first-rfe.md
   - Reference:
     - Overview: reference/index.md
+    - Constitution: reference/constitution.md
     - Glossary: reference/glossary.md
   - Deployment Guides:
     - GitHub App Setup: GITHUB_APP_SETUP.md


### PR DESCRIPTION
## Summary

Adds project constitution template to the documentation under `docs/reference/constitution.md` and integrates it into the MkDocs navigation structure.

## Changes

- **Added**: `docs/reference/constitution.md` - Project constitution template with:
  - Core principles framework (placeholder structure for 5+ principles)
  - Governance rules and amendment procedures
  - Version tracking metadata
  - Extensible sections for project-specific constraints

- **Updated**: `mkdocs.yml` - Added constitution link to Reference section navigation

## Background

This establishes a foundation for documenting project governance and development principles. The constitution template follows the spec-kit pattern used throughout the `.specify/` workflow system.

## Next Steps

- [ ] Fill in actual project principles (currently contains placeholders)
- [ ] Define governance procedures specific to Ambient Code Platform
- [ ] Update dependent templates if needed (per `.specify/memory/constitution_update_checklist.md`)
- [ ] Consider if constitution should reference existing CLAUDE.md development standards

## Test Plan

- [x] Constitution file successfully copied to docs/reference/
- [x] MkDocs navigation updated
- [ ] Verify constitution renders correctly in MkDocs site (`mkdocs serve`)
- [ ] Validate markdown linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)