### PR TITLE
fix: surface pod scheduling failures in session status conditions

### DIFF
--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -1755,6 +1755,8 @@ func monitorPod(podName, sessionName, sessionNamespace string) {
 
 		if pod.Spec.NodeName != "" {
 			statusPatch.AddCondition(conditionUpdate{Type: conditionPodScheduled, Status: "True", Reason: "Scheduled", Message: fmt.Sprintf("Scheduled on %s", pod.Spec.NodeName)})
+		} else {
+			surfacePodSchedulingFailure(pod, statusPatch)
 		}
 
 		if pod.Status.Phase == corev1.PodSucceeded {


### PR DESCRIPTION
## Summary

- When a pod can't be scheduled (insufficient memory/CPU, node affinity, etc.), the session stays in "Creating" indefinitely with no explanation to the user
- Adds a `surfacePodSchedulingFailure` helper that reads `pod.Status.Conditions` for `PodScheduled=False` and surfaces the scheduler's message (e.g., "0/1 nodes are available: 1 Insufficient memory") as a `PodScheduled` condition on the AgenticSession CR
- Called from both `UpdateSessionFromPodStatus` (controller-runtime path) and `monitorPod` (legacy watch path)
- Phase remains "Creating" (correct — the pod exists, just can't schedule), but users now see *why*

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass (verified locally)
- [ ] Deploy to a cluster with constrained resources, create a session that can't schedule, verify `kubectl get agenticsession <name> -o jsonpath='{.status.conditions}'` shows `PodScheduled: False` with the scheduler message
- [ ] Verify normal sessions still get `PodScheduled: True` with the node name once scheduled
- [ ] Verify no behavior change when pod schedules successfully (existing `NodeName` check takes precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)