### PR TITLE
fix(workflows): configure claude-code-action branch prefix for Amber

### DIFF
--- a/.github/workflows/amber-issue-handler.yml
+++ b/.github/workflows/amber-issue-handler.yml
@@ -218,6 +218,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.read-prompt.outputs.prompt }}
+          branch_prefix: "amber/"  # Use amber/ prefix to match manually created branch
 
       - name: Check if changes were made
         id: check-changes


### PR DESCRIPTION
## Fix

Configures `branch_prefix: "amber/"` for the `claude-code-action` to match the manually created branches.

## Problem  
The workflow manually creates branches with `amber/` prefix, but the `claude-code-action` was using default `claude/` prefix, causing PR creation to fail with:
```
Validation Failed: {"resource":"PullRequest","field":"head","code":"invalid"}
```

## Solution
- Added `branch_prefix: "amber/"` to the action configuration
- This aligns the action's branch management with our manually created branches  
- Ensures commits are pushed to the correct remote branch

🤖 Generated with Claude Code