### PR TITLE
fix: run ambient-api-server-db as postgres user (UID 999)

### DIFF
--- a/components/manifests/base/ambient-api-server-db.yml
+++ b/components/manifests/base/ambient-api-server-db.yml
@@ -54,6 +54,10 @@ spec:
         app: ambient-api-server
         component: database
     spec:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
       containers:
         - name: postgresql
           image: docker.io/library/postgres:16.2
@@ -96,6 +100,8 @@ spec:
             - mountPath: /var/lib/pgsql/data
               name: ambient-api-server-db-data
           securityContext:
+            runAsUser: 999
+            runAsGroup: 999
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             capabilities:


### PR DESCRIPTION
## Summary

- Add `runAsUser: 999`, `runAsGroup: 999`, `fsGroup: 999` to the ambient-api-server-db deployment
- The `postgres:16.2` Docker image entrypoint tries to `chown`/`chmod` directories when running as root, which fails under the restricted securityContext (`capabilities.drop: ALL`)
- Running as UID 999 (postgres) makes the entrypoint skip those privileged operations, and `fsGroup` ensures the PVC mount is group-writable

## Test plan

- [x] Verified fix resolves CrashLoopBackOff on kind cluster (`make kind-up`)
- [ ] Verify on minikube (`make local-up`)
- [ ] Verify on OpenShift (production overlay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)