### PR TITLE
fix: state-sync arm64 compatibility across CI and local dev

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,6 +158,17 @@ jobs:
           docker tag quay.io/ambient_code/vteam_claude_runner:latest quay.io/ambient_code/vteam_claude_runner:e2e-test
         fi
 
+        # Build state-sync image (if changed or use latest)
+        if [ "${{ needs.detect-changes.outputs.claude-runner }}" == "true" ]; then
+          echo "Building state-sync (changed)..."
+          docker build -t quay.io/ambient_code/vteam_state_sync:e2e-test \
+            components/runners/state-sync
+        else
+          echo "State-sync unchanged, pulling latest..."
+          docker pull quay.io/ambient_code/vteam_state_sync:latest
+          docker tag quay.io/ambient_code/vteam_state_sync:latest quay.io/ambient_code/vteam_state_sync:e2e-test
+        fi
+
         echo ""
         echo "✅ All images ready"
         docker images | grep e2e-test
@@ -184,6 +195,7 @@ jobs:
         kind load docker-image quay.io/ambient_code/vteam_backend:e2e-test --name ambient-local
         kind load docker-image quay.io/ambient_code/vteam_operator:e2e-test --name ambient-local
         kind load docker-image quay.io/ambient_code/vteam_claude_runner:e2e-test --name ambient-local
+        kind load docker-image quay.io/ambient_code/vteam_state_sync:e2e-test --name ambient-local
         echo "✅ All images loaded into kind cluster"
 
     - name: Update kustomization to use e2e-test images

--- a/components/manifests/overlays/kind/operator-env-patch.yaml
+++ b/components/manifests/overlays/kind/operator-env-patch.yaml
@@ -14,9 +14,9 @@ spec:
         # - operator: fsGroup:0 for volume permissions
         # - runner: minimal MCP config (webfetch only, faster startup)
         - name: AMBIENT_CODE_RUNNER_IMAGE
-          value: "quay.io/gkrumbach07/vteam_claude_runner:latest"
+          value: "quay.io/ambient_code/vteam_claude_runner:latest"
         - name: STATE_SYNC_IMAGE
-          value: "quay.io/gkrumbach07/vteam_state_sync:latest"
+          value: "quay.io/ambient_code/vteam_state_sync:latest"
         - name: IMAGE_PULL_POLICY
           value: "Always"
         - name: POD_FSGROUP

--- a/docs/developer/local-development/README.md
+++ b/docs/developer/local-development/README.md
@@ -1,248 +1,65 @@
 # Local Development Environments
 
-The Ambient Code Platform supports four local development approaches. **Kind is recommended** for most development and testing.
+**Bottom line:** Use Kind. Run `make kind-up` and access at `http://localhost:8080`. Everything else on this page is for edge cases.
 
-## Choose Your Approach
+## Approaches
 
-### 🐳 Kind (Kubernetes in Docker) - **RECOMMENDED**
+| Approach | When to Use | Startup | Guide |
+|----------|-------------|---------|-------|
+| **Kind** | All development and testing (default) | ~30 sec | [kind.md](kind.md) |
+| Hybrid | Rapid single-component iteration with IDE debugging | ~30 sec + manual | [hybrid.md](hybrid.md) |
+| CRC | OpenShift-specific features (Routes, OAuth, BuildConfigs) | ~5-10 min | [crc.md](crc.md) |
+| Minikube | Legacy fallback (deprecated) | ~2-3 min | [minikube.md](minikube.md) |
 
-**Best for:** All development, E2E testing, CI/CD
+### Kind (Recommended)
 
-**Why Kind?**
-- ⚡ **Fastest startup** (~30 seconds)
-- 🎯 **Same as CI** - Tests run in Kind, develop in Kind
-- 💨 **Lightweight** - Lower memory usage
-- 🔄 **Quick iteration** - Fast to create/destroy clusters
-- ✅ **Battle-tested** - Used by Kubernetes project itself
-
-**Pros:**
-- ⚡ Fast startup (~30 seconds)
-- 🎯 Matches CI/CD environment exactly
-- 💨 Lightweight and quick to reset
-- 🔄 Multiple clusters easy
-- ✅ Official Kubernetes project
-
-**Cons:**
-- 📚 Requires basic Docker knowledge
-- 🐳 Docker must be installed
-
-**Quick Start:**
-```bash
-make kind-up
-# Access at http://localhost:8080
-```
-
-**Full Guide:** [kind.md](kind.md)
-
----
-
-### 🚀 Minikube (Older Alternative)
-
-**Status:** ⚠️ Still supported but Kind is recommended for new development
-
-**Best for:** Beginners uncomfortable with Docker, Windows users
-
-**Best for:** First-time setup, general development, stable environment
-
-**Pros:**
-- ✅ Mature and well-documented
-- ✅ Works on all platforms (macOS, Linux, Windows)
-- ✅ Simpler troubleshooting
-- ✅ Stable driver support
-
-**Cons:**
-- ⏱️ Slower startup (~2-3 minutes)
-- 💾 Higher memory usage
-
-**Quick Start:**
-```bash
-make local-up
-# Access at http://$(minikube ip):30030
-```
-
-**Full Guide:** [minikube.md](minikube.md)
-
----
-
-### 🐳 Kind (Kubernetes in Docker)
-
-**Best for:** E2E testing, CI/CD, experienced Kubernetes developers
-
-**Pros:**
-- ⚡ Fast startup (~30 seconds)
-- 🎯 Same environment as CI/CD
-- 💨 Lightweight and quick to reset
-- 🔄 Multiple clusters easy
-
-**Cons:**
-- 📚 Steeper learning curve
-- 🐛 Less forgiving of configuration mistakes
-- 🐳 Requires Docker knowledge
-
-**Quick Start:**
-```bash
-make kind-up
-make test-e2e
-make kind-down
-```
-
-**Full Guide:** [kind.md](kind.md)
-
----
-
-### 🔴 OpenShift Local (CRC) (Specialized Use)
-
-**Status:** ⚠️ Use only when you need OpenShift-specific features
-
-**Best for:** Testing OpenShift Routes, BuildConfigs, OAuth integration
-
-**Pros:**
-- ✅ Full OpenShift features (Routes, BuildConfigs, OAuth)
-- ✅ Production-like environment
-- ✅ OpenShift console access
-- ✅ Hot-reloading development mode
-
-**Cons:**
-- ⏱️ Slower startup (~5-10 minutes first time)
-- 💾 Higher resource requirements
-- 🖥️ macOS and Linux only
-
-**Quick Start:**
-```bash
-make dev-start
-# Access at https://vteam-frontend-vteam-dev.apps-crc.testing
-```
-
-**Full Guide:** [crc.md](crc.md)
-
----
-
-### ⚡ Hybrid Local Development
-
-**Best for:** Rapid iteration on specific components
-
-**What it is:** Run components (frontend, backend, operator) locally on your machine while using Kind for dependencies (CRDs, MinIO).
-
-**Pros:**
-- 🚀 Instant code reloads (no container rebuilds)
-- 🐛 Direct debugging with IDE breakpoints
-- ⚡ Fastest iteration cycle (seconds)
-
-**Cons:**
-- 🔧 More manual setup
-- 🧩 Need to manage multiple terminals
-- 💻 Not suitable for integration testing
-
-**Quick Start:**
-```bash
-make kind-up
-# Then run components locally (see guide)
-```
-
-**Full Guide:** [hybrid.md](hybrid.md)
-
----
-
-## Quick Comparison
-
-| Feature | **Kind (Recommended)** | Minikube | CRC | Hybrid |
-|---------|------------------------|----------|-----|--------|
-| **Status** | ✅ **Recommended** | ⚠️ Older | ⚠️ Specialized | Advanced |
-| **Startup Time** | ⚡ ~30 sec | ~2-3 min | ~5-10 min | ~30 sec + manual |
-| **Memory Usage** | Lower | Higher | Highest | Lowest |
-| **CI/CD Match** | ✅ **Yes (exact!)** | No | No | No |
-| **Learning Curve** | Moderate | Easier | Moderate | Advanced |
-| **Code Iteration** | Moderate | Slow (rebuild) | Fast (hot-reload) | ⚡ Instant |
-| **Debugging** | Logs only | Logs only | Logs only | ✅ IDE debugging |
-| **OpenShift Features** | No | No | ✅ Yes | No |
-| **Production-Like** | Good | Basic | ✅ Best | No |
-| **Integration Testing** | ✅ **Best** | Yes | Yes | Limited |
-| **E2E Testing** | ✅ **Required** | Yes | Yes | No |
-| **Platform Support** | Linux/macOS | All | macOS/Linux | All |
-| **Our CI Uses** | ✅ **Kind** | No | No | No |
-
-## Which Should I Use?
-
-### ⭐ Choose **Kind** (Recommended for 95% of use cases)
-- 👋 You're new to the project → **Start with Kind**
-- 🧪 You're writing or running E2E tests → **Use Kind**
-- 🔄 You're working on any development → **Use Kind**
-- ⚡ You value fast iteration → **Use Kind**
-- 🎯 You want to match CI/CD environment → **Use Kind**
-
-**TL;DR:** Just use Kind. It's faster, lighter, and matches our CI environment.
-
----
-
-### Choose **Minikube** only if:
-- 💻 You're on Windows (Kind doesn't work well on Windows)
-- 🆘 Kind doesn't work on your machine for some reason
-- 📚 You already have Minikube experience
-
-**Note:** Minikube is the older approach. We recommend migrating to Kind.
-
----
-
-### Choose **CRC** only if:
-- 🔴 You **specifically** need OpenShift Routes (not Ingress)
-- 🏗️ You're testing OpenShift BuildConfigs
-- 🔐 You're developing OpenShift OAuth integration
-- 🎛️ You need the OpenShift console
-
-**Note:** CRC is for OpenShift-specific features only. If you don't need OpenShift features, use Kind.
-
----
-
-### Choose **Hybrid** if:
-- 🚀 You're rapidly iterating on ONE component
-- 🐛 You need to debug with IDE breakpoints
-- ⚡ Container rebuild time is slowing you down
-- 💪 You're very comfortable with Kubernetes
-
-## Getting Started
-
-### 👉 First Time Here? Use Kind!
-
-**Our recommendation for everyone:**
+Matches CI exactly. Fastest startup. Lowest resource usage.
 
 ```bash
-# 1. Install Docker (if not already installed)
-# 2. Start Kind cluster
-make kind-up
-
-# 3. Verify
-make test-e2e
-
-# Access at http://localhost:8080
+make kind-up           # Deploy with Quay.io images
+make kind-port-forward # In another terminal
+make test-e2e          # Run tests
+make kind-down         # Cleanup
 ```
 
-**Full guide:** [kind.md](kind.md)
+### Hybrid
 
-### Working on E2E Tests?
-Use **Kind** - it's what CI uses:
-```bash
-make kind-up
-make test-e2e
-```
+Run one component locally (with IDE breakpoints) while Kind provides the cluster.
 
-### Need OpenShift-Specific Features?
-Use **CRC** only if you need Routes, BuildConfigs, etc:
-```bash
-make dev-start  # CRC-based
-```
-
-### Need to Debug with Breakpoints?
-Use **Hybrid** to run components locally:
 ```bash
 make kind-up
 cd components/backend && go run .
 ```
 
-## Additional Resources
+See [hybrid.md](hybrid.md).
 
-- [Kind Quick Start](../../../QUICK_START.md) - 2-minute setup
-- [Minikube Setup](minikube.md) - Older approach (deprecated)
-- [Kind Development Guide](kind.md) - Using Kind for development and testing
-- [CRC Development Guide](crc.md) - OpenShift Local development
-- [Hybrid Development Guide](hybrid.md) - Running components locally
-- [E2E Testing](../../testing/e2e-guide.md) - End-to-end test suite
+### CRC (OpenShift Local)
+
+Only needed for OpenShift Routes, BuildConfigs, or OAuth integration testing.
+
+```bash
+make dev-start
+# Access at https://vteam-frontend-vteam-dev.apps-crc.testing
+```
+
+See [crc.md](crc.md).
+
+### Minikube (Deprecated)
+
+Still supported but Kind is recommended. See [minikube.md](minikube.md) for migration instructions.
+
+## Comparison
+
+| Feature | Kind | Hybrid | CRC | Minikube |
+|---------|------|--------|-----|----------|
+| Matches CI | Yes | No | No | No |
+| Code iteration | Moderate | Instant | Fast (hot-reload) | Slow |
+| IDE debugging | No | Yes | No | No |
+| OpenShift features | No | No | Yes | No |
+| Memory usage | Low | Lowest | High | Medium |
+| Platform | Linux/macOS | All | macOS/Linux | All |
+
+## See Also
+
+- [Kind Development Guide](kind.md) - Full reference
+- [E2E Testing](../../testing/e2e-guide.md) - Test suite documentation


### PR DESCRIPTION
**Jira:** [RHOAIENG-51898](https://issues.redhat.com/browse/RHOAIENG-51898)

## Summary

`make kind-up` on Apple Silicon crashed because the kind overlay pointed to amd64-only images. Fixed by switching to multi-arch images and adding a pre-flight architecture check.

- **Primary fix**: Kind overlay (`overlays/kind/operator-env-patch.yaml`) pointed to `quay.io/gkrumbach07/` (amd64-only) instead of `quay.io/ambient_code/` (multi-arch). The state-sync init container's rclone binary (Go) hit a known Go runtime bug (`lfstack.push invalid packing`) under QEMU emulation on arm64.
- **E2E gap**: State-sync was missing from the E2E workflow — not built, not loaded into kind.
- **Makefile gap**: `_build-and-load` target (minikube path) omitted state-sync.
- **Prevention**: New `check-image-arch` Make target runs as a `kind-up` prerequisite. On arm64 hosts, fails fast if the overlay references images outside `quay.io/ambient_code/`.
- **Docs**: Streamlined local dev README (249 → 65 lines), added bottom-line summaries to README and kind guide, added arm64 troubleshooting entry.

## Validation

Tested on Apple Silicon (arm64) Mac with existing kind cluster:
1. Patched running operator to use `quay.io/ambient_code/vteam_state_sync:latest`
2. Created AgenticSession in `test` namespace
3. `init-hydrate` completed with exit code 0 — rclone connected to S3, repo cloned successfully
4. Verified `make check-image-arch` passes with fixed overlay and fails with old `gkrumbach07` registry

## Test plan

- [ ] `make kind-up` on Apple Silicon Mac — all pods start, state-sync pulls from `quay.io/ambient_code/`
- [ ] Create AgenticSession — `init-hydrate` completes without crash
- [ ] `make check-image-arch` passes on arm64
- [ ] Simulate bad registry in overlay — `make check-image-arch` blocks with clear error
- [ ] E2E CI picks up state-sync image (visible in workflow logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)