### PR TITLE
fix(workflows): push branch before creating PR in Amber workflow

### DIFF
--- a/.github/workflows/amber-issue-handler.yml
+++ b/.github/workflows/amber-issue-handler.yml
@@ -235,6 +235,14 @@ jobs:
             echo "Changes committed on branch $BRANCH_NAME (commit: ${COMMIT_SHA:0:7})"
           fi
 
+      - name: Push branch to remote
+        if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.check-changes.outputs.branch_name }}
+        run: |
+          git push -u origin "$BRANCH_NAME"
+          echo "Pushed branch $BRANCH_NAME to remote"
+
       - name: Validate changes align with issue intent
         if: steps.check-changes.outputs.has_changes == 'true'
         env:


### PR DESCRIPTION
## Fix

Adds  step after Claude Code execution to ensure branch exists on remote before PR creation.

## Problem
The workflow was trying to create a PR using a branch that hadn't been pushed to the remote yet, causing:
```
Validation Failed: {"resource":"PullRequest","field":"head","code":"invalid"}
```

## Solution  
- Added "Push branch to remote" step after changes are detected
- Runs before PR creation step
- Uses `git push -u origin $BRANCH_NAME`

🤖 Generated with Claude Code