### PR TITLE
fix: resolve Go formatting and linting issues

### DIFF
--- a/components/backend/git/operations.go
+++ b/components/backend/git/operations.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -43,37 +42,6 @@ type DiffSummary struct {
 	TotalRemoved int `json:"total_removed"`
 	FilesAdded   int `json:"files_added"`
 	FilesRemoved int `json:"files_removed"`
-}
-
-// getProjectSettings retrieves the ProjectSettings CR for a project using the provided dynamic client
-func getProjectSettings(ctx context.Context, dynClient dynamic.Interface, projectName string) (*ProjectSettings, error) {
-	if dynClient == nil {
-		return &ProjectSettings{}, nil
-	}
-
-	if GetProjectSettingsResource == nil {
-		return &ProjectSettings{}, nil
-	}
-
-	gvr := GetProjectSettingsResource()
-	obj, err := dynClient.Resource(gvr).Namespace(projectName).Get(ctx, "projectsettings", v1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return &ProjectSettings{}, nil
-		}
-		return nil, fmt.Errorf("failed to get ProjectSettings: %w", err)
-	}
-
-	settings := &ProjectSettings{}
-	if obj != nil {
-		if spec, ok := obj.Object["spec"].(map[string]interface{}); ok {
-			if v, ok := spec["runnerSecretsName"].(string); ok {
-				settings.RunnerSecret = strings.TrimSpace(v)
-			}
-		}
-	}
-
-	return settings, nil
 }
 
 // GetGitHubToken tries to get a GitHub token from GitHub App first, then falls back to project runner secret

--- a/components/backend/handlers/content.go
+++ b/components/backend/handlers/content.go
@@ -511,13 +511,13 @@ func ContentWorkflowMetadata(c *gin.Context) {
 					shortCommand = commandName[lastDot+1:]
 				}
 
-			commands = append(commands, map[string]interface{}{
-				"id":           commandName,
-				"name":         displayName,
-				"description":  metadata["description"],
-				"slashCommand": "/" + shortCommand,
-				"icon":         metadata["icon"],
-			})
+				commands = append(commands, map[string]interface{}{
+					"id":           commandName,
+					"name":         displayName,
+					"description":  metadata["description"],
+					"slashCommand": "/" + shortCommand,
+					"icon":         metadata["icon"],
+				})
 			}
 		}
 		log.Printf("ContentWorkflowMetadata: found %d commands", len(commands))

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -312,7 +312,7 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 	maxTokens, _, _ := unstructured.NestedInt64(llmSettings, "maxTokens")
 
 	// Hardcoded secret names (convention over configuration)
-	const runnerSecretsName = "ambient-runner-secrets"              // ANTHROPIC_API_KEY only (ignored when Vertex enabled)
+	const runnerSecretsName = "ambient-runner-secrets"               // ANTHROPIC_API_KEY only (ignored when Vertex enabled)
 	const integrationSecretsName = "ambient-non-vertex-integrations" // GIT_*, JIRA_*, custom keys (optional)
 
 	// Check if integration secrets exist (optional)


### PR DESCRIPTION
- Auto-format backend handlers/content.go with gofmt
- Auto-format operator internal/handlers/sessions.go with gofmt
- Remove unused getProjectSettings function from backend git/operations.go
- Remove unused k8s.io/apimachinery/pkg/api/errors import

All files now pass:
- gofmt -l (zero output)
- go vet ./... (no issues)
- golangci-lint run (0 issues)