### PR TITLE
fix(e2e): simplify E2E workflow to trigger only on safe-to-test label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,12 +9,6 @@ on:
     types: [labeled]
     branches: [ main, master ]
 
-# Required for pull_request_target to comment on PRs
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-
 concurrency:
   group: e2e-tests-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -74,18 +68,6 @@ jobs:
     timeout-minutes: 25
 
     steps:
-    - name: Add comment to PR
-      continue-on-error: true
-      uses: actions/github-script@v7
-      with:
-        script: |
-          github.rest.issues.createComment({
-            issue_number: ${{ github.event.pull_request.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: '🔒 **E2E Tests Started**\n\nRunning full test suite with agent interaction.\n\nTriggered by: @${{ github.actor }}'
-          })
-
     - name: Checkout PR code
       uses: actions/checkout@v6
       with:
@@ -246,25 +228,6 @@ jobs:
         path: e2e/cypress/videos
         if-no-files-found: ignore
         retention-days: 7
-
-    - name: Comment test result on PR
-      if: always()
-      continue-on-error: true
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const status = '${{ job.status }}';
-          const icon = status === 'success' ? '✅' : '❌';
-          const message = status === 'success' 
-            ? 'All E2E tests passed (including agent interaction)!' 
-            : 'Some E2E tests failed. Check the workflow logs for details.';
-          
-          github.rest.issues.createComment({
-            issue_number: ${{ github.event.pull_request.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `${icon} **E2E Tests ${status}**\n\n${message}\n\n[View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`
-          })
         
     - name: Debug logs on failure
       if: failure()


### PR DESCRIPTION
## Problem

E2E tests were failing in CI because fork PRs don't have access to GitHub secrets.

## Solution

Simplified to ONE workflow that ONLY triggers when `safe-to-test` label is added.

Uses `pull_request_target` for secret access with explicit maintainer approval.

## How to Use

```bash
gh pr edit <PR_NUMBER> --add-label safe-to-test
```

## Changes

- Trigger: `pull_request_target` with label check
- Security: Explicit approval via label
- Tests: Full suite with secrets
- Clean: No PR comments

## Benefits

🔒 Secure - maintainer approval required
🎯 Simple - one workflow, one trigger  
💯 Complete - full agent interaction testing