### PR TITLE
fix: handle oversized tool call results gracefully

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -240,7 +240,10 @@ export default function ProjectSessionDetailPage({
     projectName: projectName || "",
     sessionName: sessionName || "",
     autoConnect: false, // Manual connection after hydration
-    onError: (err) => console.error("AG-UI stream error:", err),
+    onError: (err) => {
+      console.error("AG-UI stream error:", err)
+      errorToast(err)
+    },
     onTraceId: (traceId) => setLangfuseTraceId(traceId),  // Capture Langfuse trace ID for feedback
   });
   const aguiState = aguiStream.state;


### PR DESCRIPTION
## Summary

- **Runner**: Add per-event error handling in the AG-UI encoding layer. When `encoder.encode()` fails on a single event (e.g. tool result >1MB hits the ag-ui buffer limit), catch it, emit a fallback `ToolCallResultEvent` with the error message, and keep the run alive instead of killing it with a `RUN_ERROR`.
- **Frontend**: `handleRunError()` now marks pending tool calls as `status: 'error'` so their spinners stop on run failure.
- **Frontend**: Surface `RUN_ERROR` via `errorToast()` instead of silent `console.error()`.

## Test plan

- [ ] Trigger a tool call that returns >1MB (e.g. `jira_get_all_projects` on a large instance). Verify the tool call closes out with an error message and the run continues.
- [ ] Verify normal-sized tool calls still work correctly.
- [ ] If a `RUN_ERROR` occurs for other reasons, verify a toast appears and tool call spinners stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)