### PR TITLE
Fix: Architecture mismatch in local builds causing Apple Silicon crashes

### DIFF
--- a/components/manifests/minikube/frontend-deployment.yaml
+++ b/components/manifests/minikube/frontend-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: GITHUB_APP_SLUG
           value: "ambient-code"
         - name: VTEAM_VERSION
-          value: "v0.0.12-22-g5553056"
+          value: "v0.0.19-8-g6d9251e"
         - name: DISABLE_AUTH
           value: "true"
         - name: MOCK_USER

--- a/docs/developer/local-development/kind.md
+++ b/docs/developer/local-development/kind.md
@@ -44,6 +44,25 @@ podman ps && kind --version && kubectl version --client
 docker ps && kind --version && kubectl version --client
 ```
 
+## Architecture Support
+
+The platform auto-detects your host architecture and builds native images:
+
+- **Apple Silicon (M1/M2/M3):** `linux/arm64`
+- **Intel/AMD:** `linux/amd64`
+
+**Verify native builds:**
+```bash
+make check-architecture  # Should show "✓ Using native architecture"
+```
+
+**Manual override (if needed):**
+```bash
+make build-all PLATFORM=linux/arm64  # Force specific architecture
+```
+
+⚠️ **Warning:** Cross-compiling (building non-native architecture) is 4-6x slower and may crash.
+
 ## Commands
 
 ### `make kind-up`
@@ -205,6 +224,19 @@ make kind-up CONTAINER_ENGINE=docker
 lsof -i:8080  # Find what's using the port
 # Kill it or edit e2e/scripts/setup-kind.sh to use different ports
 ```
+
+### Build crashes with segmentation fault
+
+**Symptom:** `qemu: uncaught target signal 11 (Segmentation fault)` during Next.js build
+
+**Fix:**
+```bash
+# Auto-detect and use native architecture
+make local-clean
+make local-up
+```
+
+**Diagnosis:** Run `make check-architecture` to verify native builds are enabled.
 
 ### MinIO errors
 


### PR DESCRIPTION
## Problem

Apple Silicon users running `make local-up` experienced:
- Slow builds (15-20 min vs 4-6 min)
- Crashes: `qemu: uncaught target signal 11 (Segmentation fault)`
- Next.js build failures

## Root Cause

The `_build-and-load` target was missing `$(PLATFORM_FLAG)` in build commands, causing:
1. Images built without platform → defaulted to amd64
2. On Apple Silicon, amd64 images run via QEMU emulation (4-6x slower)
3. Next.js builds crash under QEMU

**Why other targets worked:** Public build targets (`build-frontend`, etc.) correctly included `$(PLATFORM_FLAG)`. Only `make local-up` was broken.

## The Fix

Added `$(PLATFORM_FLAG)` to 4 build commands in `_build-and-load`:

```makefile
# Before
@$(CONTAINER_ENGINE) build -t $(BACKEND_IMAGE) components/backend

# After  
@$(CONTAINER_ENGINE) build $(PLATFORM_FLAG) -t $(BACKEND_IMAGE) components/backend
```

## Additional Improvements

1. **Auto-detect architecture** - Apple Silicon → `linux/arm64`, Intel → `linux/amd64`
2. **Diagnostic tool** - `make check-architecture` shows detected platform
3. **Documentation** - Troubleshooting guide in `docs/developer/local-development/kind.md`

## Impact

**Before:**
- Apple Silicon: 15-20 min builds with crashes
- Had to manually set `PLATFORM=linux/arm64` (which `local-up` ignored anyway)

**After:**
- Apple Silicon: 4-6 min builds, no crashes
- Auto-detects native architecture
- Manual override supported: `make local-up PLATFORM=linux/amd64`

## Testing

```bash
make check-architecture  # Verify native builds
make local-clean
make local-up            # Should complete in 4-6 min
```

## Files Changed

- `Makefile` - Auto-detect + fix bug
- `docs/developer/local-development/kind.md` - Troubleshooting guide
- `e2e/scripts/load-images.sh` - Architecture validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)