### PR TITLE
fix(mcp): use wildcard syntax for MCP tool permissions

### DIFF
--- a/components/runners/claude-code-runner/ambient_runner/bridges/claude/mcp.py
+++ b/components/runners/claude-code-runner/ambient_runner/bridges/claude/mcp.py
@@ -82,7 +82,7 @@ def build_allowed_tools(mcp_servers: dict) -> list[str]:
     """Build the list of allowed tool names from default tools + MCP servers."""
     allowed = list(DEFAULT_ALLOWED_TOOLS)
     for server_name in mcp_servers.keys():
-        allowed.append(f"mcp__{server_name}")
+        allowed.append(f"mcp__{server_name}__*")
     logger.info(f"MCP tool permissions granted for servers: {list(mcp_servers.keys())}")
     return allowed
 


### PR DESCRIPTION
Changed MCP tool permission pattern from `mcp__{server_name}` to `mcp__{server_name}__*` to match all tools from each MCP server.

The previous implementation only allowed the server prefix itself, which didn't match actual tool names like `mcp__context7__resolve-library-id`. This caused all MCP tool calls to require manual user approval despite the server being configured.

The wildcard syntax `mcp__{server_name}__*` is the documented pattern for allowing all tools from an MCP server according to Claude Code permissions documentation.