### PR TITLE
RHOAIENG-51372: add smoke test workflow for preprod runner

### DIFF
--- a/.github/workflows/test-preprod-runner.yml
+++ b/.github/workflows/test-preprod-runner.yml
@@ -1,0 +1,12 @@
+name: "TEST: preprod runner"
+on:
+  push:
+    paths:
+      - .github/workflows/test-preprod-runner.yml
+  workflow_dispatch:
+
+jobs:
+  hello:
+    runs-on: [self-hosted, preprod]
+    steps:
+      - run: echo "Hello from $(hostname)"


### PR DESCRIPTION
## Summary
- Adds a manual `workflow_dispatch` workflow to verify the standalone GitHub Actions runner on preprod can pick up jobs. See [RHOAIENG-51372](https://issues.redhat.com/browse/RHOAIENG-51372) for context.
- Just prints the hostname — meant to be triggered once and then removed

## Test plan
- Merge, then trigger from Actions tab → ["TEST: preprod runner"](https://github.com/ambient-code/platform/actions/workflows/test-preprod-runner.yml) → Run workflow
- Confirm the job runs on the preprod self-hosted runner