### PR TITLE
Bug RHOAIENG-39106: Make URLs clickable in chat messages

### DIFF
--- a/components/frontend/src/components/ui/message.tsx
+++ b/components/frontend/src/components/ui/message.tsx
@@ -83,6 +83,16 @@ const defaultComponents: Components = {
   li: ({ children }) => (
     <li className="leading-relaxed">{children}</li>
   ),
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary hover:underline cursor-pointer"
+    >
+      {children}
+    </a>
+  ),
 };
 
 const LOADING_MESSAGES = [


### PR DESCRIPTION
## Summary
Fixes URLs not being rendered as clickable hyperlinks in chat messages.

## Changes
- Added custom anchor (`a`) component to `defaultComponents` in `message.tsx`
- Configured links to open in new tab (`target="_blank"`)
- Added security headers (`rel="noopener noreferrer"`)
- Applied primary color styling with hover underline effect

## Technical Details
The `remarkGfm` plugin auto-links URLs in markdown, but without a custom anchor component they weren't properly styled or configured for external links. This fix ensures all URLs are:
- Clickable
- Open in new tabs
- Secure (with `noopener noreferrer`)
- Styled consistently with the design system

## Testing
Verified that:
- ✅ Frontend builds successfully
- ✅ Linter passes
- ✅ URLs render as clickable links
- ✅ Links open in new tab
- ✅ Security headers are present

## Related Issue
Fixes: https://issues.redhat.com/browse/RHOAIENG-39106

🤖 Generated with [Claude Code](https://claude.com/claude-code)