### PR TITLE
fix: use ambient_code quay namespace in kind overlay

### DIFF
--- a/components/manifests/overlays/kind/operator-env-patch.yaml
+++ b/components/manifests/overlays/kind/operator-env-patch.yaml
@@ -14,10 +14,10 @@ spec:
         # - operator: fsGroup:0 for volume permissions
         # - runner: minimal MCP config (webfetch only, faster startup)
         - name: AMBIENT_CODE_RUNNER_IMAGE
-          value: "quay.io/gkrumbach07/vteam_claude_runner:latest"
+          value: "quay.io/ambient_code/vteam_claude_runner:latest"
         - name: STATE_SYNC_IMAGE
-          value: "quay.io/gkrumbach07/vteam_state_sync:latest"
+          value: "quay.io/ambient_code/vteam_state_sync:latest"
         - name: IMAGE_PULL_POLICY
-          value: "Always"
+          value: "IfNotPresent"
         - name: POD_FSGROUP
           value: "0"


### PR DESCRIPTION
## Summary

- Replace hardcoded `quay.io/gkrumbach07/` personal namespace with `quay.io/ambient_code/` for runner and state-sync images in the kind overlay
- Change `IMAGE_PULL_POLICY` from `Always` to `IfNotPresent` so locally built images loaded via `kind load` are used when available

## Context

The kind overlay at `components/manifests/overlays/kind/operator-env-patch.yaml` pointed runner and state-sync images at a personal Quay namespace. This caused session pods to either pull incorrect images or fail entirely when the personal repo was inaccessible. Discovered while testing PR #679 on a local kind cluster.

## Test plan

- [x] Verified sessions can start on kind cluster after patching operator env vars
- [ ] `make kind-up` deploys with correct image references

🤖 Generated with [Claude Code](https://claude.com/claude-code)