### PR TITLE
fix: allow periods in GitLab token validation

### DIFF
--- a/components/backend/handlers/gitlab_auth.go
+++ b/components/backend/handlers/gitlab_auth.go
@@ -102,12 +102,12 @@ func validateGitLabInput(instanceURL, token string) error {
 	}
 
 	// Validate token contains only valid characters (alphanumeric and some special chars)
-	// GitLab tokens use: a-z, A-Z, 0-9, -, _
+	// GitLab tokens use: a-z, A-Z, 0-9, -, _, .
 	for _, char := range token {
 		if (char < 'a' || char > 'z') &&
 			(char < 'A' || char > 'Z') &&
 			(char < '0' || char > '9') &&
-			char != '-' && char != '_' {
+			char != '-' && char != '_' && char != '.' {
 			return fmt.Errorf("token contains invalid characters")
 		}
 	}

--- a/components/backend/handlers/gitlab_auth_test.go
+++ b/components/backend/handlers/gitlab_auth_test.go
@@ -103,6 +103,7 @@ var _ = Describe("GitLab Auth Handler", Label(test_constants.LabelUnit, test_con
 					"token-with-dashes-456",            // with dashes
 					"UPPERCASE_TOKEN_789012",           // uppercase, 20 chars
 					"MixedCase-Token_1234567",          // mixed case, 20 chars
+					"glpat-abc123xyz.01.def456ghi",     // with periods (GitLab token format)
 				}
 
 				for _, token := range validTokens {
@@ -195,7 +196,6 @@ var _ = Describe("GitLab Auth Handler", Label(test_constants.LabelUnit, test_con
 					"token;with;semicolons",
 					"token:with:colons",
 					"token,with,commas",
-					"token.with.dots",
 					"token?with?questions",
 					"token!with!exclamations",
 				}


### PR DESCRIPTION
## Summary
- Fixed GitLab token validation to allow period (`.`) character
- GitLab Personal Access Tokens can contain periods in newer formats
- User's valid token was being rejected as invalid

## Changes
- Updated `validateGitLabInput()` to accept `.` in addition to `-` and `_`
- Added test case for token with periods: `glpat-abc123xyz.01.def456ghi`
- Removed period-containing token from invalid tokens test list

## Test Plan
- [x] Updated unit tests to cover period validation
- [x] Verified backend builds successfully
- [x] Manually tested token format matches GitLab's current token structure

## Fixes
Resolves user issue: "Invalid input: token contains invalid characters"

🤖 Generated with [Claude Code](https://claude.com/claude-code)