### PR TITLE
Revert "Added workflow dispatch trigger"

### DIFF
--- a/.github/workflows/amber-auto-review.yml
+++ b/.github/workflows/amber-auto-review.yml
@@ -1,20 +1,190 @@
-name: Amber Auto Review
+# Amber Automatic Code Review
+#
+# Uses memory system to apply repository-specific standards
+# Comments appear from github-actions[bot]
+#
+# Required GitHub Secret:
+# - CLAUDE_CODE_OAUTH_TOKEN: OAuth token for Claude Code
+
+name: Amber Automatic Code Review
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch:
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
-  review:
+  amber-review:
     runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
 
-      - name: Run review
-        run: echo 'Running auto review...'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Minimize old Claude review comments
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          echo "Finding previous Claude Code Review comments to minimize..."
+
+          # Get all comment IDs from github-actions[bot] with "Claude Code Review" at the start
+          # Using startswith() to avoid matching code blocks or inline mentions
+          COMMENT_IDS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("# Claude Code Review"))) | .node_id')
+
+          if [ -z "$COMMENT_IDS" ]; then
+            echo "No old Claude Code Review comments found"
+            exit 0
+          fi
+
+          # Minimize each comment with error handling
+          # Use here-string to avoid subshell variable scoping issues with pipe
+          COUNT=0
+          ERRORS=0
+          while read -r id; do
+            if [ -n "$id" ]; then
+              if gh api graphql -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' -f id="$id" 2>&1; then
+                echo "✓ Minimized $id"
+                ((COUNT++))
+              else
+                echo "✗ Failed to minimize $id" >&2
+                ((ERRORS++))
+              fi
+            fi
+          done <<< "$COMMENT_IDS"
+
+          echo "Minimized $COUNT comment(s), $ERRORS error(s)"
+
+      - name: Run Amber Code Review (with memory system)
+        id: amber-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: '*'
+          claude_args: |
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue list:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Load the following memory system files to understand repository standards:
+
+            1. Read CLAUDE.md (master project instructions)
+            2. Read .claude/context/backend-development.md
+            3. Read .claude/context/frontend-development.md
+            4. Read .claude/context/security-standards.md
+            5. Read .claude/patterns/k8s-client-usage.md
+            6. Read .claude/patterns/error-handling.md
+            7. Read .claude/patterns/react-query-usage.md
+
+            After loading all memory files, perform a comprehensive code review following the standards and patterns you just loaded.
+
+            Focus on:
+            1. **Code Quality** - Does it follow CLAUDE.md patterns?
+            2. **Security** - Check security standards (user token auth, RBAC, token redaction)
+            3. **Performance** - Any bottlenecks?
+            4. **Testing** - Adequate coverage?
+            5. **Architecture** - Follows project structure from memory context?
+            6. **Error Handling** - Follows error handling patterns?
+
+            Use `gh pr comment` to post your review with this format:
+
+            # Claude Code Review
+
+            ## Summary
+            [Brief overview]
+
+            ## Issues by Severity
+
+            ### 🚫 Blocker Issues
+            [Must fix before merge]
+
+            ### 🔴 Critical Issues
+            [Should fix before merge]
+
+            ### 🟡 Major Issues
+            [Important to address]
+
+            ### 🔵 Minor Issues
+            [Nice-to-have improvements]
+
+            ## Positive Highlights
+            [Things done well]
+
+            ## Recommendations
+            [Prioritized action items]
+
+      - name: Add workflow link with memory system visibility
+        if: steps.amber-review.conclusion == 'success'
+        uses: actions/github-script@v8
+        env:
+          RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const runId = process.env.RUN_ID;
+            const serverUrl = process.env.GITHUB_SERVER_URL;
+            const repository = process.env.GITHUB_REPOSITORY;
+
+            // Find review comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const reviewComment = comments.data
+              .filter(c => c.user.login === 'github-actions[bot]' && c.body.startsWith('# Claude Code Review'))
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
+            if (!reviewComment) {
+              console.log('No review comment found');
+              return;
+            }
+
+            if (reviewComment.body.includes('View AI decision process')) {
+              console.log('Transparency link already added');
+              return;
+            }
+
+            const transparencySection = '\n\n---\n🔍 [View AI decision process](' + serverUrl + '/' + repository + '/actions/runs/' + runId + ') (logs available for 90 days)\n\n' +
+              '<details>\n' +
+              '<summary>📋 View memory system files loaded (click to expand)</summary>\n\n' +
+              '### What Amber Loaded for Code Review\n\n' +
+              'Amber automatically loaded these repository standards from the memory system:\n\n' +
+              '1. **CLAUDE.md** - Master project instructions, development standards\n' +
+              '2. **backend-development.md** - Go backend, K8s integration patterns\n' +
+              '3. **frontend-development.md** - NextJS, Shadcn UI, React Query patterns\n' +
+              '4. **security-standards.md** - Auth, RBAC, token handling\n' +
+              '5. **k8s-client-usage.md** - User token vs service account patterns\n' +
+              '6. **error-handling.md** - Consistent error patterns\n' +
+              '7. **react-query-usage.md** - Data fetching patterns\n\n' +
+              '**Impact**: This review used your repository\'s specific code quality standards, security patterns, and best practices from the memory system (PRs #359, #360) - not just generic code review guidelines.\n\n' +
+              '</details>';
+
+            const updatedBody = reviewComment.body + transparencySection;
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: reviewComment.id,
+              body: updatedBody
+            });
+
+            console.log('Added transparency link to review comment');


### PR DESCRIPTION
## Summary
- Reverts commit ed18288 which accidentally replaced the full Amber Auto Review workflow (190 lines) with a 20-line placeholder that just echoes
- Restores the complete code review workflow including PR checkout, old comment minimization, Claude Code review action, and transparency link steps

## Context
The intent of ed18288 was to add `workflow_dispatch` support, but the entire workflow body was lost in the process. This revert restores the original workflow. A follow-up PR will properly add `workflow_dispatch` support.

## Test plan
- [x] Verify restored file matches the pre-ed18288 state (190 lines)
- [ ] Confirm workflow runs correctly on next PR open/synchronize event

🤖 Generated with [Claude Code](https://claude.com/claude-code)