### PR TITLE
Revert "fix(ci): add workflows:write permission to amber-issue-handler (#592)"

### DIFF
--- a/.github/workflows/amber-issue-handler.yml
+++ b/.github/workflows/amber-issue-handler.yml
@@ -29,8 +29,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write    # Required for OIDC token (Bedrock/Vertex/Foundry/OAuth)
-  workflows: write   # Required to create/update GitHub Actions workflow files
+  id-token: write  # Required for OIDC token (Bedrock/Vertex/Foundry/OAuth)
 
 jobs:
   amber-handler:


### PR DESCRIPTION
## Summary
- Reverts PR #592 which had failing CI tests
- The `workflows: write` permission fix will be re-applied directly via issue #593

## Context
PR #592 was merged but CI tests failed. Reverting to restore a clean main branch. The fix (adding `workflows: write` to amber-issue-handler) will be re-applied directly from the complete file provided in issue #593.

## Test Plan
- [ ] CI tests pass on this revert PR
- [ ] Re-apply the fix via direct edit per issue #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)