### PR TITLE
feat: Add automated version sync for local development

### DIFF
--- a/components/manifests/minikube/frontend-deployment.yaml
+++ b/components/manifests/minikube/frontend-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: GITHUB_APP_SLUG
           value: "ambient-code"
         - name: VTEAM_VERSION
-          value: "v0.0.3"
+          value: "v0.0.12-22-g5553056"
         - name: DISABLE_AUTH
           value: "true"
         - name: MOCK_USER


### PR DESCRIPTION
## Summary
Implements automated version synchronization for local development to prevent version drift between git tags and deployment manifests.

## Changes
- **Makefile**: Add `local-sync-version` target to automatically sync version from git
- **local-up workflow**: Integrated version sync to run before deploying services
- **local-status enhancement**: Show Git/Manifest/Running version alignment with drift warnings
- **Frontend manifest**: Updated to current version (auto-synced from git describe)

## Problem Solved
Previously, the web UI displayed version `v0.0.3` (hardcoded in manifest) instead of the current release `v0.0.12`. This required manual updates every release and caused version drift.

## Solution
Automatic version injection using `git describe --tags --always`, matching the pattern used in CI/CD workflows:
- **Production**: Uses release tags
- **Staging**: Uses git SHA
- **Local Dev**: Now uses git describe (latest tag + commits ahead)

## Workflow
Every `make local-up` now:
1. Syncs version from git → manifest
2. Applies updated manifest
3. Deploys with current version

## Verification
After deployment:
- API returns correct version: `{"version":"v0.0.12-22-g5553056"}`
- `make local-status` shows aligned versions with no warnings

## Benefits
- ✅ Single source of truth (git tags)
- ✅ No manual version updates needed
- ✅ Consistent across all environments (local/staging/prod)
- ✅ Prevents version drift permanently

🤖 Generated with [Claude Code](https://claude.com/claude-code)