### PR TITLE
fix: File Explorer accordion not loading files automatically

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -313,7 +313,7 @@ export default function ProjectSessionDetailPage({
       fileOps.currentSubPath
         ? `${selectedDirectory.path}/${fileOps.currentSubPath}`
         : selectedDirectory.path,
-      { enabled: openAccordionItems.includes("directories") },
+      { enabled: openAccordionItems.includes("file-explorer") },
     );
 
   // Artifacts file operations


### PR DESCRIPTION
Fixed regression from PR #361 where File Explorer files weren't loading when expanding the accordion. The accordion value was renamed from "directories" to "file-explorer" but the useWorkspaceList query's enabled condition still checked for the old value.

Changes:
- Updated enabled condition from includes("directories") to includes("file-explorer") in directoryFiles query

This fixes the issue where users had to manually click the file icon to view files in git repository context folders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@Daniel-Warner-X ptal, easy fix! 