### PR TITLE
feat: implement per-repository autoPush configuration

### DIFF
--- a/components/backend/types/session.go
+++ b/components/backend/types/session.go
@@ -28,8 +28,9 @@ type AgenticSessionSpec struct {
 
 // SimpleRepo represents a simplified repository configuration
 type SimpleRepo struct {
-	URL    string  `json:"url"`
-	Branch *string `json:"branch,omitempty"`
+	URL      string  `json:"url"`
+	Branch   *string `json:"branch,omitempty"`
+	AutoPush *bool   `json:"autoPush,omitempty"`
 }
 
 type AgenticSessionStatus struct {
@@ -53,7 +54,6 @@ type CreateAgenticSessionRequest struct {
 	ParentSessionID string       `json:"parent_session_id,omitempty"`
 	// Multi-repo support
 	Repos                []SimpleRepo      `json:"repos,omitempty"`
-	AutoPushOnComplete   *bool             `json:"autoPushOnComplete,omitempty"`
 	UserContext          *UserContext      `json:"userContext,omitempty"`
 	EnvironmentVariables map[string]string `json:"environmentVariables,omitempty"`
 	Labels               map[string]string `json:"labels,omitempty"`

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/add-context-modal.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/add-context-modal.tsx
@@ -6,13 +6,14 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Separator } from "@/components/ui/separator";
 
 type AddContextModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onAddRepository: (url: string, branch: string) => Promise<void>;
+  onAddRepository: (url: string, branch: string, autoPush?: boolean) => Promise<void>;
   onUploadFile?: () => void;
   isLoading?: boolean;
 };
@@ -26,20 +27,23 @@ export function AddContextModal({
 }: AddContextModalProps) {
   const [contextUrl, setContextUrl] = useState("");
   const [contextBranch, setContextBranch] = useState("main");
+  const [autoPush, setAutoPush] = useState(false);
 
   const handleSubmit = async () => {
     if (!contextUrl.trim()) return;
-    
-    await onAddRepository(contextUrl.trim(), contextBranch.trim() || 'main');
-    
+
+    await onAddRepository(contextUrl.trim(), contextBranch.trim() || 'main', autoPush);
+
     // Reset form
     setContextUrl("");
     setContextBranch("main");
+    setAutoPush(false);
   };
 
   const handleCancel = () => {
     setContextUrl("");
     setContextBranch("main");
+    setAutoPush(false);
     onOpenChange(false);
   };
 
@@ -85,6 +89,27 @@ export function AddContextModal({
             <p className="text-xs text-muted-foreground">
               Leave empty to use the default branch
             </p>
+          </div>
+
+          <div className="flex items-start space-x-2">
+            <Checkbox
+              id="auto-push"
+              checked={autoPush}
+              onCheckedChange={(checked) => setAutoPush(checked === true)}
+            />
+            <div className="space-y-1">
+              <Label
+                htmlFor="auto-push"
+                className="text-sm font-normal cursor-pointer"
+              >
+                Enable auto-push
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Instructs Claude to commit and push changes made to this
+                repository during the session. Requires git credentials to be
+                configured.
+              </p>
+            </div>
           </div>
 
           {onUploadFile && (

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -341,7 +341,7 @@ export default function ProjectSessionDetailPage({
 
   // Repo management mutations
   const addRepoMutation = useMutation({
-    mutationFn: async (repo: { url: string; branch: string }) => {
+    mutationFn: async (repo: { url: string; branch: string; autoPush?: boolean }) => {
       setRepoChanging(true);
       const response = await fetch(
         `/api/projects/${projectName}/agentic-sessions/${sessionName}/repos`,
@@ -2041,8 +2041,8 @@ export default function ProjectSessionDetailPage({
       <AddContextModal
         open={contextModalOpen}
         onOpenChange={setContextModalOpen}
-        onAddRepository={async (url, branch) => {
-          await addRepoMutation.mutateAsync({ url, branch });
+        onAddRepository={async (url, branch, autoPush) => {
+          await addRepoMutation.mutateAsync({ url, branch, autoPush });
           setContextModalOpen(false);
         }}
         onUploadFile={() => setUploadModalOpen(true)}

--- a/components/frontend/src/types/agentic-session.ts
+++ b/components/frontend/src/types/agentic-session.ts
@@ -16,6 +16,7 @@ export type GitRepository = {
 export type SessionRepo = {
     url: string;
     branch?: string;
+    autoPush?: boolean;
 };
 
 export type AgenticSessionSpec = {
@@ -184,7 +185,6 @@ export type CreateAgenticSessionRequest = {
 	interactive?: boolean;
 	// Multi-repo support
 	repos?: SessionRepo[];
-	autoPushOnComplete?: boolean;
 	labels?: Record<string, string>;
 	annotations?: Record<string, string>;
 };

--- a/components/frontend/src/types/api/sessions.ts
+++ b/components/frontend/src/types/api/sessions.ts
@@ -38,6 +38,7 @@ export type LLMSettings = {
 export type SessionRepo = {
   url: string;
   branch?: string;
+  autoPush?: boolean;
 };
 
 export type AgenticSessionSpec = {
@@ -117,7 +118,6 @@ export type CreateAgenticSessionRequest = {
   environmentVariables?: Record<string, string>;
   interactive?: boolean;
   repos?: SessionRepo[];
-  autoPushOnComplete?: boolean;
   userContext?: UserContext;
   labels?: Record<string, string>;
   annotations?: Record<string, string>;

--- a/components/manifests/base/crds/agenticsessions-crd.yaml
+++ b/components/manifests/base/crds/agenticsessions-crd.yaml
@@ -33,6 +33,10 @@ spec:
                       type: string
                       description: "Branch to checkout"
                       default: "main"
+                    autoPush:
+                      type: boolean
+                      default: false
+                      description: "When true, automatically commit and push changes to this repository after session completion"
               interactive:
                 type: boolean
                 description: "When true, run session in interactive chat mode using inbox/outbox files"
@@ -75,10 +79,6 @@ spec:
                 type: integer
                 default: 300
                 description: "Timeout in seconds for the agentic session"
-              autoPushOnComplete:
-                type: boolean
-                default: false
-                description: "When true, the runner will commit and push changes automatically after it finishes"
               activeWorkflow:
                 type: object
                 description: "Active workflow configuration for dynamic workflow switching"

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -686,9 +686,6 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 		})
 	}
 
-	// Read autoPushOnComplete flag
-	autoPushOnComplete, _, _ := unstructured.NestedBool(spec, "autoPushOnComplete")
-
 	// Extract userContext for observability and auditing
 	userID := ""
 	userName := ""
@@ -924,7 +921,6 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 							corev1.EnvVar{Name: "LLM_MAX_TOKENS", Value: fmt.Sprintf("%d", maxTokens)},
 							corev1.EnvVar{Name: "USE_AGUI", Value: "true"},
 							corev1.EnvVar{Name: "TIMEOUT", Value: fmt.Sprintf("%d", timeout)},
-							corev1.EnvVar{Name: "AUTO_PUSH_ON_COMPLETE", Value: fmt.Sprintf("%t", autoPushOnComplete)},
 							corev1.EnvVar{Name: "BACKEND_API_URL", Value: fmt.Sprintf("http://backend-service.%s.svc.cluster.local:8080/api", appConfig.BackendNamespace)},
 							// LEGACY: WEBSOCKET_URL removed - runner now uses AG-UI server pattern (FastAPI)
 							// Backend proxies to runner's HTTP endpoint instead of WebSocket

--- a/components/runners/claude-code-runner/tests/test_auto_push.py
+++ b/components/runners/claude-code-runner/tests/test_auto_push.py
@@ -1,0 +1,369 @@
+"""Unit tests for autoPush functionality in adapter.py."""
+
+import pytest
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch, Mock
+
+# Mock ag_ui module before importing adapter
+sys.modules['ag_ui'] = Mock()
+sys.modules['ag_ui.core'] = Mock()
+sys.modules['context'] = Mock()
+
+
+class TestGetReposConfig:
+    """Tests for _get_repos_config method."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        # Import here after mocking dependencies
+        from adapter import ClaudeCodeAdapter
+        self.adapter = ClaudeCodeAdapter()
+
+    def test_parse_simple_repo_with_autopush_true(self):
+        """Test parsing repo with autoPush=true."""
+        repos_json = json.dumps([
+            {
+                "url": "https://github.com/owner/repo.git",
+                "branch": "main",
+                "autoPush": True
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 1
+        assert result[0]["url"] == "https://github.com/owner/repo.git"
+        assert result[0]["branch"] == "main"
+        assert result[0]["autoPush"] is True
+        assert "repo" in result[0]["name"]
+
+    def test_parse_simple_repo_with_autopush_false(self):
+        """Test parsing repo with autoPush=false."""
+        repos_json = json.dumps([
+            {
+                "url": "https://github.com/owner/repo.git",
+                "branch": "develop",
+                "autoPush": False
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 1
+        assert result[0]["autoPush"] is False
+
+    def test_parse_repo_without_autopush(self):
+        """Test parsing repo without autoPush field defaults to False."""
+        repos_json = json.dumps([
+            {
+                "url": "https://github.com/owner/repo.git",
+                "branch": "main"
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 1
+        assert result[0]["autoPush"] is False
+
+    def test_parse_multiple_repos_mixed_autopush(self):
+        """Test parsing multiple repos with mixed autoPush settings."""
+        repos_json = json.dumps([
+            {
+                "url": "https://github.com/owner/repo1.git",
+                "branch": "main",
+                "autoPush": True
+            },
+            {
+                "url": "https://github.com/owner/repo2.git",
+                "branch": "develop",
+                "autoPush": False
+            },
+            {
+                "url": "https://github.com/owner/repo3.git",
+                "branch": "feature"
+                # No autoPush field
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 3
+        assert result[0]["autoPush"] is True
+        assert result[1]["autoPush"] is False
+        assert result[2]["autoPush"] is False  # Default
+
+    def test_parse_repo_with_explicit_name(self):
+        """Test parsing repo with explicit name field."""
+        repos_json = json.dumps([
+            {
+                "name": "my-custom-repo",
+                "url": "https://github.com/owner/repo.git",
+                "branch": "main",
+                "autoPush": True
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 1
+        assert result[0]["name"] == "my-custom-repo"
+        assert result[0]["autoPush"] is True
+
+    def test_parse_empty_repos_json(self):
+        """Test parsing empty REPOS_JSON."""
+        with patch.dict(os.environ, {"REPOS_JSON": ""}):
+            result = self.adapter._get_repos_config()
+
+        assert result == []
+
+    def test_parse_missing_repos_json(self):
+        """Test parsing when REPOS_JSON not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = self.adapter._get_repos_config()
+
+        assert result == []
+
+    def test_parse_invalid_json(self):
+        """Test parsing invalid JSON returns empty list."""
+        with patch.dict(os.environ, {"REPOS_JSON": "invalid-json{"}):
+            result = self.adapter._get_repos_config()
+
+        assert result == []
+
+    def test_parse_non_list_json(self):
+        """Test parsing non-list JSON returns empty list."""
+        repos_json = json.dumps({"url": "https://github.com/owner/repo.git"})
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert result == []
+
+    def test_parse_repo_without_url(self):
+        """Test that repos without URL are skipped."""
+        repos_json = json.dumps([
+            {
+                "branch": "main",
+                "autoPush": True
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert result == []
+
+    def test_derive_repo_name_from_url(self):
+        """Test automatic derivation of repo name from URL."""
+        test_cases = [
+            ("https://github.com/owner/my-repo.git", "my-repo"),
+            ("https://github.com/owner/my-repo", "my-repo"),
+            ("git@github.com:owner/another-repo.git", "another-repo"),
+        ]
+
+        for url, expected_name in test_cases:
+            repos_json = json.dumps([{"url": url, "autoPush": True}])
+
+            with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+                result = self.adapter._get_repos_config()
+
+            assert len(result) == 1
+            assert result[0]["name"] == expected_name
+
+    def test_autopush_with_invalid_string_type(self):
+        """Test that string autoPush values default to False."""
+        repos_json = json.dumps([
+            {
+                "url": "https://github.com/owner/repo.git",
+                "autoPush": "true"  # String instead of boolean
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 1
+        # Invalid type should default to False
+        assert result[0]["autoPush"] is False
+
+    def test_autopush_with_invalid_number_type(self):
+        """Test that numeric autoPush values default to False."""
+        repos_json = json.dumps([
+            {
+                "url": "https://github.com/owner/repo.git",
+                "autoPush": 1  # Number instead of boolean
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 1
+        # Invalid type should default to False
+        assert result[0]["autoPush"] is False
+
+    def test_autopush_with_null_value(self):
+        """Test that null autoPush values default to False."""
+        repos_json = json.dumps([
+            {
+                "url": "https://github.com/owner/repo.git",
+                "autoPush": None  # null in JSON
+            }
+        ])
+
+        with patch.dict(os.environ, {"REPOS_JSON": repos_json}):
+            result = self.adapter._get_repos_config()
+
+        assert len(result) == 1
+        # null should default to False
+        assert result[0]["autoPush"] is False
+
+
+class TestBuildWorkspaceContextPrompt:
+    """Tests for _build_workspace_context_prompt method."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        # Import here after mocking dependencies
+        from adapter import ClaudeCodeAdapter
+
+        self.adapter = ClaudeCodeAdapter()
+
+        # Create a mock context
+        mock_context = MagicMock()
+        mock_context.workspace_path = "/workspace"
+        self.adapter.context = mock_context
+
+    def test_prompt_includes_git_instructions_with_autopush(self):
+        """Test that git push instructions are included when autoPush=true."""
+        repos_cfg = [
+            {
+                "name": "my-repo",
+                "url": "https://github.com/owner/my-repo.git",
+                "branch": "main",
+                "autoPush": True
+            }
+        ]
+
+        prompt = self.adapter._build_workspace_context_prompt(
+            repos_cfg=repos_cfg,
+            workflow_name=None,
+            artifacts_path="artifacts",
+            ambient_config={}
+        )
+
+        # Verify git instructions are present
+        assert "Git Push Instructions" in prompt
+        assert "repos/my-repo/" in prompt
+        assert "branch: main" in prompt
+        assert "git add" in prompt
+        assert "git commit" in prompt
+        assert "git push origin" in prompt
+
+    def test_prompt_excludes_git_instructions_without_autopush(self):
+        """Test that git push instructions are excluded when autoPush=false."""
+        repos_cfg = [
+            {
+                "name": "my-repo",
+                "url": "https://github.com/owner/my-repo.git",
+                "branch": "main",
+                "autoPush": False
+            }
+        ]
+
+        prompt = self.adapter._build_workspace_context_prompt(
+            repos_cfg=repos_cfg,
+            workflow_name=None,
+            artifacts_path="artifacts",
+            ambient_config={}
+        )
+
+        # Verify git instructions are NOT present
+        assert "Git Push Instructions" not in prompt
+        assert "git add" not in prompt
+        assert "git commit" not in prompt
+        assert "git push origin" not in prompt
+
+    def test_prompt_includes_multiple_autopush_repos(self):
+        """Test that all autoPush repos are listed in instructions."""
+        repos_cfg = [
+            {
+                "name": "repo1",
+                "url": "https://github.com/owner/repo1.git",
+                "branch": "main",
+                "autoPush": True
+            },
+            {
+                "name": "repo2",
+                "url": "https://github.com/owner/repo2.git",
+                "branch": "develop",
+                "autoPush": True
+            },
+            {
+                "name": "repo3",
+                "url": "https://github.com/owner/repo3.git",
+                "branch": "feature",
+                "autoPush": False
+            }
+        ]
+
+        prompt = self.adapter._build_workspace_context_prompt(
+            repos_cfg=repos_cfg,
+            workflow_name=None,
+            artifacts_path="artifacts",
+            ambient_config={}
+        )
+
+        # Verify both autoPush repos are listed
+        assert "repos/repo1/" in prompt
+        assert "branch: main" in prompt
+        assert "repos/repo2/" in prompt
+        assert "branch: develop" in prompt
+        # repo3 should not be in git instructions since autoPush=false
+        # (but it will be in the general repos list)
+
+    def test_prompt_without_repos(self):
+        """Test prompt generation when no repos are configured."""
+        prompt = self.adapter._build_workspace_context_prompt(
+            repos_cfg=[],
+            workflow_name=None,
+            artifacts_path="artifacts",
+            ambient_config={}
+        )
+
+        # Should not include git instructions
+        assert "Git Push Instructions" not in prompt
+        # Should still include other sections
+        assert "Workspace Structure" in prompt
+        assert "Artifacts" in prompt
+
+    def test_prompt_with_workflow(self):
+        """Test prompt generation with workflow context."""
+        repos_cfg = [
+            {
+                "name": "my-repo",
+                "url": "https://github.com/owner/my-repo.git",
+                "branch": "main",
+                "autoPush": True
+            }
+        ]
+
+        prompt = self.adapter._build_workspace_context_prompt(
+            repos_cfg=repos_cfg,
+            workflow_name="test-workflow",
+            artifacts_path="artifacts",
+            ambient_config={}
+        )
+
+        # Should include both workflow info and git instructions
+        assert "workflows/test-workflow/" in prompt
+        assert "Git Push Instructions" in prompt
+        assert "repos/my-repo/" in prompt


### PR DESCRIPTION
Replace global autoPushOnComplete setting with per-repository autoPush field to enable granular control of git push behavior for agentic sessions. Each repository can now be configured independently with autoPush: true/false.

## Changes

- Add autoPush field to SessionRepo type (backend, frontend, CRD)
- Remove deprecated autoPushOnComplete from all components
- Add type validation in runner to handle invalid autoPush values
- Generate Git Push Instructions in system prompt for repos with autoPush=true
- Add comprehensive test coverage (10 backend tests, 19 runner tests)
- Update UI with clear help text explaining autoPush behavior

## Testing

- All 351 backend tests pass
- All 19 runner tests pass (including edge case type validation tests)
- Frontend builds with 0 errors, 0 warnings
- Manual testing verified correct behavior