### PR TITLE
docs: remove non-existent files from mkdocs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,9 +46,6 @@ nav:
     - Getting Started: user-guide/getting-started.md
     - Working with Amber: user-guide/working-with-amber.md
     - Amber Quickstart: user-guide/amber-quickstart.md
-    - Amber Interactive Mode: user-guide/amber-interactive.md
-    - Amber Background Agent: user-guide/amber-background-agent.md
-    - Amber Troubleshooting: user-guide/amber-troubleshooting.md
   - Developer Guide:
     - Observability & Instrumentation: observability-langfuse.md
     - Model Pricing: model-pricing.md


### PR DESCRIPTION
## Summary

Fixes the remaining mkdocs build warnings caused by PR #425.

## Problem

PR #425 added these files to  navigation:
- `user-guide/amber-interactive.md`
- `user-guide/amber-background-agent.md`
- `user-guide/amber-troubleshooting.md`

However, these files don't exist in the repository (they only exist in my local working directory and are not tracked by git).

This caused 10 new warnings in the docs build: https://github.com/ambient-code/platform/actions/runs/19938373634

## Changes

Removed the three non-existent files from `mkdocs.yml` navigation, keeping only:
- `user-guide/amber-quickstart.md` ✅ (exists in repo)

## Verification

✅ `mkdocs build --strict` completes with 0 warnings  
✅ All navigation links valid  
✅ No references to non-existent files

## Testing

```bash
mkdocs build --strict
# Output: Documentation built in 1.73 seconds (0 warnings)
```

## Impact

- ✅ Documentation builds cleanly
- ✅ GitHub Pages deployment succeeds  
- ✅ No broken navigation links

Fixes the build failures introduced in #425.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)