### PR TITLE
fix(ci): add workflows:write permission to amber-issue-handler

### DIFF
--- a/.github/workflows/amber-issue-handler.yml
+++ b/.github/workflows/amber-issue-handler.yml
@@ -29,7 +29,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write  # Required for OIDC token (Bedrock/Vertex/Foundry/OAuth)
+  id-token: write    # Required for OIDC token (Bedrock/Vertex/Foundry/OAuth)
+  workflows: write   # Required to create/update GitHub Actions workflow files
 
 jobs:
   amber-handler:


### PR DESCRIPTION
## Summary
- Adds `workflows: write` permission to the amber-issue-handler workflow
- Fixes the "Push branch to remote" step failure when Amber creates/modifies files under `.github/workflows/`
- GitHub requires explicit `workflows` permission for any token touching workflow files, even with `contents: write`

## Context

The `amber-handler` job in [run #21777412886](https://github.com/ambient-code/platform/actions/runs/21777412886/job/62836130769) failed because Amber created a `nightly-builds.yml` workflow file for issue #591, but GitHub rejected the push:

```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/nightly-builds.yml` without `workflows` permission
```

## Test Plan
- [ ] Re-run the amber handler on issue #591 (or re-label with `amber:auto-fix`)
- [ ] Amber should be able to push branches containing workflow file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)