### PR TITLE
fix(e2e): simplify E2E workflow to trigger only on safe-to-test label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,17 +68,6 @@ jobs:
     timeout-minutes: 25
 
     steps:
-    - name: Add comment to PR
-      uses: actions/github-script@v7
-      with:
-        script: |
-          github.rest.issues.createComment({
-            issue_number: ${{ github.event.pull_request.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: '🔒 **E2E Tests Started**\n\nRunning full test suite with agent interaction.\n\nTriggered by: @${{ github.actor }}'
-          })
-
     - name: Checkout PR code
       uses: actions/checkout@v6
       with:
@@ -239,24 +228,6 @@ jobs:
         path: e2e/cypress/videos
         if-no-files-found: ignore
         retention-days: 7
-
-    - name: Comment test result on PR
-      if: always()
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const status = '${{ job.status }}';
-          const icon = status === 'success' ? '✅' : '❌';
-          const message = status === 'success' 
-            ? 'All E2E tests passed (including agent interaction)!' 
-            : 'Some E2E tests failed. Check the workflow logs for details.';
-          
-          github.rest.issues.createComment({
-            issue_number: ${{ github.event.pull_request.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `${icon} **E2E Tests ${status}**\n\n${message}\n\n[View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`
-          })
         
     - name: Debug logs on failure
       if: failure()


### PR DESCRIPTION
## Problem

E2E tests fail on fork PRs because they don't have access to GitHub secrets (ANTHROPIC_API_KEY).

## Solution

Changed E2E workflow to ONLY run when `safe-to-test` label is added to a PR.

**Security model:**
- Uses `pull_request_target` for secret access
- Requires explicit maintainer approval via label
- Runs full test suite with ANTHROPIC_API_KEY

## Usage

```bash
# Maintainer reviews PR code
# Then adds label to trigger tests
gh pr edit <PR_NUMBER> --add-label safe-to-test
```

## Benefits

- 🔒 **Secure**: Maintainer review required before running with secrets
- 🎯 **Simple**: One workflow, one trigger
- 💯 **Complete**: Full agent interaction testing
- ✅ **Clean**: Results show in Actions UI, no PR comment spam