### PR TITLE
fix: increase minio resources and relax health probes

### DIFF
--- a/components/manifests/base/minio-deployment.yaml
+++ b/components/manifests/base/minio-deployment.yaml
@@ -60,21 +60,25 @@ spec:
           httpGet:
             path: /minio/health/live
             port: 9000
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /minio/health/ready
             port: 9000
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         resources:
           requests:
-            cpu: 250m
-            memory: 512Mi
+            cpu: 2000m
+            memory: 4Gi
           limits:
-            cpu: 1000m
-            memory: 2Gi
+            cpu: 4000m
+            memory: 8Gi
       volumes:
       - name: data
         persistentVolumeClaim:


### PR DESCRIPTION
## Summary

- Increase minio CPU/memory requests (250m/512Mi → 2000m/4Gi) and limits (1000m/2Gi → 4000m/8Gi)
- Relax liveness and readiness probes with higher `initialDelaySeconds`, `failureThreshold: 5`, and `timeoutSeconds: 5` to tolerate slow minio startups

## Test plan

- [ ] Deploy to a cluster and verify minio pod starts without probe-triggered restarts
- [ ] Confirm minio service becomes ready and accepts connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)