### PR TITLE
fix: use full UBI9 nodejs image for frontend build stage

### DIFF
--- a/components/frontend/Dockerfile
+++ b/components/frontend/Dockerfile
@@ -10,7 +10,9 @@ COPY package.json package-lock.json* ./
 RUN npm ci
 
 # Rebuild the source code only when needed
-FROM registry.access.redhat.com/ubi9/nodejs-20-minimal AS builder
+# Use the full nodejs-20 image (not minimal) for the build stage because
+# Next.js 16 Turbopack requires native SWC binaries that depend on glibc.
+FROM registry.access.redhat.com/ubi9/nodejs-20 AS builder
 
 USER 0
 


### PR DESCRIPTION
## Summary

- Switch the frontend Dockerfile build stage from `ubi9/nodejs-20-minimal` to the full `ubi9/nodejs-20` image

## Problem

Next.js 16 Turbopack requires native SWC binaries that depend on glibc. The `ubi9/nodejs-20-minimal` image lacks glibc, which causes arm64 build failures when Turbopack attempts to load its native bindings during the build stage.

## Fix

Use the full `ubi9/nodejs-20` image for the frontend build stage, which includes glibc and all required system libraries for SWC/Turbopack native binaries to load correctly on both amd64 and arm64 architectures.