### PR TITLE
fix: disable OTel metrics export when no collector is configured

### DIFF
--- a/components/operator/internal/controller/otel_metrics.go
+++ b/components/operator/internal/controller/otel_metrics.go
@@ -45,12 +45,15 @@ var (
 	podRestarts        metric.Int64Counter
 )
 
-// InitMetrics initializes OpenTelemetry metrics
+// InitMetrics initializes OpenTelemetry metrics.
+// Set OTEL_EXPORTER_OTLP_ENDPOINT to configure the collector address.
+// Leave unset or empty to disable metrics export (no-op).
 func InitMetrics(ctx context.Context) (func(), error) {
-	// Get OTLP endpoint from environment
+	// Get OTLP endpoint from environment; skip if not configured
 	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	if endpoint == "" {
-		endpoint = "localhost:4317" // Default OTLP gRPC endpoint
+		log.Println("OTEL_EXPORTER_OTLP_ENDPOINT not set, metrics export disabled")
+		return func() {}, nil
 	}
 
 	// Create resource with service information


### PR DESCRIPTION
Previously, InitMetrics defaulted to localhost:4317 when OTEL_EXPORTER_OTLP_ENDPOINT was unset, causing "failed to upload metrics" errors every 30s in environments without an OTel collector (kind, CRC, minikube, and any production cluster without one).

Make metrics export opt-in: return a no-op when the endpoint is not configured, and log a single informational line at startup.

This is mostly relevant for local dev where running the collector is not necessary (and is undefined in most overlays). The specific errors reported in the log are:

```
2026/02/16 19:22:53 failed to upload metrics: context deadline exceeded: rpc error: code = Unavailable desc = name resolver error: produced zero addresses
```