### PR TITLE
fix: remove backend-ingress to resolve auth token routing conflict

### DIFF
--- a/components/manifests/overlays/e2e/kustomization.yaml
+++ b/components/manifests/overlays/e2e/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - secrets.yaml
 - test-user.yaml
 - frontend-ingress.yaml
-- backend-ingress.yaml
+# backend-ingress.yaml removed - frontend handles all routing and proxies to backend internally
 - operator-config.yaml
 
 # Patches for e2e environment


### PR DESCRIPTION
## Summary

Fixes the "Invalid or missing token" authentication error users encounter when accessing the UI after running `setup-kind.sh` and `deploy.sh`.

## Problem

The `backend-ingress` was intercepting all `/api/*` requests and routing them directly to the Go backend, bypassing the Next.js frontend's API routes. This caused:

- Next.js API routes (like `/api/me`, `/api/cluster-info`) to return 404
- Frontend unable to access `OC_TOKEN` environment variable for authentication
- Authentication failures preventing UI access

## Solution

Removed `backend-ingress.yaml` from the e2e kustomization overlay. The correct architecture is:

\`\`\`
Browser → frontend-ingress → Next.js Frontend
                                  ↓
                              /api/* routes (handles auth)
                                  ↓
                              backend-service:8080/api (internal proxy)
\`\`\`

This follows the **API Gateway pattern** where Next.js acts as the unified entry point for both UI and API traffic.

## Changes

- \`components/manifests/overlays/e2e/kustomization.yaml\`: Removed \`backend-ingress.yaml\` from resources list

## Test Plan

- [x] Local kind cluster deployment via \`setup-kind.sh\` + \`deploy.sh\`
- [x] Frontend accessible at http://localhost:8080
- [x] Authentication working (no "Invalid or missing token" error)
- [x] \`/api/me\` endpoint returns authenticated user info
- [x] \`/api/cluster-info\` endpoint working

## Impact

- **Users**: Can now access the UI immediately after deployment without manual token configuration
- **Architecture**: Simplified routing - single ingress point through frontend
- **Security**: No change - authentication still enforced via ServiceAccount tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)