### PR TITLE
fix: GitHub integration not showing as connected after App install

### DIFF
--- a/components/backend/handlers/integrations_status.go
+++ b/components/backend/handlers/integrations_status.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -44,6 +45,7 @@ func GetIntegrationsStatus(c *gin.Context) {
 // Helper functions to get individual integration statuses
 
 func getGitHubStatusForUser(ctx context.Context, userID string) gin.H {
+	log.Printf("getGitHubStatusForUser: querying status for user=%s", userID)
 	status := gin.H{
 		"installed": false,
 		"pat":       gin.H{"configured": false},
@@ -52,11 +54,14 @@ func getGitHubStatusForUser(ctx context.Context, userID string) gin.H {
 	// Check GitHub App
 	inst, err := GetGitHubInstallation(ctx, userID)
 	if err == nil && inst != nil {
+		log.Printf("getGitHubStatusForUser: found installation for user=%s installationId=%d githubUser=%s", userID, inst.InstallationID, inst.GitHubUserID)
 		status["installed"] = true
 		status["installationId"] = inst.InstallationID
 		status["host"] = inst.Host
 		status["githubUserId"] = inst.GitHubUserID
 		status["updatedAt"] = inst.UpdatedAt.Format("2006-01-02T15:04:05Z07:00")
+	} else {
+		log.Printf("getGitHubStatusForUser: no installation found for user=%s", userID)
 	}
 
 	// Check GitHub PAT

--- a/components/frontend/src/app/integrations/github/setup/page.tsx
+++ b/components/frontend/src/app/integrations/github/setup/page.tsx
@@ -13,26 +13,31 @@ export default function GitHubSetupPage() {
   useEffect(() => {
     const url = new URL(window.location.href)
     const installationId = url.searchParams.get('installation_id')
+    const code = url.searchParams.get('code')
 
     if (!installationId) {
       setMessage('No installation was detected.')
       return
     }
 
-    connectMutation.mutate(
-      { installationId: Number(installationId) },
-      {
-        onSuccess: () => {
-          setMessage('GitHub connected. Redirecting...')
-          setTimeout(() => {
-            window.location.replace('/integrations')
-          }, 800)
-        },
-        onError: (err) => {
-          setError(err instanceof Error ? err.message : 'Failed to complete setup')
-        },
-      }
-    )
+    const request: { installationId: number; code?: string } = {
+      installationId: Number(installationId),
+    }
+    if (code) {
+      request.code = code
+    }
+
+    connectMutation.mutate(request, {
+      onSuccess: () => {
+        setMessage('GitHub connected. Redirecting...')
+        setTimeout(() => {
+          window.location.replace('/integrations')
+        }, 800)
+      },
+      onError: (err) => {
+        setError(err instanceof Error ? err.message : 'Failed to complete setup')
+      },
+    })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/components/frontend/src/components/github-connection-card.tsx
+++ b/components/frontend/src/components/github-connection-card.tsx
@@ -41,9 +41,10 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
 
   const handleConnect = () => {
     if (!appSlug) return
-    const setupUrl = new URL('/integrations/github/setup', window.location.origin)
-    const redirectUri = encodeURIComponent(setupUrl.toString())
-    const url = `https://github.com/apps/${appSlug}/installations/new?redirect_uri=${redirectUri}`
+    // Let GitHub use the Callback URL configured in the App settings
+    // rather than overriding with redirect_uri (which GitHub ignores
+    // unless it matches a configured callback URL)
+    const url = `https://github.com/apps/${appSlug}/installations/new`
     window.location.href = url
   }
 

--- a/components/frontend/src/services/api/github.ts
+++ b/components/frontend/src/services/api/github.ts
@@ -34,7 +34,7 @@ export async function connectGitHub(data: GitHubConnectRequest): Promise<string>
     '/auth/github/install',
     data
   );
-  return response.username;
+  return response.message;
 }
 
 /**

--- a/components/frontend/src/services/queries/use-github.ts
+++ b/components/frontend/src/services/queries/use-github.ts
@@ -76,8 +76,9 @@ export function useConnectGitHub() {
   return useMutation({
     mutationFn: (data: GitHubConnectRequest) => githubApi.connectGitHub(data),
     onSuccess: () => {
-      // Invalidate status to show connected state
+      // Invalidate both GitHub-specific and unified integrations status
       queryClient.invalidateQueries({ queryKey: githubKeys.status() });
+      queryClient.invalidateQueries({ queryKey: ['integrations', 'status'] });
     },
   });
 }
@@ -91,8 +92,9 @@ export function useDisconnectGitHub() {
   return useMutation({
     mutationFn: githubApi.disconnectGitHub,
     onSuccess: () => {
-      // Invalidate status to show disconnected state
+      // Invalidate both GitHub-specific and unified integrations status
       queryClient.invalidateQueries({ queryKey: githubKeys.status() });
+      queryClient.invalidateQueries({ queryKey: ['integrations', 'status'] });
       // Clear forks cache
       queryClient.invalidateQueries({ queryKey: githubKeys.forks() });
     },
@@ -163,6 +165,7 @@ export function useSaveGitHubPAT() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...githubKeys.all, 'pat', 'status'] });
       queryClient.invalidateQueries({ queryKey: githubKeys.status() });
+      queryClient.invalidateQueries({ queryKey: ['integrations', 'status'] });
     },
   });
 }
@@ -178,6 +181,7 @@ export function useDeleteGitHubPAT() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...githubKeys.all, 'pat', 'status'] });
       queryClient.invalidateQueries({ queryKey: githubKeys.status() });
+      queryClient.invalidateQueries({ queryKey: ['integrations', 'status'] });
     },
   });
 }

--- a/components/frontend/src/types/api/github.ts
+++ b/components/frontend/src/types/api/github.ts
@@ -85,14 +85,12 @@ export type CreatePRResponse = {
 
 export type GitHubConnectRequest = {
   installationId: number;
-  // Legacy OAuth fields (deprecated)
   code?: string;
-  state?: string;
 };
 
 export type GitHubConnectResponse = {
   message: string;
-  username: string;
+  installationId: number;
 };
 
 export type GitHubDisconnectResponse = {


### PR DESCRIPTION
Fix multiple issues preventing GitHub App installations from being reflected as "Connected" in the integrations UI:

- Forward OAuth `code` param from GitHub callback to backend for verified ownership via token exchange (reuses existing helpers)
- Fix `connectGitHub()` return value: backend returns `message`, not `username`
- Fix `GitHubConnectResponse` type to match actual backend response
- Fix cache invalidation: mutations now also invalidate `['integrations', 'status']` (used by the Integrations page), not just `['github', 'status']`
- Remove `redirect_uri` override from connect URL so GitHub uses the configured Callback URL in App settings
- Add debug logging to installation lookup and status queries

fix #602 