### PR TITLE
fix: Change AG-UI server port from 8000 to 8001

### DIFF
--- a/components/backend/websocket/agui_proxy.go
+++ b/components/backend/websocket/agui_proxy.go
@@ -410,9 +410,9 @@ func HandleAGUIInterrupt(c *gin.Context) {
 // The operator creates a Service named "session-{sessionName}" in the project namespace
 func getRunnerEndpoint(projectName, sessionName string) (string, error) {
 	// Use naming convention for service discovery
-	// Format: http://session-{sessionName}.{projectName}.svc.cluster.local:8000/
+	// Format: http://session-{sessionName}.{projectName}.svc.cluster.local:8001/
 	// The operator creates this Service automatically when spawning the runner Job
-	return fmt.Sprintf("http://session-%s.%s.svc.cluster.local:8000/", sessionName, projectName), nil
+	return fmt.Sprintf("http://session-%s.%s.svc.cluster.local:8001/", sessionName, projectName), nil
 }
 
 // broadcastToThread sends event to all thread-level subscribers

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -1096,7 +1096,7 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 							// Expose AG-UI server port for backend proxy
 							Ports: []corev1.ContainerPort{{
 								Name:          "agui",
-								ContainerPort: 8000,
+								ContainerPort: 8001,
 								Protocol:      corev1.ProtocolTCP,
 							}},
 
@@ -1537,8 +1537,8 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 			Ports: []corev1.ServicePort{{
 				Name:       "agui",
 				Protocol:   corev1.ProtocolTCP,
-				Port:       8000,
-				TargetPort: intstr.FromInt(8000),
+				Port:       8001,
+				TargetPort: intstr.FromInt(8001),
 			}},
 		},
 	}
@@ -1653,7 +1653,7 @@ func reconcileSpecReposWithPatch(sessionNamespace, sessionName string, spec map[
 
 	// AG-UI pattern: Call runner's REST endpoints to update configuration
 	// Runner will restart Claude SDK client with new repo configuration
-	runnerBaseURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:8000", sessionName, sessionNamespace)
+	runnerBaseURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:8001", sessionName, sessionNamespace)
 
 	// Add repos
 	for _, repo := range toAdd {
@@ -1774,7 +1774,7 @@ func reconcileActiveWorkflowWithPatch(sessionNamespace, sessionName string, spec
 
 	// AG-UI pattern: Call runner's /workflow endpoint to update configuration
 	// Runner will restart Claude SDK client with new workflow
-	runnerURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:8000/workflow", sessionName, sessionNamespace)
+	runnerURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:8001/workflow", sessionName, sessionNamespace)
 
 	payload := map[string]interface{}{
 		"gitUrl": gitURL,

--- a/components/runners/claude-code-runner/Dockerfile
+++ b/components/runners/claude-code-runner/Dockerfile
@@ -43,7 +43,7 @@ ENV RUNNER_TYPE=claude
 ENV HOME=/app
 ENV SHELL=/bin/bash
 ENV TERM=xterm-256color
-ENV AGUI_PORT=8000
+ENV AGUI_PORT=8001
 
 # Build metadata as environment variables
 ENV GIT_COMMIT=${GIT_COMMIT}
@@ -64,9 +64,9 @@ RUN chmod -R g=u /app && chmod -R g=u /usr/local && chmod g=u /etc/passwd
 # Run as UID 1001 to match content service (fixes permission issues)
 USER 1001
 
-# Expose AG-UI server port
-EXPOSE 8000
+# Expose AG-UI server port (8001 to avoid conflict with workspace-mcp OAuth on 8000)
+EXPOSE 8001
 
 # Start FastAPI AG-UI server using uvicorn
 # The main module is installed as part of the package
-CMD ["/bin/bash", "-c", "umask 0022 && cd /app/claude-runner && uvicorn main:app --host 0.0.0.0 --port 8000"]
+CMD ["/bin/bash", "-c", "umask 0022 && cd /app/claude-runner && uvicorn main:app --host 0.0.0.0 --port 8001"]


### PR DESCRIPTION
Avoid conflict with workspace-mcp OAuth callback server which also uses port 8000. This was causing Google Workspace MCP to fail on first run with 'port 8000 already in use' error.

Updated:
- Dockerfile: AGUI_PORT, EXPOSE, CMD
- Operator: container port, service port, URLs
- Backend: websocket proxy URL