### PR TITLE
Remove command & agent expansions from Workflows panel

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/workflows-accordion.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/workflows-accordion.tsx
@@ -8,23 +8,16 @@ import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, Sele
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import type { WorkflowConfig } from "../../lib/types";
 
-type WorkflowMetadata = {
-  commands: Array<{ id: string; name: string; slashCommand: string; description?: string }>;
-  agents: Array<{ id: string; name: string; description?: string }>;
-};
-
 type WorkflowsAccordionProps = {
   sessionPhase?: string;
   activeWorkflow: string | null;
   selectedWorkflow: string;
   pendingWorkflow: WorkflowConfig | null;
   workflowActivating: boolean;
-  workflowMetadata?: WorkflowMetadata;
   ootbWorkflows: WorkflowConfig[];
   isExpanded: boolean;
   onWorkflowChange: (value: string) => void;
   onActivateWorkflow: () => void;
-  onCommandClick: (slashCommand: string) => void;
   onResume?: () => void;
 };
 
@@ -34,12 +27,10 @@ export function WorkflowsAccordion({
   selectedWorkflow,
   pendingWorkflow,
   workflowActivating,
-  workflowMetadata,
   ootbWorkflows,
   isExpanded,
   onWorkflowChange,
   onActivateWorkflow,
-  onCommandClick,
   onResume,
 }: WorkflowsAccordionProps) {
   const isSessionStopped = sessionPhase === 'Stopped' || sessionPhase === 'Error' || sessionPhase === 'Completed';

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -750,12 +750,10 @@ export default function ProjectSessionDetailPage({
                       selectedWorkflow={workflowManagement.selectedWorkflow}
                       pendingWorkflow={workflowManagement.pendingWorkflow}
                       workflowActivating={workflowManagement.workflowActivating}
-                      workflowMetadata={workflowMetadata}
                       ootbWorkflows={ootbWorkflows}
                       isExpanded={openAccordionItems.includes("workflows")}
                       onWorkflowChange={handleWorkflowChange}
                       onActivateWorkflow={workflowManagement.activateWorkflow}
-                      onCommandClick={handleCommandClick}
                       onResume={handleContinue}
                     />
 


### PR DESCRIPTION
Removes the "Show # available commands" and "Show # available agents" expandable sections from the Workflows panel within a session's details/chat page.

Based on internal feedback these lists being duplicative with the lists in the chatbox region was a bit confusing, and removing them from the panel also reduces some visual noise.

cc @Daniel-Warner-X 

## Before

<img width="399" height="296" alt="image" src="https://github.com/user-attachments/assets/41650c9d-651b-4493-b325-c0f964c1fb01" />

## After

<img width="360" height="184" alt="Arc 2025-12-15 11 46 04" src="https://github.com/user-attachments/assets/b6a8b361-867d-4b85-8860-7c4b5a95f570" />
