### PR TITLE
Task RHOAIENG-46350: Enable image paste in chat input

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -2031,6 +2031,12 @@ export default function ProjectSessionDetailPage({
                           userHasInteracted={userHasInteracted}
                           queuedMessages={sessionQueue.messages}
                           hasRealMessages={hasRealMessages}
+                          onPasteImage={async (file: File) => {
+                            await uploadFileMutation.mutateAsync({
+                              type: 'local',
+                              file: file
+                            });
+                          }}
                           welcomeExperienceComponent={
                             <WelcomeExperience
                               ootbWorkflows={ootbWorkflows}

--- a/components/frontend/src/components/session/MessagesTab.tsx
+++ b/components/frontend/src/components/session/MessagesTab.tsx
@@ -36,10 +36,11 @@ export type MessagesTabProps = {
   userHasInteracted?: boolean;  // Track if user has sent any messages
   queuedMessages?: QueuedMessageItem[];  // Messages queued while session wasn't running
   hasRealMessages?: boolean;  // Track if there are real user/agent messages
+  onPasteImage?: (file: File) => Promise<void>;  // Handler for pasted images
 };
 
 
-const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chatInput, setChatInput, onSendChat, onInterrupt, onEndSession, onGoToResults, onContinue, workflowMetadata, onCommandClick, isRunActive = false, showWelcomeExperience, welcomeExperienceComponent, activeWorkflow, userHasInteracted = false, queuedMessages = [], hasRealMessages = false }) => {
+const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chatInput, setChatInput, onSendChat, onInterrupt, onEndSession, onGoToResults, onContinue, workflowMetadata, onCommandClick, isRunActive = false, showWelcomeExperience, welcomeExperienceComponent, activeWorkflow, userHasInteracted = false, queuedMessages = [], hasRealMessages = false, onPasteImage }) => {
   const [interrupting, setInterrupting] = useState(false);
   const [ending, setEnding] = useState(false);
   const [sendingChat, setSendingChat] = useState(false);
@@ -243,14 +244,14 @@ const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chat
   const handleChatInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
     const cursorPos = e.target.selectionStart;
-    
+
     setChatInput(newValue);
-    
+
     // Check if we should show autocomplete
     if (cursorPos > 0) {
       const charBeforeCursor = newValue[cursorPos - 1];
       const textBeforeCursor = newValue.substring(0, cursorPos);
-      
+
       // Check for @ or / trigger
       if (charBeforeCursor === '@' || charBeforeCursor === '/') {
         // Make sure it's at the start or after whitespace
@@ -263,11 +264,11 @@ const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chat
           return;
         }
       }
-      
+
       // Update filter if autocomplete is open
       if (autocompleteOpen) {
         const filterText = textBeforeCursor.substring(autocompleteTriggerPos + 1);
-        
+
         // Close if we've moved past the trigger or hit whitespace
         if (cursorPos <= autocompleteTriggerPos || /\s/.test(filterText)) {
           setAutocompleteOpen(false);
@@ -284,6 +285,37 @@ const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chat
         setAutocompleteOpen(false);
         setAutocompleteType(null);
         setAutocompleteFilter('');
+      }
+    }
+  };
+
+  // Handle paste events to detect and upload images
+  const handlePaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!onPasteImage) return;
+
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+
+        const file = item.getAsFile();
+        if (!file) continue;
+
+        // Generate filename for clipboard image
+        const timestamp = Date.now();
+        const extension = item.type.split('/')[1] || 'png';
+        const filename = `clipboard-${timestamp}.${extension}`;
+
+        // Create File object with proper name
+        const namedFile = new File([file], filename, { type: item.type });
+
+        try {
+          await onPasteImage(namedFile);
+        } catch (error) {
+          console.error('Image paste upload failed:', error);
+        }
       }
     }
   };
@@ -410,6 +442,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chat
                   placeholder={isRunActive ? "Agent is processing... (click Stop to interrupt)" : "Type a message to the agent... (Press Enter to send, Shift+Enter for new line)"}
                   value={chatInput}
                   onChange={handleChatInputChange}
+                  onPaste={handlePaste}
                   onKeyDown={(e) => {
                     // Handle autocomplete navigation
                     if (autocompleteOpen && filteredAutocompleteItems.length > 0) {


### PR DESCRIPTION
## Summary

This PR implements the ability to paste images directly into the chat input textarea. Images are automatically uploaded to the workspace using the existing file upload infrastructure.

## Changes

- Added `onPasteImage` prop to `MessagesTab` component
- Implemented `handlePaste` event handler to detect and process clipboard images
- Wired up `uploadFileMutation` from parent component to handle pasted image uploads
- Generate unique filenames for clipboard images using timestamp pattern: `clipboard-{timestamp}.{ext}`
- Support all image formats (png, jpg, gif, webp, etc.)
- Handle multiple images pasted at once
- Provide user feedback via existing toast notifications

## Implementation Details

The implementation reuses the existing upload endpoint (`/api/projects/{name}/agentic-sessions/{sessionName}/workspace/upload`) and mutation logic, ensuring consistent:
- Error handling
- File refresh behavior  
- Success/error notifications
- Upload progress tracking

## Testing

- ✅ Frontend builds successfully
- ✅ Linter passes without errors
- ✅ TypeScript types are correct
- Supports all image formats through MIME type detection
- Handles multiple simultaneous image pastes
- Gracefully degrades when handler is not provided
- Does not interfere with normal text paste operations

## Related Issue

Resolves: https://issues.redhat.com/browse/RHOAIENG-46350

🤖 Generated with [Claude Code](https://claude.com/claude-code)