### PR TITLE
feat(runner): add fixed workspace paths to system prompt

### DIFF
--- a/components/runners/claude-code-runner/ambient_runner/platform/prompts.py
+++ b/components/runners/claude-code-runner/ambient_runner/platform/prompts.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 
 WORKSPACE_STRUCTURE_HEADER = "# Workspace Structure\n\n"
 
+WORKSPACE_FIXED_PATHS_PROMPT = (
+    "**ACP Session Workspace Paths** (use directly, never search):\n"
+    "- `/workspace/file-uploads/` user uploads\n"
+    "- `/workspace/repos/<name>/` git repositories added to context by user\n"
+    "- `/workspace/artifacts/` AI writes all output here\n\n"
+)
+
 MCP_INTEGRATIONS_PROMPT = (
     "## MCP Integrations\n"
     "If you need Google Drive access: Ask user to go to Integrations page "
@@ -124,6 +131,7 @@ def build_workspace_context_prompt(
         Formatted prompt string.
     """
     prompt = WORKSPACE_STRUCTURE_HEADER
+    prompt += WORKSPACE_FIXED_PATHS_PROMPT
 
     # Workflow directory
     if workflow_name:


### PR DESCRIPTION
## Summary
- Adds explicit ACP session workspace paths to the runner system prompt
- AI will now always know fixed paths for uploads, repos, and artifacts without searching

## Change
```
**ACP Session Workspace Paths** (use directly, never search):
- `/workspace/file-uploads/` user uploads
- `/workspace/repos/<name>/` git repositories added to context by user
- `/workspace/artifacts/` AI writes all output here
```

## Test plan
- [ ] Deploy runner locally and verify prompt includes new paths
- [ ] Start a session and confirm AI uses paths directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)