### PR TITLE
Lefthand column in chat UI now scrolls to view overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ dmypy.json
 
 .claude/settings.local.json
 
+# Design documentation
+.design/
+
 # macOS system files
 .DS_Store
 .DS_Store?

--- a/components/frontend/src/app/globals.css
+++ b/components/frontend/src/app/globals.css
@@ -259,3 +259,15 @@
 .dark .scrollbar-thin::-webkit-scrollbar-thumb:hover {
   background: hsl(var(--foreground));
 }
+
+/* Hide scrollbar while maintaining scroll functionality */
+.scrollbar-hide {
+  /* Firefox */
+  scrollbar-width: none;
+  /* WebKit browsers (Chrome, Safari, Edge) */
+  -ms-overflow-style: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -1566,7 +1566,7 @@ export default function ProjectSessionDetailPage({
                   </Button>
                 </div>
                 <div className={cn(
-                  "flex-grow pb-6",
+                  "flex-grow pb-6 overflow-y-auto scrollbar-hide",
                   ["Stopped", "Completed", "Failed"].includes(phase) && "blur-[2px]"
                 )}>
                   <Accordion


### PR DESCRIPTION
Small usability fix.

In 1/16 user test, user reported that lefthand column was not scrollable. The data they wanted to see was pushed out of the view and was inaccessible.

<img width="496" height="790" alt="image" src="https://github.com/user-attachments/assets/55104858-4ab3-4531-bc4d-46eac87bc0ea" />

Now the column is scrollable...


https://github.com/user-attachments/assets/83c443d8-485a-4e9c-a348-5ae0ccacdaba

