### PR TITLE
fix(runner): enable CLAUDE.md discovery from additional directories

### DIFF
--- a/components/runners/claude-code-runner/ambient_runner/bridges/claude/bridge.py
+++ b/components/runners/claude-code-runner/ambient_runner/bridges/claude/bridge.py
@@ -343,6 +343,8 @@ class ClaudeBridge(PlatformBridge):
 
         # Workspace paths
         cwd_path, add_dirs = resolve_workspace_paths(self._context)
+        if add_dirs:
+            os.environ["CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD"] = "1"
 
         # Observability (before MCP so rubric tool can access it)
         await self._setup_observability(configured_model)


### PR DESCRIPTION
## Summary

- Set `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` when `add_dirs` is non-empty so the Claude Code SDK discovers `CLAUDE.md` and `.claude/rules/*.md` files from additional directories

**Problem:** In multi-repo or workflow sessions, non-main repos are passed to the SDK via `add_dirs`. The SDK only discovers `CLAUDE.md` files from the current working directory by default, so context files in secondary repos were silently ignored.

**Fix:** Set the env var before SDK initialization when additional directories are present. This enables native SDK discovery for all `add_dirs` repos.

## Test plan

- [ ] Verify multi-repo session where non-main repo has a `CLAUDE.md` — it should now be loaded
- [ ] Verify workflow session where repos in `add_dirs` have `.claude/rules/*.md` — rules should apply
- [ ] Verify single-repo session (no `add_dirs`) is unaffected — env var is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)