### PR TITLE
Fix frontend health check timing issue in smoke tests

### DIFF
--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -44,16 +44,19 @@ jobs:
           echo "⚠️  Backend deployment timeout - showing status"
           kubectl get pods -n ambient-code -o wide
           kubectl describe deployment backend-api -n ambient-code | tail -50
+          exit 1
         }
         kubectl wait --for=condition=available --timeout=180s deployment/frontend -n ambient-code || {
           echo "⚠️  Frontend deployment timeout - showing status"
           kubectl get pods -n ambient-code -o wide
           kubectl describe deployment frontend -n ambient-code | tail -50
+          exit 1
         }
         kubectl wait --for=condition=available --timeout=180s deployment/agentic-operator -n ambient-code || {
           echo "⚠️  Operator deployment timeout - showing status"
           kubectl get pods -n ambient-code -o wide
           kubectl describe deployment agentic-operator -n ambient-code | tail -50
+          exit 1
         }
     
     - name: Run Makefile smoke tests

--- a/Makefile
+++ b/Makefile
@@ -355,12 +355,28 @@ local-test-quick: check-kubectl check-minikube ## Quick smoke test of local envi
 	@minikube status >/dev/null 2>&1 && echo "$(COLOR_GREEN)✓$(COLOR_RESET) Minikube running" || (echo "$(COLOR_RED)✗$(COLOR_RESET) Minikube not running" && exit 1)
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Testing namespace..."
 	@kubectl get namespace $(NAMESPACE) >/dev/null 2>&1 && echo "$(COLOR_GREEN)✓$(COLOR_RESET) Namespace exists" || (echo "$(COLOR_RED)✗$(COLOR_RESET) Namespace missing" && exit 1)
-	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Testing pods..."
-	@kubectl get pods -n $(NAMESPACE) 2>/dev/null | grep -q "Running" && echo "$(COLOR_GREEN)✓$(COLOR_RESET) Pods running" || (echo "$(COLOR_RED)✗$(COLOR_RESET) No pods running" && exit 1)
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for pods to be ready..."
+	@kubectl wait --for=condition=ready pod -l app=backend -n $(NAMESPACE) --timeout=60s >/dev/null 2>&1 && \
+	 kubectl wait --for=condition=ready pod -l app=frontend -n $(NAMESPACE) --timeout=60s >/dev/null 2>&1 && \
+	 echo "$(COLOR_GREEN)✓$(COLOR_RESET) Pods ready" || (echo "$(COLOR_RED)✗$(COLOR_RESET) Pods not ready" && exit 1)
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Testing backend health..."
-	@curl -sf http://$$(minikube ip):30080/health >/dev/null 2>&1 && echo "$(COLOR_GREEN)✓$(COLOR_RESET) Backend healthy" || (echo "$(COLOR_RED)✗$(COLOR_RESET) Backend not responding" && exit 1)
+	@for i in 1 2 3 4 5; do \
+		curl -sf http://$$(minikube ip):30080/health >/dev/null 2>&1 && { echo "$(COLOR_GREEN)✓$(COLOR_RESET) Backend healthy"; break; } || { \
+			if [ $$i -eq 5 ]; then \
+				echo "$(COLOR_RED)✗$(COLOR_RESET) Backend not responding after 5 attempts"; exit 1; \
+			fi; \
+			sleep 2; \
+		}; \
+	done
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Testing frontend..."
-	@curl -sf http://$$(minikube ip):30030 >/dev/null 2>&1 && echo "$(COLOR_GREEN)✓$(COLOR_RESET) Frontend accessible" || (echo "$(COLOR_RED)✗$(COLOR_RESET) Frontend not responding" && exit 1)
+	@for i in 1 2 3 4 5; do \
+		curl -sf http://$$(minikube ip):30030 >/dev/null 2>&1 && { echo "$(COLOR_GREEN)✓$(COLOR_RESET) Frontend accessible"; break; } || { \
+			if [ $$i -eq 5 ]; then \
+				echo "$(COLOR_RED)✗$(COLOR_RESET) Frontend not responding after 5 attempts"; exit 1; \
+			fi; \
+			sleep 2; \
+		}; \
+	done
 	@echo ""
 	@echo "$(COLOR_GREEN)✓ Quick smoke test passed!$(COLOR_RESET)"
 


### PR DESCRIPTION
## Summary
Fixes the intermittent frontend health check failures in smoke tests by addressing a race condition between pod readiness and NodePort service routing.

## Problem
PR #453 and potentially other PRs were failing with:
```
✗ Frontend not responding
```

Even though:
- Pods showed as `Running` and `Ready`
- All readiness probes passed
- The frontend was actually working

This was a timing issue: the smoke test ran immediately after pods became Ready, but NodePort service endpoint propagation can lag slightly behind pod readiness state.

## Solution
1. **Added explicit pod readiness wait** using `kubectl wait --for=condition=ready`
2. **Implemented retry logic** for health checks (5 attempts with 2s delays)
3. **Fixed deployment timeout handling** in GitHub Actions to properly fail the job

## Testing
The fix has been tested on branch `fix-frontend-smoke-test-timing` and successfully addresses the timing issue.

## Related Issues
- Fixes failures from: https://github.com/ambient-code/platform/actions/runs/20064017469/job/57547783304
- Will allow PR #453 and other PRs to pass smoke tests reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>