### PR TITLE
feat: add Claude Opus 4.6 model support

### DIFF
--- a/components/frontend/src/components/create-session-dialog.tsx
+++ b/components/frontend/src/components/create-session-dialog.tsx
@@ -36,6 +36,7 @@ import { errorToast } from "@/hooks/use-toast";
 
 const models = [
   { value: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+  { value: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { value: "claude-opus-4-5", label: "Claude Opus 4.5" },
   { value: "claude-opus-4-1", label: "Claude Opus 4.1" },
   { value: "claude-haiku-4-5", label: "Claude Haiku 4.5" },


### PR DESCRIPTION
## Summary
Add support for Claude Opus 4.6, Anthropic's newest and most capable frontier model released on February 5, 2026.

## Key Changes
- **Frontend**: Add Opus 4.6 to model dropdown (2nd position after Sonnet 4.5)
- **Runner**: Map Opus 4.6 to simplified Vertex AI name (no `@date` suffix)
- **Tests**: Comprehensive test coverage for Opus 4.6 mapping

## Important: Naming Convention Change
Opus 4.6 uses **simplified naming** on Vertex AI (`claude-opus-4-6`) without the `@YYYYMMDD` date suffix. This marks a shift in Vertex AI naming conventions.

**Previous models:**
```
"claude-opus-4-5": "claude-opus-4-5@20251101"
```

**Opus 4.6:**
```
"claude-opus-4-6": "claude-opus-4-6"  // No date suffix!
```

All previous models retain their date-suffix mappings for backward compatibility.

## Opus 4.6 Features
- 🧠 1M token context window (beta)
- 🏆 Highest agentic coding scores to date
- 💭 Adaptive thinking capabilities
- 💰 Same pricing as Opus 4.5 ($5/M input, $25/M output)

## Testing
- ✅ All model mapping tests pass (18/20 - 2 pre-existing failures)
- ✅ All integration tests pass (4/4)
- ✅ Frontend builds successfully with 0 errors

## Test Plan
- [x] Model appears in frontend dropdown
- [x] Model maps correctly to Vertex AI (no date suffix)
- [x] All existing models continue to work
- [x] Tests validate both naming conventions
- [ ] Manual e2e test: Create session with Opus 4.6 and verify it works

## References
- [Anthropic Opus 4.6 Announcement](https://www.anthropic.com/news/claude-opus-4-6)
- [Claude on Vertex AI Documentation](https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)