### PR TITLE
fix: public-api Dockerfile Go version + add to push-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ registry-login: ## Login to container registry
 
 push-all: registry-login ## Push all images to registry
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Pushing images to $(REGISTRY)..."
-	@for image in $(FRONTEND_IMAGE) $(BACKEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE); do \
+	@for image in $(FRONTEND_IMAGE) $(BACKEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE) $(PUBLIC_API_IMAGE); do \
 		echo "  Tagging and pushing $$image..."; \
 		$(CONTAINER_ENGINE) tag $$image $(REGISTRY)/$$image && \
 		$(CONTAINER_ENGINE) push $(REGISTRY)/$$image; \

--- a/components/public-api/Dockerfile
+++ b/components/public-api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Fix public-api Dockerfile Go version mismatch (`golang:1.23-alpine` → `golang:1.24-alpine`) that prevented CI from building `vteam_public_api` since dee5f79
- Add `vteam_public_api` to `push-all` target so it gets pushed to registry

## Test plan

- [ ] `cd components/public-api && podman build -t vteam_public_api:latest .` — builds successfully with Go 1.24
- [ ] CI: trigger with `components: public-api` or `force_build_all: true` to push image to Quay

🤖 Generated with [Claude Code](https://claude.com/claude-code)