### PR TITLE
Bug RHOAIENG-46361: Make chat window monospace font

### DIFF
--- a/components/frontend/src/components/ui/message.tsx
+++ b/components/frontend/src/components/ui/message.tsx
@@ -216,7 +216,7 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
               !borderless && (isBot ? "bg-card" : "bg-border/30")
             )}>
               {/* Content */}
-              <div className={cn("text-sm text-foreground", !isBot && "py-2 px-4")}>
+              <div className={cn("text-sm text-foreground font-mono", !isBot && "py-2 px-4")}>
                 {isLoading ? (
                   <div>
                     <div className="text-sm text-muted-foreground mb-2">{content}</div>


### PR DESCRIPTION
## Summary
This PR fixes RHOAIENG-46361 by making the chat window display messages in a monospace system font.

## Changes
- Added `font-mono` class to the message content div in `components/frontend/src/components/ui/message.tsx:219`
- The input box styling remains unchanged as requested
- Both bot and user messages now display in monospace font

## Testing
- ✅ Build passes
- ✅ Linter passes
- ✅ Change is minimal and focused

## Related
- Jira: RHOAIENG-46361

---
🤖 Generated with Claude Code