### PR TITLE
fix: Increase K8s client rate limits for parallel SSAR checks

### DIFF
--- a/components/backend/server/k8s.go
+++ b/components/backend/server/k8s.go
@@ -37,6 +37,11 @@ func InitK8sClients() error {
 		}
 	}
 
+	// Increase rate limits for parallel operations (default is QPS=5, Burst=10)
+	// This is needed for parallel SSAR checks when listing projects
+	config.QPS = 100
+	config.Burst = 200
+
 	// Create standard Kubernetes client
 	K8sClient, err = kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes a critical performance issue discovered after merging #428 (pagination and parallel SSAR checks).

### Problem

The default Kubernetes client rate limits (QPS=5, Burst=10) were causing significant throttling during parallel SSAR checks:

```
"Waited before sending request" delay="1.997446758s" reason="client-side throttling"
```

### Solution

Increase rate limits:
- QPS: 5 → 100
- Burst: 10 → 200

### Performance Impact

Tested with 51 namespaces:
- **Before**: 8.2 seconds
- **After**: 50 milliseconds
- **Improvement**: ~164x faster

### Testing

Verified on dev cluster with 51 managed namespaces. Timing logs confirmed SSAR checks completed in 30ms with the increased rate limits.