### PR TITLE
chore: update Kind node image from v1.28.0 to v1.35.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ local-up: check-minikube check-kubectl ## Start local development environment (m
 			(minikube status >/dev/null 2>&1 && echo "$(COLOR_GREEN)✓$(COLOR_RESET) Minikube already running") || \
 			(echo "$(COLOR_RED)✗$(COLOR_RESET) Failed to start minikube" && exit 1); \
 	else \
-		minikube start --driver=podman --memory=4096 --cpus=2 --kubernetes-version=v1.28.3 --container-runtime=cri-o $(QUIET_REDIRECT) || \
+		minikube start --driver=podman --memory=4096 --cpus=2 --kubernetes-version=v1.35.0 --container-runtime=cri-o $(QUIET_REDIRECT) || \
 			(minikube status >/dev/null 2>&1 && echo "$(COLOR_GREEN)✓$(COLOR_RESET) Minikube already running") || \
 			(echo "$(COLOR_RED)✗$(COLOR_RESET) Failed to start minikube" && exit 1); \
 	fi

--- a/e2e/scripts/setup-kind.sh
+++ b/e2e/scripts/setup-kind.sh
@@ -63,8 +63,8 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  # Use more stable Kubernetes version for Podman compatibility
-  image: kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
+  # Kind v0.31.0 default node image
+  image: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
   extraPortMappings:
   - containerPort: 30080
     hostPort: ${HTTP_PORT}
@@ -77,7 +77,7 @@ EOF
 echo ""
 echo "✅ Kind cluster ready!"
 echo "   Cluster: ambient-local"
-echo "   Kubernetes: v1.28.0"
+echo "   Kubernetes: v1.35.0"
 echo "   NodePort: 30080 → host port ${HTTP_PORT}"
 echo ""
 echo "📝 Next steps:"


### PR DESCRIPTION
## Summary
- Update Kind node image from `kindest/node:v1.28.0` to `v1.35.0` (Kind v0.31.0 default)
- Update minikube Kubernetes version from `v1.28.3` to `v1.35.0` for consistency
- Update outdated comment about Podman compatibility

## Test Plan
- [ ] `make kind-down` (if existing cluster)
- [ ] `make kind-up` — cluster creates successfully with v1.35.0
- [ ] `kubectl get nodes` shows v1.35.0
- [ ] `make test-e2e-local` — e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)