### PR TITLE
fix(frontend): forward Authorization header for kind local dev, improve kind docs

### DIFF
--- a/components/frontend/src/lib/auth.ts
+++ b/components/frontend/src/lib/auth.ts
@@ -69,7 +69,7 @@ export function buildForwardHeaders(request: Request, extra?: Record<string, str
   if (!headers['X-Forwarded-Email'] && process.env.OC_EMAIL) {
     headers['X-Forwarded-Email'] = process.env.OC_EMAIL;
   }
-  
+
   // Add token fallback for local development
   if (!headers['X-Forwarded-Access-Token'] && process.env.OC_TOKEN) {
     headers['X-Forwarded-Access-Token'] = process.env.OC_TOKEN;
@@ -83,11 +83,11 @@ export function buildForwardHeaders(request: Request, extra?: Record<string, str
   const needsIdentity = !headers['X-Forwarded-User'] && !headers['X-Forwarded-Preferred-Username'];
   const needsToken = !headers['X-Forwarded-Access-Token'];
 
-  // We cannot await top-level in this sync function, so expose best-effort sync
-  // pattern by stashing promises on the object and resolving outside if needed.
-  // For simplicity, perform a lazy, best-effort fetch and only if in server runtime.
+  // Best-effort async discovery — the IIFE resolves *after* this function
+  // returns, so these mutations only help callers that hold a reference to
+  // `headers` long enough (e.g. long-lived SSE connections). For reliable
+  // oc CLI discovery, use buildForwardHeadersAsync instead.
   if (enableOc && runningInNode && (needsIdentity || needsToken)) {
-    // Fire-and-forget: we won't block the request if oc isn't present
     (async () => {
       try {
         if (needsIdentity) {


### PR DESCRIPTION
## Summary

- **auth.ts**: `buildForwardHeaders` now sets both `X-Forwarded-Access-Token` and `Authorization: Bearer` when forwarding tokens to the backend. The backend's `ExtractServiceAccountFromAuth` only reads the `Authorization` header to parse JWT subjects, so `X-Forwarded-Access-Token` alone caused "Invalid token" errors when running the frontend locally against a kind cluster with service account tokens.

- **kind.md**: Adds practical guidance discovered during local development:
  - Vertex AI setup script requires `GOOGLE_APPLICATION_CREDENTIALS` as an env var (not just a make arg)
  - Runner secrets (`ambient-runner-secrets`, `ambient-vertex`) must be created per project namespace to run interactive sessions
  - Frontend local dev workflow: `npm run dev` against the kind backend with port-forward (fastest iteration for frontend changes)
  - Memory troubleshooting: how to scale down non-essential pods on the single-node kind cluster

## Test plan

- [x] Verified locally: created kind cluster, ran frontend with `npm run dev`, created workspace and session successfully after auth fix
- [ ] Verify `buildForwardHeaders` doesn't break production OAuth proxy flow (Authorization header should already be set by the proxy, so the additional set is a no-op)
- [ ] Review kind.md instructions for accuracy on a clean setup


Made with [Cursor](https://cursor.com)