### PR TITLE
fix: public-api build + add kind-local overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: local-logs local-logs-backend local-logs-frontend local-logs-operator local-shell local-shell-frontend
 .PHONY: local-test local-test-dev local-test-quick test-all local-url local-troubleshoot local-port-forward local-stop-port-forward
 .PHONY: push-all registry-login setup-hooks remove-hooks check-minikube check-kind check-kubectl
-.PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift
+.PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift kind-local-up
 .PHONY: setup-minio minio-console minio-logs minio-status
 .PHONY: validate-makefile lint-makefile check-shell makefile-health
 .PHONY: _create-operator-config _auto-port-forward _show-access-info _build-and-load
@@ -172,7 +172,7 @@ registry-login: ## Login to container registry
 
 push-all: registry-login ## Push all images to registry
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Pushing images to $(REGISTRY)..."
-	@for image in $(FRONTEND_IMAGE) $(BACKEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE); do \
+	@for image in $(FRONTEND_IMAGE) $(BACKEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE) $(PUBLIC_API_IMAGE); do \
 		echo "  Tagging and pushing $$image..."; \
 		$(CONTAINER_ENGINE) tag $$image $(REGISTRY)/$$image && \
 		$(CONTAINER_ENGINE) push $(REGISTRY)/$$image; \
@@ -606,6 +606,47 @@ kind-up: check-kind check-kubectl ## Start kind cluster with Quay.io images (pro
 	@echo "Run tests:"
 	@echo "  make test-e2e"
 
+kind-local-up: check-kind check-kubectl ## Start kind cluster with locally built images
+	@echo "$(COLOR_BOLD)Starting kind cluster with locally built images$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Step 1/6: Creating kind cluster..."
+	@cd e2e && CONTAINER_ENGINE=$(CONTAINER_ENGINE) ./scripts/setup-kind.sh
+	@for i in 1 2 3 4 5 6 7 8 9 10; do \
+		if kubectl cluster-info >/dev/null 2>&1; then \
+			echo "$(COLOR_GREEN)✓$(COLOR_RESET) API server ready"; \
+			break; \
+		fi; \
+		if [ $$i -eq 10 ]; then \
+			echo "$(COLOR_RED)✗$(COLOR_RESET) Timeout waiting for API server"; \
+			exit 1; \
+		fi; \
+		sleep 3; \
+	done
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Step 2/6: Building all images locally..."
+	@$(MAKE) --no-print-directory build-all
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Step 3/6: Loading images into kind cluster..."
+	@cd e2e && CONTAINER_ENGINE=$(CONTAINER_ENGINE) ./scripts/load-images.sh
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Step 4/6: Deploying with local images..."
+	@kubectl apply --validate=false -k components/manifests/overlays/kind-local/
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Step 5/6: Waiting for pods..."
+	@cd e2e && ./scripts/wait-for-ready.sh
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Step 6/6: Initializing MinIO and extracting test token..."
+	@cd e2e && ./scripts/init-minio.sh
+	@cd e2e && CONTAINER_ENGINE=$(CONTAINER_ENGINE) ./scripts/extract-token.sh
+	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Kind cluster ready with local images!"
+	@echo ""
+	@echo "$(COLOR_BOLD)Access the platform:$(COLOR_RESET)"
+	@echo "  Run in another terminal: $(COLOR_BLUE)make kind-port-forward$(COLOR_RESET)"
+	@echo ""
+	@echo "  Then access:"
+	@echo "  Frontend: http://localhost:8080"
+	@echo "  Backend:  http://localhost:8081"
+	@echo ""
+	@echo "  Get test token: kubectl get secret test-user-token -n ambient-code -o jsonpath='{.data.token}' | base64 -d"
+	@echo ""
+	@echo "Run tests:"
+	@echo "  make test-e2e"
+
 kind-down: ## Stop and delete kind cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Cleaning up kind cluster..."
 	@cd e2e && CONTAINER_ENGINE=$(CONTAINER_ENGINE) ./scripts/cleanup.sh
@@ -700,21 +741,26 @@ _build-and-load: ## Internal: Build and load images
 	@$(CONTAINER_ENGINE) build $(PLATFORM_FLAG) -t $(OPERATOR_IMAGE) components/operator $(QUIET_REDIRECT)
 	@echo "  Building runner ($(PLATFORM))..."
 	@$(CONTAINER_ENGINE) build $(PLATFORM_FLAG) -t $(RUNNER_IMAGE) -f components/runners/claude-code-runner/Dockerfile components/runners $(QUIET_REDIRECT)
+	@echo "  Building public-api ($(PLATFORM))..."
+	@$(CONTAINER_ENGINE) build $(PLATFORM_FLAG) -t $(PUBLIC_API_IMAGE) components/public-api $(QUIET_REDIRECT)
 	@echo "  Tagging images with localhost prefix..."
 	@$(CONTAINER_ENGINE) tag $(BACKEND_IMAGE) localhost/$(BACKEND_IMAGE) 2>/dev/null || true
 	@$(CONTAINER_ENGINE) tag $(FRONTEND_IMAGE) localhost/$(FRONTEND_IMAGE) 2>/dev/null || true
 	@$(CONTAINER_ENGINE) tag $(OPERATOR_IMAGE) localhost/$(OPERATOR_IMAGE) 2>/dev/null || true
 	@$(CONTAINER_ENGINE) tag $(RUNNER_IMAGE) localhost/$(RUNNER_IMAGE) 2>/dev/null || true
+	@$(CONTAINER_ENGINE) tag $(PUBLIC_API_IMAGE) localhost/$(PUBLIC_API_IMAGE) 2>/dev/null || true
 	@echo "  Loading images into minikube..."
 	@mkdir -p /tmp/minikube-images
 	@$(CONTAINER_ENGINE) save -o /tmp/minikube-images/backend.tar localhost/$(BACKEND_IMAGE)
 	@$(CONTAINER_ENGINE) save -o /tmp/minikube-images/frontend.tar localhost/$(FRONTEND_IMAGE)
 	@$(CONTAINER_ENGINE) save -o /tmp/minikube-images/operator.tar localhost/$(OPERATOR_IMAGE)
 	@$(CONTAINER_ENGINE) save -o /tmp/minikube-images/runner.tar localhost/$(RUNNER_IMAGE)
+	@$(CONTAINER_ENGINE) save -o /tmp/minikube-images/public-api.tar localhost/$(PUBLIC_API_IMAGE)
 	@minikube image load /tmp/minikube-images/backend.tar $(QUIET_REDIRECT)
 	@minikube image load /tmp/minikube-images/frontend.tar $(QUIET_REDIRECT)
 	@minikube image load /tmp/minikube-images/operator.tar $(QUIET_REDIRECT)
 	@minikube image load /tmp/minikube-images/runner.tar $(QUIET_REDIRECT)
+	@minikube image load /tmp/minikube-images/public-api.tar $(QUIET_REDIRECT)
 	@rm -rf /tmp/minikube-images
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Images built and loaded"
 

--- a/components/manifests/overlays/kind-local/backend-env-patch.yaml
+++ b/components/manifests/overlays/kind-local/backend-env-patch.yaml
@@ -1,0 +1,15 @@
+# Patch backend to use IfNotPresent for dynamically created resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-api
+spec:
+  template:
+    spec:
+      containers:
+      - name: backend-api
+        env:
+        - name: IMAGE_PULL_POLICY
+          value: "IfNotPresent"
+        - name: CONTENT_SERVICE_IMAGE
+          value: "docker.io/library/vteam_backend:latest"

--- a/components/manifests/overlays/kind-local/image-pull-policy-patch.yaml
+++ b/components/manifests/overlays/kind-local/image-pull-policy-patch.yaml
@@ -1,0 +1,5 @@
+# Patch to set imagePullPolicy: IfNotPresent for kind-local cluster
+# Uses locally built and loaded images, not pulled from a registry
+- op: replace
+  path: /spec/template/spec/containers/0/imagePullPolicy
+  value: IfNotPresent

--- a/components/manifests/overlays/kind-local/kustomization.yaml
+++ b/components/manifests/overlays/kind-local/kustomization.yaml
@@ -1,0 +1,62 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Build on top of the kind overlay (inherits base, secrets, test-user, etc.)
+resources:
+- ../kind
+
+# Override patches for kind-local environment
+patches:
+# Use locally built runner/state-sync images with IfNotPresent
+- path: operator-env-patch.yaml
+  target:
+    kind: Deployment
+    name: agentic-operator
+# Override backend env vars to use local images and IfNotPresent
+- path: backend-env-patch.yaml
+  target:
+    kind: Deployment
+    name: backend-api
+
+# JSON patches to override imagePullPolicy to IfNotPresent
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: backend-api
+  path: image-pull-policy-patch.yaml
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: frontend
+  path: image-pull-policy-patch.yaml
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: agentic-operator
+  path: image-pull-policy-patch.yaml
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: public-api
+  path: image-pull-policy-patch.yaml
+
+# Kind-local overlay: Use locally built images loaded via `kind load`
+# Images are imported with docker.io/library/ prefix by ctr
+images:
+- name: quay.io/ambient_code/vteam_backend
+  newName: docker.io/library/vteam_backend
+  newTag: latest
+- name: quay.io/ambient_code/vteam_frontend
+  newName: docker.io/library/vteam_frontend
+  newTag: latest
+- name: quay.io/ambient_code/vteam_operator
+  newName: docker.io/library/vteam_operator
+  newTag: latest
+- name: quay.io/ambient_code/vteam_public_api
+  newName: docker.io/library/vteam_public_api
+  newTag: latest

--- a/components/manifests/overlays/kind-local/operator-env-patch.yaml
+++ b/components/manifests/overlays/kind-local/operator-env-patch.yaml
@@ -1,0 +1,19 @@
+# Patch operator to use locally built runner/state-sync images
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentic-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: agentic-operator
+        env:
+        - name: AMBIENT_CODE_RUNNER_IMAGE
+          value: "docker.io/library/vteam_claude_runner:latest"
+        - name: STATE_SYNC_IMAGE
+          value: "docker.io/library/vteam_state_sync:latest"
+        - name: IMAGE_PULL_POLICY
+          value: "IfNotPresent"
+        - name: POD_FSGROUP
+          value: "0"

--- a/components/public-api/Dockerfile
+++ b/components/public-api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Fix public-api Dockerfile Go version mismatch (`golang:1.23-alpine` → `golang:1.24-alpine`) that prevented CI from building `vteam_public_api` since it was merged in `dee5f79`
- Add `kind-local` kustomize overlay and `make kind-local-up` target for fully local development without pulling images from Quay
- Add `vteam_public_api` to `push-all`, `load-images.sh`, and minikube `_build-and-load`
- Fix pre-existing OCI archive path bug in `load-images.sh` (`:` in image tag created nested directory path)

Split from #587 — the Kind node image update was merged separately as #590.

## Test plan

- [ ] `cd components/public-api && podman build -t vteam_public_api:latest .` — builds successfully with Go 1.24
- [ ] `make kind-local-up` — creates kind cluster, builds all images locally, loads them, deploys, all pods running
- [ ] `kubectl kustomize components/manifests/overlays/kind-local/` — renders correctly with local image names and `IfNotPresent`
- [ ] CI: trigger with `components: public-api` or `force_build_all: true` to push image to Quay

🤖 Generated with [Claude Code](https://claude.com/claude-code)