### PR TITLE
Bug RHOAIENG-39110: Fix username display to remove cluster suffix

### DIFF
--- a/components/frontend/src/app/api/me/route.ts
+++ b/components/frontend/src/app/api/me/route.ts
@@ -13,12 +13,16 @@ export async function GET(request: Request) {
       return Response.json({ authenticated: false }, { status: 200 });
     }
 
+    // Clean the displayName by removing cluster suffix (e.g., "@cluster.local", "@apps-crc.testing")
+    const rawDisplayName = username || email || userId;
+    const displayName = rawDisplayName?.split('@')[0] || rawDisplayName;
+
     return Response.json({
       authenticated: true,
       userId,
       email,
       username,
-      displayName: username || email || userId,
+      displayName,
     });
   } catch (error) {
     console.error('Error reading user headers:', error);


### PR DESCRIPTION
## Summary
Fixes username display in the top-right corner to show clean username instead of `user@cluster.local` format.

## Problem
The `X-Forwarded-Preferred-Username` header contains values like `gkrumbac@cluster.local`, and the frontend API endpoint was using this value directly for `displayName`, causing the UI to show `gkrumbac@cluster.local` instead of just `gkrumbac`.

## Solution
Modified `components/frontend/src/app/api/me/route.ts` to strip everything after the `@` symbol from the displayName while preserving the original username field unchanged.

## Changes
- Added logic to split displayName by `@` and take the first part
- Handles edge cases:
  - Usernames without `@` symbol (passthrough)
  - Multiple `@` symbols (takes first part)
  - Email addresses (strips domain)
  - Empty/undefined values (fallback preserved)
- Maintains backward compatibility

## Testing
The fix handles all expected scenarios:
- `gkrumbac@cluster.local` → displays as `gkrumbac` ✓
- `user@apps-crc.testing` → displays as `user` ✓
- `username` → displays as `username` ✓
- Email addresses → strips domain appropriately ✓

## Related Issue
Fixes: https://issues.redhat.com/browse/RHOAIENG-39110