### PR TITLE
feat: add pre-commit framework with all linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,83 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  # ── General file hygiene ──────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ['--allow-multiple-documents']
+        exclude: ^mkdocs\.yml$
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  # ── Python (ruff) ────────────────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+      - id: ruff-format
+        files: ^(components/runners/|scripts/)
+        types_or: [python]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+        files: ^(components/runners/|scripts/)
+        types_or: [python]
+
+  # ── Go ───────────────────────────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: gofmt-check
+        name: gofmt
+        entry: scripts/pre-commit/gofmt-check.sh
+        language: script
+        types: [go]
+        pass_filenames: true
+
+      - id: go-vet
+        name: go vet
+        entry: scripts/pre-commit/go-vet.sh
+        language: script
+        types: [go]
+        pass_filenames: true
+        require_serial: true
+
+      - id: golangci-lint
+        name: golangci-lint
+        entry: scripts/pre-commit/golangci-lint.sh
+        language: script
+        types: [go]
+        pass_filenames: true
+        require_serial: true
+
+  # ── Frontend (ESLint) ────────────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: scripts/pre-commit/eslint.sh
+        language: script
+        files: ^components/frontend/.*\.(ts|tsx|js|jsx)$
+        pass_filenames: true
+
+  # ── Branch protection ────────────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: branch-protection
+        name: branch protection
+        entry: python3 scripts/git-hooks/pre-commit
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: push-protection
+        name: push protection
+        entry: python3 scripts/git-hooks/pre-push
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Before contributing, ensure you have:
 
 ### Install Git Hooks (Recommended)
 
-To prevent accidental commits to protected branches (`main`, `master`, `production`), install our git hooks:
+We use the [pre-commit](https://pre-commit.com/) framework to run linters and branch protection checks automatically on every commit. Install with:
 
 ```bash
 make setup-hooks
@@ -106,12 +106,24 @@ Or run the installation script directly:
 ./scripts/install-git-hooks.sh
 ```
 
-**What the hooks do:**
+**What runs on every commit:**
 
-- **pre-commit** - Blocks commits to `main`/`master`/`production` branches
-- **pre-push** - Blocks pushes to `main`/`master`/`production` branches
+- **File hygiene** - trailing whitespace, EOF fixer, YAML validation, large file check, merge conflict markers, private key detection
+- **Python** - `ruff format` + `ruff check --fix` (runners and scripts)
+- **Go** - `gofmt`, `go vet`, `golangci-lint` (backend, operator, public-api)
+- **Frontend** - ESLint (TypeScript/JavaScript)
+- **Branch protection** - blocks commits to `main`/`master`/`production`
 
-**Hooks are automatically installed** when you run `make dev-start`.
+**What runs on push:**
+
+- **Push protection** - blocks pushes to `main`/`master`/`production`
+
+**Run all hooks manually:**
+
+```bash
+make lint
+# or: pre-commit run --all-files
+```
 
 If you need to override the hooks (e.g., for hotfixes):
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: local-dev-token
 .PHONY: local-logs local-logs-backend local-logs-frontend local-logs-operator local-shell local-shell-frontend
 .PHONY: local-test local-test-dev local-test-quick test-all local-url local-troubleshoot local-port-forward local-stop-port-forward
-.PHONY: push-all registry-login setup-hooks remove-hooks check-minikube check-kind check-kubectl
+.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl
 .PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift
 .PHONY: setup-minio minio-console minio-logs minio-status
 .PHONY: validate-makefile lint-makefile check-shell makefile-health
@@ -153,16 +153,26 @@ build-public-api: ## Build public API gateway image
 		-t $(PUBLIC_API_IMAGE) .
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Public API built: $(PUBLIC_API_IMAGE)"
 
-##@ Git Hooks
+##@ Git Hooks & Linting
 
-setup-hooks: ## Install git hooks for branch protection
+setup-hooks: ## Install pre-commit hooks (linters + branch protection)
 	@./scripts/install-git-hooks.sh
 
-remove-hooks: ## Remove git hooks
+remove-hooks: ## Remove pre-commit hooks
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Removing git hooks..."
-	@rm -f .git/hooks/pre-commit
-	@rm -f .git/hooks/pre-push
+	@if command -v pre-commit >/dev/null 2>&1; then \
+		pre-commit uninstall && pre-commit uninstall --hook-type pre-push; \
+	else \
+		rm -f .git/hooks/pre-commit .git/hooks/pre-push; \
+	fi
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Git hooks removed"
+
+lint: ## Run all pre-commit linters on the entire repo
+	@if ! command -v pre-commit >/dev/null 2>&1; then \
+		echo "$(COLOR_RED)✗$(COLOR_RESET) pre-commit not installed. Run: make setup-hooks"; \
+		exit 1; \
+	fi
+	pre-commit run --all-files
 
 ##@ Registry Operations
 

--- a/components/runners/claude-code-runner/Dockerfile
+++ b/components/runners/claude-code-runner/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf install -y git jq && \
     dnf clean all
 
-    
+
 # Install Node.js
 # Use UBI AppStream to avoid conflicts with preinstalled nodejs-full-i18n
 RUN dnf module reset -y nodejs && \
@@ -54,8 +54,8 @@ RUN dnf module reset -y nodejs && \
 #       "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "0"
 #     }
 #   }
-# Install uv (provides uvx for package execution)
-RUN pip install --no-cache-dir uv
+# Install uv (provides uvx for package execution) and pre-commit (for repo hooks)
+RUN pip install --no-cache-dir uv pre-commit
 
 # Create working directory
 WORKDIR /app

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -1,280 +1,140 @@
-# Git Hooks for Branch Protection
+# Git Hooks (pre-commit Framework)
 
-This directory contains git hooks that enforce the feature branch workflow to prevent accidental commits and pushes to protected branches.
+This project uses the [pre-commit](https://pre-commit.com/) framework to manage git hooks. All hook configuration lives in `.pre-commit-config.yaml` at the repository root.
 
 ## What's Included
 
-### `pre-commit`
+### Pre-commit Stage (runs on `git commit`)
 
-Runs before every `git commit` and blocks commits to protected branches:
+| Hook | Source | Scope |
+|------|--------|-------|
+| trailing-whitespace | pre-commit-hooks | All files |
+| end-of-file-fixer | pre-commit-hooks | All files |
+| check-yaml | pre-commit-hooks | YAML files |
+| check-added-large-files | pre-commit-hooks | All files (>1MB) |
+| check-merge-conflict | pre-commit-hooks | All files |
+| detect-private-key | pre-commit-hooks | All files |
+| ruff-format | ruff-pre-commit | Python (runners, scripts) |
+| ruff | ruff-pre-commit | Python (runners, scripts) |
+| gofmt | local wrapper | Go files |
+| go vet | local wrapper | Go files (per-module) |
+| golangci-lint | local wrapper | Go files (per-module) |
+| eslint | local wrapper | Frontend TS/JS files |
+| branch-protection | local (this directory) | All commits |
 
-- `main`
-- `master`
-- `production`
+### Pre-push Stage (runs on `git push`)
 
-**Error message example:**
+| Hook | Source | Scope |
+|------|--------|-------|
+| push-protection | local (this directory) | All pushes |
 
-```
-⚠️  Attempting to commit directly to 'main'
-❌ Direct commits to 'main' are not allowed.
+### Local Wrapper Scripts
 
-💡 Create a feature branch instead:
-   git checkout -b feature/your-feature-name
-   git checkout -b fix/bug-description
-   git checkout -b issue-123-description
+Go and ESLint hooks use wrapper scripts in `scripts/pre-commit/` because:
 
-🔧 Or force commit (not recommended):
-   git commit --no-verify -m 'your message'
-```
-
-### `pre-push`
-
-Runs before every `git push` and blocks pushes to protected branches:
-
-- Blocks if you're currently on a protected branch
-- Blocks if you're pushing to a protected remote branch
-
-**Error message example:**
-
-```
-⚠️  Attempting to push directly to 'main'
-❌ Direct pushes to 'main' are not allowed.
-
-💡 Use the pull request workflow instead:
-   1. Create a feature branch: git checkout -b feature/your-feature
-   2. Push your feature branch: git push origin feature/your-feature
-   3. Open a pull request on GitHub
-
-🔧 Or force push (not recommended):
-   git push --no-verify
-```
+- **Go** has 3 separate modules (`backend`, `operator`, `public-api`) — tools must `cd` into each module directory
+- **ESLint** config and `node_modules` live in `components/frontend/`
+- All wrappers skip gracefully if the toolchain is not installed
 
 ## Installation
 
-### Automatic Installation (Recommended)
-
-Hooks are automatically installed when you run:
-
 ```bash
-make dev-start
+make setup-hooks
 ```
 
-### Manual Installation
-
-If you need to install hooks manually:
+Or directly:
 
 ```bash
 ./scripts/install-git-hooks.sh
 ```
 
-Or via Makefile:
-
-```bash
-make setup-hooks
-```
-
-### Verify Installation
-
-Check that symlinks exist in `.git/hooks/`:
-
-```bash
-ls -la .git/hooks/ | grep -E 'pre-commit|pre-push'
-```
-
-You should see symlinks pointing to `../../scripts/git-hooks/pre-commit` and `pre-push`.
+This installs pre-commit (if needed) and registers hooks for both `pre-commit` and `pre-push` stages.
 
 ## Usage
 
-### Normal Workflow (Hooks Active)
+### Automatic (default)
+
+Hooks run automatically on every `git commit` and `git push`. Only files staged for commit are checked.
+
+### Manual
+
+Run all hooks against the entire repo:
 
 ```bash
-# Create a feature branch
-git checkout -b feature/my-feature
-
-# Make changes and commit (hook allows this)
-git add .
-git commit -m "feat: add new feature"
-
-# Push to feature branch (hook allows this)
-git push origin feature/my-feature
-
-# Try to commit to main (hook blocks this)
-git checkout main
-git commit -m "oops"  # ❌ Blocked by pre-commit hook
+make lint
+# or: pre-commit run --all-files
 ```
 
-### Override When Necessary
-
-In rare cases where you need to commit/push to a protected branch (e.g., hotfix, CI automation):
+Run a specific hook:
 
 ```bash
-# Override pre-commit hook
-git commit --no-verify -m "hotfix: critical security patch"
-
-# Override pre-push hook
-git push --no-verify origin main
+pre-commit run gofmt-check --all-files
+pre-commit run eslint --all-files
+pre-commit run golangci-lint --all-files
 ```
 
-**⚠️ Use `--no-verify` sparingly!** It bypasses all safety checks.
+### Skip Hooks
+
+```bash
+git commit --no-verify -m "hotfix: critical fix"
+git push --no-verify
+```
+
+## Branch Protection Scripts
+
+The Python scripts in this directory (`pre-commit` and `pre-push`) implement branch protection logic. They are invoked by the pre-commit framework — not as raw git hooks.
+
+### `pre-commit` (Python)
+
+Blocks commits to protected branches: `main`, `master`, `production`.
+
+### `pre-push` (Python)
+
+Blocks pushes to protected branches by checking both the current branch and push targets.
 
 ## Uninstallation
-
-To remove the git hooks:
 
 ```bash
 make remove-hooks
 ```
-
-Or manually:
-
-```bash
-rm .git/hooks/pre-commit
-rm .git/hooks/pre-push
-```
-
-Backed-up hooks (if any existed before installation) are saved as `.git/hooks/pre-commit.backup`.
-
-## How It Works
-
-### Symlinks
-
-The installation script creates symlinks from `.git/hooks/` to `scripts/git-hooks/`:
-
-```
-.git/hooks/pre-commit  →  ../../scripts/git-hooks/pre-commit
-.git/hooks/pre-push    →  ../../scripts/git-hooks/pre-push
-```
-
-**Benefits:**
-
-- Changes to hook scripts automatically apply (no reinstall needed)
-- Hooks are tracked in git (in `scripts/git-hooks/`)
-- Easy to update and maintain
-
-### Hook Execution Flow
-
-**Pre-commit:**
-
-1. Git runs `.git/hooks/pre-commit` before creating commit
-2. Hook checks current branch with `git rev-parse --abbrev-ref HEAD`
-3. If branch is protected → exit code 1 (block commit)
-4. If branch is allowed → exit code 0 (proceed)
-
-**Pre-push:**
-
-1. Git runs `.git/hooks/pre-push` before pushing
-2. Hook receives push targets via stdin (local ref, remote ref)
-3. Checks both current branch and target branch
-4. If either is protected → exit code 1 (block push)
-5. If both are allowed → exit code 0 (proceed)
 
 ## Customization
 
 ### Add More Protected Branches
 
-Edit the `PROTECTED_BRANCHES` list in both hook files:
+Edit `PROTECTED_BRANCHES` in both `pre-commit` and `pre-push` Python scripts.
 
-```python
-PROTECTED_BRANCHES: List[str] = ["main", "master", "production", "release"]
-```
+### Modify Linter Configuration
 
-### Change Suggested Branch Prefixes
-
-Edit the `SUGGESTED_PREFIXES` list in `pre-commit`:
-
-```python
-SUGGESTED_PREFIXES: List[str] = [
-    "feature/",
-    "fix/",
-    "docs/",
-    "refactor/",
-    "test/",
-    "issue-",
-    "jira-",  # Add your custom prefixes
-]
-```
-
-### Disable Hooks Temporarily
-
-Instead of uninstalling, you can temporarily disable:
-
-```bash
-# Disable pre-commit
-mv .git/hooks/pre-commit .git/hooks/pre-commit.disabled
-
-# Re-enable
-mv .git/hooks/pre-commit.disabled .git/hooks/pre-commit
-```
-
-Or use `--no-verify` for individual operations.
+Edit `.pre-commit-config.yaml` at the repo root.
 
 ## Troubleshooting
 
-### Hook Not Running
-
-**Check if hook is executable:**
+### Hooks Not Running
 
 ```bash
-ls -l .git/hooks/pre-commit
-# Should show: lrwxr-xr-x (symlink with execute permissions)
-```
+# Verify installation
+pre-commit --version
+ls -la .git/hooks/pre-commit
 
-**Verify symlink target:**
-
-```bash
-readlink .git/hooks/pre-commit
-# Should show: ../../scripts/git-hooks/pre-commit
-```
-
-**Reinstall hooks:**
-
-```bash
+# Reinstall
 make remove-hooks
 make setup-hooks
 ```
 
-### Python Not Found
+### Specific Linter Failing
 
-Hooks require Python 3.11+ (project standard). Verify:
-
-```bash
-python3 --version
-```
-
-If Python is not in your PATH, update the shebang in hook files:
-
-```python
-#!/usr/bin/env python3.11  # Specific version
-```
-
-### Hook Fails with Error
-
-Run the hook manually to see detailed errors:
+Run the failing hook in isolation to see detailed output:
 
 ```bash
-python3 scripts/git-hooks/pre-commit
-python3 scripts/git-hooks/pre-push < /dev/null
+pre-commit run <hook-id> --all-files --verbose
 ```
 
-### Backed-Up Hook Lost
+### Old Symlink Hooks
 
-If the installer backed up your previous hook, restore it:
+The installer automatically removes old symlink-based hooks pointing to `scripts/git-hooks/`. If you still have issues, manually remove them:
 
 ```bash
-mv .git/hooks/pre-commit.backup .git/hooks/pre-commit
+rm -f .git/hooks/pre-commit .git/hooks/pre-push
+make setup-hooks
 ```
-
-## Contributing
-
-When modifying hooks:
-
-1. Test thoroughly on both protected and non-protected branches
-2. Ensure error messages are clear and actionable
-3. Follow project Python standards (black, isort, type hints)
-4. Update this README if behavior changes
-
-## References
-
-- [Git Hooks Documentation](https://git-scm.com/docs/githooks)
-- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Project contribution guide
-- [Makefile](../../Makefile) - Development commands

--- a/scripts/pre-commit/eslint.sh
+++ b/scripts/pre-commit/eslint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# eslint.sh — run ESLint on staged frontend files.
+# Skips gracefully if Node.js / npx is not available or node_modules missing.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+FRONTEND_DIR="$REPO_ROOT/components/frontend"
+
+if ! command -v npx &>/dev/null; then
+    echo "npx not found — skipping ESLint (install Node.js to enable)"
+    exit 0
+fi
+
+if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
+    echo "node_modules not found in components/frontend — skipping ESLint"
+    echo "Run: cd components/frontend && npm install"
+    exit 0
+fi
+
+# Strip the components/frontend/ prefix so ESLint resolves paths relative to its config
+relative_files=()
+for file in "$@"; do
+    # Handle both absolute and relative paths
+    rel="${file#"$FRONTEND_DIR/"}"
+    rel="${rel#components/frontend/}"
+    relative_files+=("$rel")
+done
+
+if [ ${#relative_files[@]} -eq 0 ]; then
+    exit 0
+fi
+
+cd "$FRONTEND_DIR"
+exec npx eslint "${relative_files[@]}"

--- a/scripts/pre-commit/go-vet.sh
+++ b/scripts/pre-commit/go-vet.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# go-vet.sh — run `go vet` in each affected Go module.
+# Determines which module(s) contain staged files and runs vet per-module.
+# Skips gracefully if Go is not installed.
+set -euo pipefail
+
+if ! command -v go &>/dev/null; then
+    echo "go not found — skipping (install Go to enable)"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Known Go module directories (relative to repo root)
+GO_MODULES=(
+    "components/backend"
+    "components/operator"
+    "components/public-api"
+)
+
+# Determine which modules are affected by the staged files
+declare -A affected_modules
+for file in "$@"; do
+    for mod in "${GO_MODULES[@]}"; do
+        if [[ "$file" == "$mod/"* || "$file" == "$REPO_ROOT/$mod/"* ]]; then
+            affected_modules["$mod"]=1
+        fi
+    done
+done
+
+if [ ${#affected_modules[@]} -eq 0 ]; then
+    exit 0
+fi
+
+exit_code=0
+for mod in "${!affected_modules[@]}"; do
+    mod_dir="$REPO_ROOT/$mod"
+    if [ -f "$mod_dir/go.mod" ]; then
+        echo "go vet: $mod"
+        if ! (cd "$mod_dir" && go vet ./...); then
+            exit_code=1
+        fi
+    fi
+done
+
+exit $exit_code

--- a/scripts/pre-commit/gofmt-check.sh
+++ b/scripts/pre-commit/gofmt-check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# gofmt-check.sh — check that staged Go files are gofmt-formatted.
+# Skips gracefully if Go is not installed.
+set -euo pipefail
+
+if ! command -v gofmt &>/dev/null; then
+    echo "gofmt not found — skipping (install Go to enable)"
+    exit 0
+fi
+
+unformatted=$(gofmt -l "$@" 2>/dev/null || true)
+if [ -n "$unformatted" ]; then
+    echo "The following files are not gofmt-formatted:"
+    echo "$unformatted"
+    echo ""
+    echo "Run: gofmt -w <file>"
+    exit 1
+fi

--- a/scripts/pre-commit/golangci-lint.sh
+++ b/scripts/pre-commit/golangci-lint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# golangci-lint.sh — run golangci-lint in each affected Go module.
+# Skips gracefully if golangci-lint is not installed.
+set -euo pipefail
+
+if ! command -v golangci-lint &>/dev/null; then
+    echo "golangci-lint not found — skipping (install to enable)"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Known Go module directories (relative to repo root)
+GO_MODULES=(
+    "components/backend"
+    "components/operator"
+    "components/public-api"
+)
+
+# Determine which modules are affected by the staged files
+declare -A affected_modules
+for file in "$@"; do
+    for mod in "${GO_MODULES[@]}"; do
+        if [[ "$file" == "$mod/"* || "$file" == "$REPO_ROOT/$mod/"* ]]; then
+            affected_modules["$mod"]=1
+        fi
+    done
+done
+
+if [ ${#affected_modules[@]} -eq 0 ]; then
+    exit 0
+fi
+
+exit_code=0
+for mod in "${!affected_modules[@]}"; do
+    mod_dir="$REPO_ROOT/$mod"
+    if [ -f "$mod_dir/go.mod" ]; then
+        echo "golangci-lint: $mod"
+        if ! (cd "$mod_dir" && golangci-lint run --timeout=5m); then
+            exit_code=1
+        fi
+    fi
+done
+
+exit $exit_code


### PR DESCRIPTION
## Summary

- Adds the [pre-commit](https://pre-commit.com/) framework so every linter that CI runs also runs locally before commit
- Replaces the old symlink-based git hooks with pre-commit managed hooks
- Adds `make lint` target to run all hooks manually

**Hooks included:**
| Hook | Scope |
|------|-------|
| trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, check-merge-conflict, detect-private-key | All files |
| ruff-format, ruff (check + fix) | Python (runners, scripts) |
| gofmt, go vet, golangci-lint | Go (per-module: backend, operator, public-api) |
| eslint | Frontend TS/JS |
| branch-protection | Blocks commits to main/master/production |
| push-protection | Blocks pushes to main/master/production |

Go and ESLint use local wrapper scripts (`scripts/pre-commit/`) because Go has 3 separate modules and ESLint config lives in `components/frontend/`. All wrappers skip gracefully if the toolchain is not installed.

## Files Changed

| File | Action |
|------|--------|
| `.pre-commit-config.yaml` | New — central hook config |
| `scripts/pre-commit/{gofmt-check,go-vet,golangci-lint,eslint}.sh` | New — wrapper scripts |
| `scripts/install-git-hooks.sh` | Rewritten — installs pre-commit, removes old symlinks |
| `Makefile` | Updated `setup-hooks`, `remove-hooks`; added `lint` |
| `components/runners/claude-code-runner/Dockerfile` | Added `pre-commit` to pip install |
| `components/runners/state-sync/hydrate.sh` | Auto-installs hooks after repo clone |
| `CLAUDE.md` | Added pre-commit section, updated checklists |
| `CONTRIBUTING.md` | Updated git hooks section |
| `scripts/git-hooks/README.md` | Rewritten for pre-commit framework |

## Test plan

- [x] `make setup-hooks` installs pre-commit and registers hooks
- [x] `pre-commit run --all-files` runs all hooks (trailing-whitespace and end-of-file-fixer auto-fix pre-existing issues; all other hooks pass on clean files)
- [x] `pre-commit run branch-protection` passes on feature branch
- [x] `pre-commit run check-yaml --all-files` passes (with `--allow-multiple-documents` for K8s manifests)
- [ ] `make remove-hooks` cleanly uninstalls
- [ ] Verify hooks fire on normal `git commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)