### PR TITLE
feat: add /session-config skill for generating session-config repos

### DIFF
--- a/.claude/skills/session-config/SKILL.md
+++ b/.claude/skills/session-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-config
-description: Generates ACP session-config repositories interactively. Use when creating or refreshing a session-config repo with CLAUDE.md, .claude/rules, skills, agents, settings.json, .mcp.json, hooks, or .ambient/workflows. Presents all configuration surfaces and scaffolds self-documented files.
+description: Generates ACP session-config repositories interactively. Use when creating or refreshing a session-config repo with CLAUDE.md, .claude/rules, skills, agents, settings.json, .mcp.json, hooks, .ambient/workflows, or plugin marketplaces. Presents all configuration surfaces and scaffolds self-documented files.
 ---
 
 # Session Config Generator
@@ -30,6 +30,7 @@ Present ALL surfaces. Use AskUserQuestion multiSelect to let the user pick.
 | 6 | **MCP Servers** | `.mcp.json` | MCP server configuration (stdio, http, oauth) |
 | 7 | **Hooks** | `.claude/settings.json` hooks key | Lifecycle automation (PreToolUse, PostToolUse, etc.) |
 | 8 | **Workflows** | `.ambient/workflows/` | ACP workflow definitions with optional rubrics |
+| 9 | **Plugin Marketplaces** | `.claude/settings.json` | Plugin sources, enablement, and marketplace declarations |
 
 For full schemas, frontmatter fields, and examples for each surface, see [reference.md](reference.md).
 
@@ -102,6 +103,14 @@ For full schemas, frontmatter fields, and examples for each surface, see [refere
 - Documentation — generate project docs
 - Onboarding — guided project walkthrough
 - Custom
+
+## Plugin Marketplace Options to Offer
+
+- **odh-ai-helpers** — `opendatahub-io/ai-helpers` (FIPS compliance, Python packaging, Jira, GitLab, vLLM tools) — **enable by default**
+- **Custom GitHub marketplace** — user provides `{owner}/{repo}` with marketplace.json
+- **Custom git URL** — any git repo containing a marketplace
+- **Custom npm package** — npm-distributed marketplace
+- **Plugin enablement presets** — pre-enable/disable specific plugins from declared marketplaces
 
 ## File Generation Rules
 

--- a/.claude/skills/session-config/reference.md
+++ b/.claude/skills/session-config/reference.md
@@ -369,3 +369,122 @@ JSON files under `.ambient/workflows/`. Each defines a reusable workflow.
 ```
 
 Standalone workflow repos use `.ambient/ambient.json` at the repo root and can include `CLAUDE.md`, `.claude/`, and a `rubric.md` file for evaluation criteria.
+
+## 9. Plugin Marketplaces & Enablement
+
+Configured in `.claude/settings.json`. Controls which plugin marketplaces are available and which plugins are enabled by default.
+
+### Marketplace Sources
+
+```jsonc
+{
+  // Extra marketplaces (additive to defaults)
+  "extraKnownMarketplaces": {
+    "odh-ai-helpers": {                  // Marketplace display name
+      "source": {
+        "source": "github",             // Source type
+        "repo": "opendatahub-io/ai-helpers"  // GitHub {owner}/{repo}
+      }
+    },
+    "acme-tools": {
+      "source": {
+        "source": "github",
+        "repo": "acme-corp/claude-plugins"
+      }
+    }
+  },
+
+  // Strict marketplaces (managed settings — replaces defaults)
+  "strictKnownMarketplaces": [
+    {
+      "source": "github",               // GitHub repository
+      "repo": "opendatahub-io/ai-helpers",
+      "ref": "main",                     // Optional: pin to branch/tag
+      "path": ""                          // Optional: subdirectory
+    },
+    {
+      "source": "git",                   // Any git URL
+      "url": "https://gitlab.example.com/tools/plugins.git",
+      "ref": "production"
+    },
+    {
+      "source": "url",                   // HTTP endpoint
+      "url": "https://plugins.example.com/marketplace.json",
+      "headers": {
+        "Authorization": "Bearer ${TOKEN}"
+      }
+    },
+    {
+      "source": "npm",                   // npm package
+      "package": "@acme-corp/claude-plugins"
+    },
+    {
+      "source": "file",                  // Local file path
+      "path": "/usr/local/share/claude/marketplace.json"
+    },
+    {
+      "source": "directory",             // Local directory
+      "path": "/usr/local/share/claude/plugins/"
+    },
+    {
+      "source": "hostPattern",           // Allow any repo matching pattern
+      "hostPattern": "^github\\.example\\.com$"
+    }
+  ],
+
+  // Block specific marketplaces
+  "blockedMarketplaces": [
+    { "source": "github", "repo": "untrusted/plugins" }
+  ],
+
+  // Only allow managed marketplace sources (enterprise lockdown)
+  "allowManagedMcpServersOnly": false
+}
+```
+
+### Plugin Enablement
+
+```jsonc
+{
+  // Enable/disable specific plugins from declared marketplaces
+  "enabledPlugins": {
+    "odh-ai-helpers@odh-ai-helpers": true,       // plugin@marketplace
+    "fips-compliance-checker@odh-ai-helpers": true,
+    "formatter@acme-tools": true,
+    "untrusted-plugin@acme-tools": false          // Explicitly disabled
+  }
+}
+```
+
+### Marketplace Source Types
+
+| Source | Required Fields | Description |
+|--------|----------------|-------------|
+| `github` | `repo` | GitHub `{owner}/{repo}` with `.claude-plugin/marketplace.json` |
+| `git` | `url` | Any git repo URL (HTTPS/SSH) |
+| `url` | `url` | HTTP endpoint returning marketplace JSON |
+| `npm` | `package` | npm package containing marketplace |
+| `file` | `path` | Local JSON file |
+| `directory` | `path` | Local directory containing plugins |
+| `hostPattern` | `hostPattern` | Regex allowing repos from matching hosts |
+
+### Default Marketplace to Include
+
+When generating session-config repos, include `opendatahub-io/ai-helpers` by default:
+
+```jsonc
+{
+  "extraKnownMarketplaces": {
+    "odh-ai-helpers": {
+      "source": {
+        "source": "github",
+        "repo": "opendatahub-io/ai-helpers"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "odh-ai-helpers@odh-ai-helpers": true,
+    "fips-compliance-checker@odh-ai-helpers": true
+  }
+}
+```


### PR DESCRIPTION
**Jira:** [RHOAIENG-51888](https://issues.redhat.com/browse/RHOAIENG-51888)

## Summary

- Adds `/session-config` skill that interactively walks users through creating ACP session-config repositories
- Covers all 8 Claude Code configuration surfaces: CLAUDE.md, settings.json, rules, skills, agents, .mcp.json, hooks, and .ambient/workflows
- Uses progressive disclosure per Anthropic best practices: concise SKILL.md (139 lines) links to reference.md (371 lines) for full schemas

## Structure

```
.claude/skills/session-config/
├── SKILL.md        # Interactive generation process, surface overview, archetypes
└── reference.md    # Complete schemas for all 8 surfaces
```

## How It Works

1. User invokes `/session-config`
2. Skill presents all 8 config surfaces via multiSelect
3. For each selected surface, asks about content preferences
4. Generates self-documented files with inline schema comments
5. Creates README explaining overlay behavior

## Test plan

- [ ] Invoke `/session-config` and verify all 8 surfaces presented
- [ ] Select subset of surfaces and verify only selected ones generated
- [ ] Verify generated files include inline documentation
- [ ] Verify reference.md schemas match current Claude Code docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)