### PR TITLE
fix: auto-activate custom workflow after submission

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -2034,6 +2034,17 @@ export default function ProjectSessionDetailPage({
         onSubmit={(url, branch, path) => {
           workflowManagement.setCustomWorkflow(url, branch, path);
           setCustomWorkflowDialogOpen(false);
+          // Automatically activate the custom workflow (same as OOTB workflows)
+          const customWorkflow = {
+            id: "custom",
+            name: "Custom workflow",
+            description: `Custom workflow from ${url}`,
+            gitUrl: url,
+            branch: branch || "main",
+            path: path || "",
+            enabled: true,
+          };
+          workflowManagement.activateWorkflow(customWorkflow, session?.status?.phase);
         }}
         isActivating={workflowManagement.workflowActivating}
       />


### PR DESCRIPTION
## Problem

Custom workflows were not being activated after submission - the form dialog would close, but no network call was made to the backend API to actually load the workflow.

## Root Cause

When submitting a custom workflow, the code was only calling `setCustomWorkflow()` which set it as "pending" but never called `activateWorkflow()`. Out-of-the-box workflows automatically activated, but custom ones didn't.

## Solution

Modified the `CustomWorkflowDialog` submission handler to automatically activate the workflow after setting it as pending. This now:

1. Sets the workflow as pending
2. Closes the dialog
3. Creates a workflow config object
4. **Immediately activates it** (makes the POST request to `/api/projects/{project}/agentic-sessions/{session}/workflow`)

This matches the behavior of OOTB workflows.

## Testing

- ✅ Frontend builds successfully with `npm run build`
- ✅ No linting errors
- Ready to test on dev cluster after deployment

## Changes

- Modified `components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx`
  - Added automatic activation call in `CustomWorkflowDialog` onSubmit handler