### PR TITLE
RHOAIENG-51481: switch pull_request_target to pull_request

### DIFF
--- a/.github/workflows/amber-auto-review.yml
+++ b/.github/workflows/amber-auto-review.yml
@@ -9,11 +9,12 @@
 name: Amber Automatic Code Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 jobs:
   amber-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,11 +31,9 @@ jobs:
           fetch-depth: 1
           path: base-ref
 
-      - name: Checkout PR head
+      - name: Checkout PR code
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Determine command file path (security)

--- a/.github/workflows/claude-live-test.yml
+++ b/.github/workflows/claude-live-test.yml
@@ -5,7 +5,7 @@ name: Claude Live Testing
 # Claude will test the feature with browser automation and provide reports
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
     branches: [ main, master ]
 
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   # Security check - only proceed if claude-test label was added
   check-label:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}

--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -12,7 +12,7 @@ on:
       - 'components/frontend/**'
       - 'components/public-api/**'
       - 'components/ambient-api-server/**'
-  pull_request_target:
+  pull_request:
     branches: [main]
     paths:
       - '.github/workflows/components-build-deploy.yml'
@@ -42,6 +42,7 @@ concurrency:
 
 jobs:
   detect-changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -166,13 +167,13 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build ${{ matrix.component.name }} image for pull requests but don't push
-        if: (matrix.component.changed == 'true' || github.event.inputs.force_build_all == 'true' || contains(github.event.inputs.components, matrix.component.name)) && github.event_name == 'pull_request_target'
+        if: (matrix.component.changed == 'true' || github.event.inputs.force_build_all == 'true' || contains(github.event.inputs.components, matrix.component.name)) && github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.component.context }}
           file: ${{ matrix.component.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: false
           tags: ${{ matrix.component.image }}:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ name: E2E Tests
 # Maintainers: Review PR code before adding label!
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
     branches: [ main, master ]
 
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   # Security check - only proceed if safe-to-test label was added
   check-label:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}

--- a/scripts/validate-amber-workflows.sh
+++ b/scripts/validate-amber-workflows.sh
@@ -94,10 +94,10 @@ echo "Test 4: Workflow Trigger Validation"
 echo "------------------------------------"
 
 # amber-auto-review should trigger on PR events
-if grep -q "pull_request_target:" ".github/workflows/amber-auto-review.yml"; then
-    report_test 0 "amber-auto-review triggers on pull_request_target"
+if grep -q "pull_request:" ".github/workflows/amber-auto-review.yml"; then
+    report_test 0 "amber-auto-review triggers on pull_request"
 else
-    report_test 1 "amber-auto-review missing pull_request_target trigger"
+    report_test 1 "amber-auto-review missing pull_request trigger"
 fi
 
 # amber-issue-handler should have proper label/comment filtering


### PR DESCRIPTION
External contributors disclosed vulnerabilities in our `pull_request_target` workflows. Switching to `pull_request` prevents untrusted fork code from running with access to repository secrets.

Leave the dependabot-auto-merge workflow unchanged, because it checks `github.actor` as a guard and never checks out code.

Once we merge this, these workflows will no longer act on forks.

```
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
```

Fixes: #749 

https://issues.redhat.com/browse/RHOAIENG-51481