### PR TITLE
fix: add background color to checkbox indicator in dropdown menu

### DIFF
--- a/components/frontend/src/components/ui/dropdown-menu.tsx
+++ b/components/frontend/src/components/ui/dropdown-menu.tsx
@@ -105,7 +105,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center border border-border">
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center border border-border bg-background rounded-sm">
       <DropdownMenuPrimitive.ItemIndicator>
         <CheckIcon className="h-4 w-4 text-foreground" />
       </DropdownMenuPrimitive.ItemIndicator>


### PR DESCRIPTION
## Summary
Fixed the rendering issue with the "Show system messages" checkbox. The checkbox indicator was missing a background color, making it invisible or difficult to see.

## Changes
- Added `bg-background` class to provide visible background for checkbox box
- Added `rounded-sm` class for proper border radius matching design system

**File:** `components/frontend/src/components/ui/dropdown-menu.tsx` (line 108)

## Root Cause
The `DropdownMenuCheckboxItem` component uses a span element to render the checkbox box with a border, but was missing the background color styling. This made the checkbox appear broken or invisible.

## Impact
Fixes all dropdown menu checkboxes throughout the application, including the "Show system messages" toggle in MessagesTab.

## Testing
- ✅ Frontend builds without errors
- ✅ Local dev server runs successfully
- ✅ Minimal change with targeted fix

🤖 Generated with Claude Code