### PR TITLE
fix: compact jq output for GITHUB_OUTPUT compatibility

### DIFF
--- a/.github/workflows/ci-failure-resolver-with-agent.yml
+++ b/.github/workflows/ci-failure-resolver-with-agent.yml
@@ -24,7 +24,7 @@ jobs:
             PRS=$(gh pr list --state open --json number,statusCheckRollup \
               --jq '[.[] | select(.statusCheckRollup[]? | .status == "COMPLETED" and .conclusion == "FAILURE") | .number] | unique')
           else
-            PRS=$(echo "${{ inputs.prs }}" | tr ',' '\n' | jq -R 'tonumber' | jq -s .)
+            PRS=$(echo "${{ inputs.prs }}" | tr ',' '\n' | jq -R 'tonumber' | jq -sc .)
           fi
           echo "matrix={\"pr\":${PRS:-[]}}" >> $GITHUB_OUTPUT
 
@@ -70,7 +70,7 @@ jobs:
             -d "{\"model\":\"claude-sonnet-4-20250514\",\"max_tokens\":256,\"messages\":[{\"role\":\"user\",\"content\":\"Classify this CI failure as JSON only: {\\\"category\\\": \\\"flake_network|flake_timeout|flake_race|error_code|error_test|unknown\\\", \\\"summary\\\": \\\"one sentence\\\", \\\"is_flake\\\": bool}\\n\\nLogs:\\n${LOGS}\"}]}" \
             | jq -r '.content[0].text')
 
-          echo "classification=$RESULT" >> $GITHUB_OUTPUT
+          echo "classification=$(echo "$RESULT" | jq -c .)" >> $GITHUB_OUTPUT
           IS_FLAKE=$(echo "$RESULT" | jq -r '.is_flake')
 
           [ "$IS_FLAKE" = "true" ] && [ "$ATTEMPT" -eq 0 ] && echo "action=retry" >> $GITHUB_OUTPUT && exit 0


### PR DESCRIPTION
## Summary

- Fix `gather-prs` job failure caused by multi-line `jq` output written to `$GITHUB_OUTPUT` (requires single-line `key=value` pairs)
- Add `-c` (compact) flag to `jq -s` so the PR number array is single-line JSON
- Also compact the `classification` output from Claude API responses, which would hit the same issue in the `fix-pr` job

## Root Cause

`jq -s .` (slurp) formats JSON with newlines by default:
```
[
  604
]
```

When interpolated into `$GITHUB_OUTPUT`, the second line (`  604`) has no `key=value` format, causing:
```
##[error]Invalid format '  604'
```

## Fix

`jq -sc .` produces compact single-line output: `[604]`

## Test plan

- [ ] Re-run the CI Failure Resolver workflow with `prs: "604"` and verify `gather-prs` succeeds
- [ ] Test with comma-separated input like `"604,605"` to verify multi-PR parsing

Fixes: https://github.com/ambient-code/platform/actions/runs/22532850833/job/65275015456

🤖 Generated with [Claude Code](https://claude.com/claude-code)