### PR TITLE
fix: disconnect EventSource when navigating away from session detail

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -230,7 +230,14 @@ export default function ProjectSessionDetailPage({
       hasConnectedRef.current = true;
       aguiConnectRef.current();
     }
-  }, [projectName, sessionName]);
+    
+    // CRITICAL: Disconnect when navigating away to prevent hung connections
+    return () => {
+      console.log('[Session Detail] Unmounting, disconnecting AG-UI stream');
+      aguiStream.disconnect();
+      hasConnectedRef.current = false;
+    };
+  }, [projectName, sessionName, aguiStream]);
 
   // Auto-send initial prompt (handles session start, workflow activation, restarts)
   // AG-UI pattern: Client (or backend) initiates runs via POST /agui/run


### PR DESCRIPTION
## Problem

When navigating from a session detail page to the sessions list page, the frontend would hang with all network requests stuck in "pending" state. This only occurred in OpenShift deployments, not locally.

The root cause: the EventSource (SSE) connection wasn't being cleaned up when unmounting the session detail component. This left the connection open and blocked the browser's connection pool (6 concurrent connections per domain).

## Solution

Added a cleanup function in the useEffect hook that calls `aguiStream.disconnect()` when the component unmounts. This properly closes the EventSource connection.

## Changes

- **components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx**: Added return cleanup function in the AG-UI connection useEffect

## Testing

1. Navigate to a session detail page (connection opens)
2. Navigate back to sessions list (connection now properly closes)
3. All network requests work normally - no more hanging

## Impact

- ✅ Fixes frontend hanging on navigation
- ✅ Prevents resource leaks from unclosed connections
- ✅ No breaking changes - purely additive cleanup
- ✅ MVP fix - minimal changes for maximum impact