### PR TITLE
fix: add retry logic to MinIO init to prevent silent bucket creation failures

### DIFF
--- a/e2e/scripts/init-minio.sh
+++ b/e2e/scripts/init-minio.sh
@@ -13,7 +13,7 @@ kubectl wait --for=condition=ready --timeout=60s pod -n ambient-code -l app=mini
 MINIO_POD=$(kubectl get pod -n ambient-code -l app=minio -o jsonpath='{.items[0].metadata.name}')
 
 if [ -z "$MINIO_POD" ]; then
-  echo "❌ MinIO pod not found"
+  echo "MinIO pod not found"
   exit 1
 fi
 
@@ -23,24 +23,39 @@ echo "MinIO pod: $MINIO_POD"
 MINIO_USER=$(kubectl get secret -n ambient-code minio-credentials -o jsonpath='{.data.root-user}' | base64 -d)
 MINIO_PASSWORD=$(kubectl get secret -n ambient-code minio-credentials -o jsonpath='{.data.root-password}' | base64 -d)
 
-echo "Setting up MinIO alias..."
-kubectl exec -n ambient-code $MINIO_POD -- mc alias set myminio http://localhost:9000 $MINIO_USER $MINIO_PASSWORD 2>/dev/null || {
-  echo "❌ Failed to connect to MinIO"
-  exit 1
-}
+# Retry loop: MinIO pod can be "Ready" before the S3 API accepts connections
+MAX_RETRIES=10
+RETRY_DELAY=3
+
+echo "Waiting for MinIO S3 API to accept connections..."
+for i in $(seq 1 $MAX_RETRIES); do
+  if output=$(kubectl exec -n ambient-code "$MINIO_POD" -- mc alias set myminio http://localhost:9000 "$MINIO_USER" "$MINIO_PASSWORD" 2>&1); then
+    echo "MinIO S3 API is ready"
+    break
+  fi
+  if [ "$i" -eq "$MAX_RETRIES" ]; then
+    echo "Failed to connect to MinIO after $MAX_RETRIES attempts"
+    echo "Last error: $output"
+    exit 1
+  fi
+  echo "  Attempt $i/$MAX_RETRIES failed, retrying in ${RETRY_DELAY}s..."
+  sleep "$RETRY_DELAY"
+done
 
 echo "Creating ambient-sessions bucket..."
-kubectl exec -n ambient-code $MINIO_POD -- mc mb myminio/ambient-sessions 2>/dev/null || {
-  echo "   ℹ️  Bucket may already exist, verifying..."
-}
+if kubectl exec -n ambient-code "$MINIO_POD" -- mc mb myminio/ambient-sessions 2>/dev/null; then
+  echo "  Created ambient-sessions bucket"
+else
+  echo "  Bucket may already exist, verifying..."
+fi
 
 # Verify bucket exists
-kubectl exec -n ambient-code $MINIO_POD -- mc ls myminio/ | grep -q ambient-sessions && {
-  echo "   ✅ ambient-sessions bucket ready"
-} || {
-  echo "   ❌ Failed to verify bucket"
+if kubectl exec -n ambient-code "$MINIO_POD" -- mc ls myminio/ | grep -q ambient-sessions; then
+  echo "  ambient-sessions bucket ready"
+else
+  echo "  Failed to verify ambient-sessions bucket"
   exit 1
-}
+fi
 
 echo ""
-echo "✅ MinIO initialized successfully!"
+echo "MinIO initialized successfully!"

--- a/e2e/scripts/wait-for-ready.sh
+++ b/e2e/scripts/wait-for-ready.sh
@@ -22,10 +22,15 @@ kubectl wait --for=condition=available --timeout=300s \
   deployment/frontend \
   -n ambient-code
 
+# Wait for MinIO (required for session state persistence)
+echo "⏳ Waiting for minio..."
+kubectl wait --for=condition=available --timeout=300s \
+  deployment/minio \
+  -n ambient-code 2>/dev/null || echo "⚠️  MinIO not deployed (S3 persistence disabled)"
+
 echo ""
 echo "✅ All pods are ready!"
 echo ""
 
 # Show pod status
 kubectl get pods -n ambient-code
-


### PR DESCRIPTION
## Summary

- **MinIO init race condition**: The MinIO pod can report `Ready` before its S3 API actually accepts connections. `init-minio.sh` was silently swallowing `mc alias set` failures (via `2>/dev/null`), which caused the `ambient-sessions` bucket to never be created. Sessions then fail with `init-hydrate` exit 1.
- **Missing MinIO wait**: `wait-for-ready.sh` waited for backend, operator, and frontend but not MinIO, allowing `init-minio.sh` to run before MinIO was available.

## Changes

- `e2e/scripts/init-minio.sh`: Add retry loop (10 attempts, 3s delay) for `mc alias set` so the script waits for the S3 API to actually accept connections before attempting bucket creation
- `e2e/scripts/wait-for-ready.sh`: Add MinIO deployment to the wait list (non-fatal if MinIO isn't deployed)

## Test plan

- [ ] `make kind-up` completes with `ambient-sessions` bucket created
- [ ] Verify with `kubectl exec -n ambient-code <minio-pod> -- mc ls myminio/` shows the bucket
- [ ] Sessions start without `init-hydrate` failures


🤖 Generated with [Claude Code](https://claude.com/claude-code)