### PR TITLE
Fix golangci-lint configuration version for v2 compatibility

### DIFF
--- a/components/backend/.golangci.yml
+++ b/components/backend/.golangci.yml
@@ -4,6 +4,8 @@
 # This configuration is pragmatic for a Kubernetes-native application.
 # We focus on catching real bugs rather than style issues.
 
+version: "2"
+
 run:
   timeout: 5m
 

--- a/components/operator/.golangci.yml
+++ b/components/operator/.golangci.yml
@@ -3,6 +3,8 @@
 #
 # Pragmatic configuration for Kubernetes operator development.
 
+version: "2"
+
 run:
   timeout: 5m
 


### PR DESCRIPTION
Add required version: "2" field to both backend and operator .golangci.yml files. Newer versions of golangci-lint require this field to be explicitly set to indicate the configuration schema version.

This fixes the CI error: "unsupported version of the configuration"

🤖 Generated with [Claude Code](https://claude.com/claude-code)