### PR TITLE
Fix MinIO health probe timeouts causing CrashLoopBackOff

### DIFF
--- a/components/manifests/base/minio-deployment.yaml
+++ b/components/manifests/base/minio-deployment.yaml
@@ -60,14 +60,18 @@ spec:
           httpGet:
             path: /minio/health/live
             port: 9000
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /minio/health/ready
             port: 9000
           initialDelaySeconds: 10
-          periodSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m


### PR DESCRIPTION
## Summary

- **Increases health probe timeouts from 1s (default) to 5s** — the implicit 1s timeout was too aggressive for MinIO on EBS-backed storage, causing repeated liveness failures → SIGKILL (exit 137) → CrashLoopBackOff
- **Increases liveness `initialDelaySeconds` from 30s to 60s** — allows time for EBS attach + MinIO metadata scan before probing begins
- **Makes `failureThreshold: 3` explicit** on both probes for clarity

### Probe Changes

| Probe | Setting | Before | After |
|-------|---------|--------|-------|
| Liveness | `initialDelaySeconds` | 30 | **60** |
| Liveness | `timeoutSeconds` | 1 (implicit) | **5** |
| Liveness | `periodSeconds` | 10 | **15** |
| Readiness | `timeoutSeconds` | 1 (implicit) | **5** |
| Readiness | `periodSeconds` | 5 | **10** |
| Both | `failureThreshold` | 3 (implicit) | **3** (explicit) |

### Root Cause

MinIO starts and binds ports successfully, but during startup I/O on the 50Gi EBS volume (metadata index scan of `/data`), the `/minio/health/live` endpoint can't respond within 1 second. After 3 consecutive failures, the kubelet kills the container (exit code 137). This produced 17+ restarts and CrashLoopBackOff on `vteam-uat`.

## Test plan

- [ ] `kustomize build components/manifests/overlays/production` renders correctly
- [ ] Apply to `vteam-uat` and confirm MinIO pod reaches `1/1 Ready` with zero restarts
- [ ] Verify probes pass: `oc describe pod -l app=minio -n ambient-code | grep -A5 Liveness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)