### PR TITLE
UI Polish: Fix cursor hover, context overflow, and trailing slash handling

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/repositories-accordion.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/repositories-accordion.tsx
@@ -124,7 +124,7 @@ export function RepositoriesAccordion({
                       {hasBranches && (
                         <button
                           onClick={toggleExpanded}
-                          className="h-4 w-4 text-muted-foreground flex-shrink-0 hover:text-foreground"
+                          className="h-4 w-4 text-muted-foreground flex-shrink-0 hover:text-foreground cursor-pointer"
                         >
                           {isExpanded ? (
                             <ChevronDown className="h-4 w-4" />
@@ -135,7 +135,7 @@ export function RepositoriesAccordion({
                       )}
                       {!hasBranches && <div className="h-4 w-4 flex-shrink-0" />}
                       <GitBranch className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                      <div className="flex-1 overflow-visible">
+                      <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 flex-wrap">
                           <div className="text-sm font-medium truncate">{repoName}</div>
                           {currentBranch && (

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/add-context-modal.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/add-context-modal.tsx
@@ -34,9 +34,12 @@ export function AddContextModal({
   const handleSubmit = async () => {
     if (!contextUrl.trim()) return;
 
+    // Trim URL and remove trailing slash
+    const sanitizedUrl = contextUrl.trim().replace(/\/+$/, '');
+
     // Use autoBranch from backend (single source of truth), or empty to let runner auto-generate
     const defaultBranch = autoBranch || '';
-    await onAddRepository(contextUrl.trim(), contextBranch.trim() || defaultBranch, autoPush);
+    await onAddRepository(sanitizedUrl, contextBranch.trim() || defaultBranch, autoPush);
 
     // Reset form
     setContextUrl("");


### PR DESCRIPTION
## Summary
- Fix #514: Add cursor pointer to repository expand/collapse chevron button
- Fix #519: Fix Context panel overflow with proper text truncation
- Fix #518: Handle trailing slash in repository URLs

## Changes

### Fix #514 - Cursor Pointer on Interactive Element
**File**: `repositories-accordion.tsx`
**Change**: Added `cursor-pointer` class to the chevron toggle button

**Before**: Chevron expand/collapse button had no cursor feedback  
**After**: Button shows pointer cursor on hover, indicating it's clickable

```tsx
className="... cursor-pointer"
```

### Fix #519 - Context Panel Overflow
**File**: `repositories-accordion.tsx`
**Change**: Changed `overflow-visible` to `min-w-0` on repository container

**Before**: Long repository URLs pushed the remove (X) button off-screen  
**After**: URLs properly truncate and remove button stays visible

```tsx
<div className="flex-1 min-w-0">  {/* was overflow-visible */}
```

### Fix #518 - Trailing Slash Handling
**File**: `add-context-modal.tsx`
**Change**: Sanitize URL input by removing trailing slashes

**Before**: URLs like `https://github.com/org/repo/` would fail validation  
**After**: Trailing slashes are automatically removed before submission

```tsx
const sanitizedUrl = contextUrl.trim().replace(/\/+$/, '');
```

## Test Plan
- [x] Verify cursor changes to pointer on chevron hover
- [x] Test long repository URLs don't push remove button off screen
- [x] Test repository URLs with trailing slashes are accepted
- [x] Verify no regressions in Context panel functionality

## Impact
All changes are CSS/input handling improvements with no functional side effects.

Generated with [Claude Code](https://claude.com/claude-code)