### PR TITLE
fix: move OpenShift Route out of kustomize base

### DIFF
--- a/components/manifests/base/kustomization.yaml
+++ b/components/manifests/base/kustomization.yaml
@@ -19,7 +19,6 @@ resources:
 - ambient-api-server-secrets.yml
 - ambient-api-server-db.yml
 - ambient-api-server-service.yml
-- ambient-api-server-route.yml
 - unleash-deployment.yaml
 
 # Default images (can be overridden by overlays)
@@ -38,4 +37,3 @@ images:
   newTag: latest
 - name: quay.io/ambient_code/vteam_api_server
   newTag: latest
-

--- a/components/manifests/overlays/local-dev/ambient-api-server-route.yaml
+++ b/components/manifests/overlays/local-dev/ambient-api-server-route.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ambient-api-server
+  labels:
+    app: ambient-api-server
+    component: api
+spec:
+  to:
+    kind: Service
+    name: ambient-api-server
+  port:
+    targetPort: api
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/components/manifests/overlays/local-dev/kustomization.yaml
+++ b/components/manifests/overlays/local-dev/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: vteam-dev
 # Resources (base + local-dev-specific)
 resources:
 - ../../base
+- ambient-api-server-route.yaml
 - build-configs.yaml
 - dev-users.yaml
 - frontend-auth.yaml

--- a/components/manifests/overlays/production/ambient-api-server-route.yaml
+++ b/components/manifests/overlays/production/ambient-api-server-route.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ambient-api-server
+  labels:
+    app: ambient-api-server
+    component: api
+spec:
+  to:
+    kind: Service
+    name: ambient-api-server
+  port:
+    targetPort: api
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/components/manifests/overlays/production/kustomization.yaml
+++ b/components/manifests/overlays/production/kustomization.yaml
@@ -12,6 +12,7 @@ namespace: ambient-code
 # Manage this secret separately: oc apply -f github-app-secret.yaml -n ambient-code
 resources:
 - ../../base
+- ambient-api-server-route.yaml
 - route.yaml
 - backend-route.yaml
 - public-api-route.yaml


### PR DESCRIPTION
## Summary

- Remove `ambient-api-server-route.yml` (OpenShift Route) from the base kustomization
- Add it as a local resource in the `production` and `local-dev` overlays where OpenShift CRDs are available
- Kind and e2e overlays no longer inherit the Route, so `kubectl apply` completes without error

## Root cause

The base kustomization included an `route.openshift.io/v1` Route resource. On kind/e2e clusters (no OpenShift CRDs), `kubectl apply` fails with:

```
error: resource mapping not found for name: "ambient-api-server"
  no matches for kind "Route" in version "route.openshift.io/v1"
```

This aborted `make kind-up` at the `kubectl apply` step, preventing all subsequent steps from running:
- `wait-for-ready.sh` (pod readiness checks)
- `init-minio.sh` (bucket creation)
- `extract-token.sh` (test user token)

Sessions then failed because the MinIO bucket was never created.

## Verification

All four overlays build cleanly with `kubectl kustomize`:

| Overlay | Routes | Status |
|---------|--------|--------|
| kind | 0 | OK |
| e2e | 0 | OK |
| production | 5 | OK |
| local-dev | 4 | OK |

## Test plan

- [ ] `make kind-up` completes without errors (full pipeline including MinIO init)
- [ ] `make kind-down && make kind-up` from scratch
- [ ] Verify production overlay still renders all Routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)