### PR TITLE
don't npm install claude-code in runner Dockerfile

### DIFF
--- a/components/runners/claude-code-runner/Dockerfile
+++ b/components/runners/claude-code-runner/Dockerfile
@@ -5,9 +5,6 @@ RUN apt-get update && apt-get install -y \
     git \
     curl \
     ca-certificates \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
-    && npm install -g @anthropic-ai/claude-code \
     && rm -rf /var/lib/apt/lists/*
 
 # Create working directory


### PR DESCRIPTION
`claude-agent-sdk` now bundles its own CLI so no longer needed to npm install
Without this change, the runner breaks on next update. 