### PR TITLE
fix(ambient-api-server): rename Go module path to match GitHub org

### DIFF
--- a/components/ambient-api-server/CLAUDE.md
+++ b/components/ambient-api-server/CLAUDE.md
@@ -76,7 +76,7 @@ go run ./scripts/generator.go \
   --kind YourKind \
   --fields "name:string:required,description:string,priority:int" \
   --project ambient-api-server \
-  --repo github.com/ambient/platform/components \
+  --repo github.com/ambient-code/platform/components \
   --library github.com/openshift-online/rh-trex-ai
 ```
 

--- a/components/ambient-api-server/Makefile
+++ b/components/ambient-api-server/Makefile
@@ -6,7 +6,7 @@ git_sha:=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 git_dirty:=$(shell git diff --quiet 2>/dev/null || echo "-modified")
 build_version:=$(git_sha)$(git_dirty)
 build_time:=$(shell date -u '+%Y-%m-%d %H:%M:%S UTC')
-ldflags=-X github.com/ambient/platform/components/ambient-api-server/pkg/api.Version=$(build_version) -X 'github.com/ambient/platform/components/ambient-api-server/pkg/api.BuildTime=$(build_time)'
+ldflags=-X github.com/ambient-code/platform/components/ambient-api-server/pkg/api.Version=$(build_version) -X 'github.com/ambient-code/platform/components/ambient-api-server/pkg/api.BuildTime=$(build_time)'
 
 .PHONY: binary
 binary:

--- a/components/ambient-api-server/README.md
+++ b/components/ambient-api-server/README.md
@@ -35,7 +35,7 @@ To create your first Kind:
 
 ```bash
 # Generate a HelloWorld Kind with a Message attribute
-go run ./scripts/generator.go --kind HelloWorld --fields "message:string:required" --project "ambient-api-server" --repo "github.com/ambient/platform/components"
+go run ./scripts/generator.go --kind HelloWorld --fields "message:string:required" --project "ambient-api-server" --repo "github.com/ambient-code/platform/components"
 
 ```
 

--- a/components/ambient-api-server/cmd/ambient-api-server/main.go
+++ b/components/ambient-api-server/cmd/ambient-api-server/main.go
@@ -3,21 +3,21 @@ package main
 import (
 	"github.com/golang/glog"
 
-	localapi "github.com/ambient/platform/components/ambient-api-server/pkg/api"
+	localapi "github.com/ambient-code/platform/components/ambient-api-server/pkg/api"
 	pkgcmd "github.com/openshift-online/rh-trex-ai/pkg/cmd"
 
-	_ "github.com/ambient/platform/components/ambient-api-server/cmd/ambient-api-server/environments"
-	_ "github.com/ambient/platform/components/ambient-api-server/pkg/middleware"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/cmd/ambient-api-server/environments"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/pkg/middleware"
 
 	// Core plugins from upstream
 	_ "github.com/openshift-online/rh-trex-ai/plugins/events"
 	_ "github.com/openshift-online/rh-trex-ai/plugins/generic"
 
 	// Backend-compatible plugins only
-	_ "github.com/ambient/platform/components/ambient-api-server/plugins/projectSettings"
-	_ "github.com/ambient/platform/components/ambient-api-server/plugins/projects"
-	_ "github.com/ambient/platform/components/ambient-api-server/plugins/sessions"
-	_ "github.com/ambient/platform/components/ambient-api-server/plugins/users"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/plugins/projectSettings"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/plugins/projects"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/plugins/sessions"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/plugins/users"
 )
 
 func main() {

--- a/components/ambient-api-server/docs/code-generation.md
+++ b/components/ambient-api-server/docs/code-generation.md
@@ -9,7 +9,7 @@ go run ./scripts/generator.go \
   --kind HelloWorld \
   --fields "message:string:required,priority:int,active:bool" \
   --project ambient-api-server \
-  --repo github.com/ambient/platform/components \
+  --repo github.com/ambient-code/platform/components \
   --library github.com/openshift-online/rh-trex-ai
 ```
 
@@ -20,7 +20,7 @@ go run ./scripts/generator.go \
 | `--kind` | `Asteroid` | PascalCase Kind name (e.g., `HelloWorld`) |
 | `--fields` | `""` | Comma-separated `name:type[:required\|optional]` |
 | `--project` | `ambient-api-server` | Project directory name |
-| `--repo` | `github.com/ambient/platform/components` | Module path prefix |
+| `--repo` | `github.com/ambient-code/platform/components` | Module path prefix |
 | `--library` | `github.com/openshift-online/rh-trex-ai` | rh-trex-ai module path |
 | `--plural` | auto | Override auto-pluralization |
 | `--skip-generate` | false | Skip `make generate` after code gen |
@@ -66,7 +66,7 @@ For a Kind named `HelloWorld` (pluralized to `helloWorlds`):
 | `{{.KindSnakeCasePlural}}` | `hello_worlds` | snake_case plural (URL path, table name) |
 | `{{.Project}}` | `ambient-api-server` | Project name |
 | `{{.ProjectPascalCase}}` | `AmbientApiServer` | Project in PascalCase |
-| `{{.Repo}}` | `github.com/ambient/platform/components` | Repository path |
+| `{{.Repo}}` | `github.com/ambient-code/platform/components` | Repository path |
 | `{{.Library}}` | `github.com/openshift-online/rh-trex-ai` | Framework library path |
 | `{{.Cmd}}` | `ambient-api-server` | Command directory name |
 | `{{.ID}}` | `202602141530` | Migration ID (timestamp) |

--- a/components/ambient-api-server/go.mod
+++ b/components/ambient-api-server/go.mod
@@ -1,4 +1,4 @@
-module github.com/ambient/platform/components/ambient-api-server
+module github.com/ambient-code/platform/components/ambient-api-server
 
 go 1.24.0
 

--- a/components/ambient-api-server/pkg/api/grpc/grpcutil.go
+++ b/components/ambient-api-server/pkg/api/grpc/grpcutil.go
@@ -1,7 +1,7 @@
 package grpc
 
 import (
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 )
 

--- a/components/ambient-api-server/plugins/projectSettings/factory_test.go
+++ b/components/ambient-api-server/plugins/projectSettings/factory_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ambient/platform/components/ambient-api-server/plugins/projectSettings"
-	"github.com/ambient/platform/components/ambient-api-server/plugins/projects"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/projectSettings"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/projects"
 	"github.com/openshift-online/rh-trex-ai/pkg/environments"
 )
 

--- a/components/ambient-api-server/plugins/projectSettings/grpc_handler.go
+++ b/components/ambient-api-server/plugins/projectSettings/grpc_handler.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api"
-	localgrpc "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc"
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api"
+	localgrpc "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/openshift-online/rh-trex-ai/pkg/server"
 	"github.com/openshift-online/rh-trex-ai/pkg/server/grpcutil"
 	"github.com/openshift-online/rh-trex-ai/pkg/services"

--- a/components/ambient-api-server/plugins/projectSettings/grpc_integration_test.go
+++ b/components/ambient-api-server/plugins/projectSettings/grpc_integration_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestProjectSettingsGRPCCrud(t *testing.T) {

--- a/components/ambient-api-server/plugins/projectSettings/grpc_presenter.go
+++ b/components/ambient-api-server/plugins/projectSettings/grpc_presenter.go
@@ -1,7 +1,7 @@
 package projectSettings
 
 import (
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/components/ambient-api-server/plugins/projectSettings/handler.go
+++ b/components/ambient-api-server/plugins/projectSettings/handler.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/errors"
 	"github.com/openshift-online/rh-trex-ai/pkg/handlers"

--- a/components/ambient-api-server/plugins/projectSettings/integration_test.go
+++ b/components/ambient-api-server/plugins/projectSettings/integration_test.go
@@ -9,8 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/resty.v1"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestProjectSettingsGet(t *testing.T) {

--- a/components/ambient-api-server/plugins/projectSettings/plugin.go
+++ b/components/ambient-api-server/plugins/projectSettings/plugin.go
@@ -3,7 +3,7 @@ package projectSettings
 import (
 	"net/http"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/gorilla/mux"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"

--- a/components/ambient-api-server/plugins/projectSettings/presenter.go
+++ b/components/ambient-api-server/plugins/projectSettings/presenter.go
@@ -1,7 +1,7 @@
 package projectSettings
 
 import (
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/util"

--- a/components/ambient-api-server/plugins/projectSettings/testmain_test.go
+++ b/components/ambient-api-server/plugins/projectSettings/testmain_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestMain(m *testing.M) {

--- a/components/ambient-api-server/plugins/projects/factory_test.go
+++ b/components/ambient-api-server/plugins/projects/factory_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ambient/platform/components/ambient-api-server/plugins/projects"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/projects"
 	"github.com/openshift-online/rh-trex-ai/pkg/environments"
 )
 

--- a/components/ambient-api-server/plugins/projects/grpc_handler.go
+++ b/components/ambient-api-server/plugins/projects/grpc_handler.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api"
-	localgrpc "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc"
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api"
+	localgrpc "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/openshift-online/rh-trex-ai/pkg/server"
 	"github.com/openshift-online/rh-trex-ai/pkg/server/grpcutil"
 	"github.com/openshift-online/rh-trex-ai/pkg/services"

--- a/components/ambient-api-server/plugins/projects/grpc_integration_test.go
+++ b/components/ambient-api-server/plugins/projects/grpc_integration_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestProjectGRPCCrud(t *testing.T) {

--- a/components/ambient-api-server/plugins/projects/grpc_presenter.go
+++ b/components/ambient-api-server/plugins/projects/grpc_presenter.go
@@ -1,7 +1,7 @@
 package projects
 
 import (
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/components/ambient-api-server/plugins/projects/handler.go
+++ b/components/ambient-api-server/plugins/projects/handler.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/errors"
 	"github.com/openshift-online/rh-trex-ai/pkg/handlers"

--- a/components/ambient-api-server/plugins/projects/integration_test.go
+++ b/components/ambient-api-server/plugins/projects/integration_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/resty.v1"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
-	"github.com/ambient/platform/components/ambient-api-server/plugins/projects"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/projects"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 	"github.com/openshift-online/rh-trex-ai/pkg/environments"
 )
 

--- a/components/ambient-api-server/plugins/projects/plugin.go
+++ b/components/ambient-api-server/plugins/projects/plugin.go
@@ -3,7 +3,7 @@ package projects
 import (
 	"net/http"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/gorilla/mux"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"

--- a/components/ambient-api-server/plugins/projects/presenter.go
+++ b/components/ambient-api-server/plugins/projects/presenter.go
@@ -1,7 +1,7 @@
 package projects
 
 import (
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/util"

--- a/components/ambient-api-server/plugins/projects/testmain_test.go
+++ b/components/ambient-api-server/plugins/projects/testmain_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestMain(m *testing.M) {

--- a/components/ambient-api-server/plugins/sessions/factory_test.go
+++ b/components/ambient-api-server/plugins/sessions/factory_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ambient/platform/components/ambient-api-server/plugins/sessions"
-	"github.com/ambient/platform/components/ambient-api-server/plugins/users"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/sessions"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/users"
 	"github.com/openshift-online/rh-trex-ai/pkg/environments"
 )
 

--- a/components/ambient-api-server/plugins/sessions/grpc_handler.go
+++ b/components/ambient-api-server/plugins/sessions/grpc_handler.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api"
-	localgrpc "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc"
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api"
+	localgrpc "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/openshift-online/rh-trex-ai/pkg/auth"
 	"github.com/openshift-online/rh-trex-ai/pkg/server"
 	"github.com/openshift-online/rh-trex-ai/pkg/server/grpcutil"

--- a/components/ambient-api-server/plugins/sessions/grpc_integration_test.go
+++ b/components/ambient-api-server/plugins/sessions/grpc_integration_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestSessionGRPCCrud(t *testing.T) {

--- a/components/ambient-api-server/plugins/sessions/grpc_presenter.go
+++ b/components/ambient-api-server/plugins/sessions/grpc_presenter.go
@@ -1,7 +1,7 @@
 package sessions
 
 import (
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/components/ambient-api-server/plugins/sessions/handler.go
+++ b/components/ambient-api-server/plugins/sessions/handler.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/auth"
 	"github.com/openshift-online/rh-trex-ai/pkg/errors"

--- a/components/ambient-api-server/plugins/sessions/integration_test.go
+++ b/components/ambient-api-server/plugins/sessions/integration_test.go
@@ -11,9 +11,9 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/resty.v1"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
-	"github.com/ambient/platform/components/ambient-api-server/plugins/sessions"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/sessions"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 	"github.com/openshift-online/rh-trex-ai/pkg/environments"
 )
 

--- a/components/ambient-api-server/plugins/sessions/plugin.go
+++ b/components/ambient-api-server/plugins/sessions/plugin.go
@@ -3,7 +3,7 @@ package sessions
 import (
 	"net/http"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/gorilla/mux"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"

--- a/components/ambient-api-server/plugins/sessions/presenter.go
+++ b/components/ambient-api-server/plugins/sessions/presenter.go
@@ -1,7 +1,7 @@
 package sessions
 
 import (
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/util"

--- a/components/ambient-api-server/plugins/sessions/testmain_test.go
+++ b/components/ambient-api-server/plugins/sessions/testmain_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestMain(m *testing.M) {

--- a/components/ambient-api-server/plugins/users/factory_test.go
+++ b/components/ambient-api-server/plugins/users/factory_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ambient/platform/components/ambient-api-server/plugins/users"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/users"
 	"github.com/openshift-online/rh-trex-ai/pkg/environments"
 )
 

--- a/components/ambient-api-server/plugins/users/grpc_handler.go
+++ b/components/ambient-api-server/plugins/users/grpc_handler.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api"
-	localgrpc "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc"
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api"
+	localgrpc "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/openshift-online/rh-trex-ai/pkg/server"
 	"github.com/openshift-online/rh-trex-ai/pkg/server/grpcutil"
 	"github.com/openshift-online/rh-trex-ai/pkg/services"

--- a/components/ambient-api-server/plugins/users/grpc_integration_test.go
+++ b/components/ambient-api-server/plugins/users/grpc_integration_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestUserGRPCCrud(t *testing.T) {

--- a/components/ambient-api-server/plugins/users/grpc_presenter.go
+++ b/components/ambient-api-server/plugins/users/grpc_presenter.go
@@ -1,7 +1,7 @@
 package users
 
 import (
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/components/ambient-api-server/plugins/users/handler.go
+++ b/components/ambient-api-server/plugins/users/handler.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/errors"
 	"github.com/openshift-online/rh-trex-ai/pkg/handlers"

--- a/components/ambient-api-server/plugins/users/integration_test.go
+++ b/components/ambient-api-server/plugins/users/integration_test.go
@@ -9,8 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/resty.v1"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestUserGet(t *testing.T) {

--- a/components/ambient-api-server/plugins/users/plugin.go
+++ b/components/ambient-api-server/plugins/users/plugin.go
@@ -3,7 +3,7 @@ package users
 import (
 	"net/http"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
 	"github.com/gorilla/mux"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"

--- a/components/ambient-api-server/plugins/users/presenter.go
+++ b/components/ambient-api-server/plugins/users/presenter.go
@@ -1,7 +1,7 @@
 package users
 
 import (
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
 	"github.com/openshift-online/rh-trex-ai/pkg/util"

--- a/components/ambient-api-server/plugins/users/testmain_test.go
+++ b/components/ambient-api-server/plugins/users/testmain_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 )
 
 func TestMain(m *testing.M) {

--- a/components/ambient-api-server/proto/ambient/v1/common.proto
+++ b/components/ambient-api-server/proto/ambient/v1/common.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ambient.v1;
 
-option go_package = "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
+option go_package = "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/components/ambient-api-server/proto/ambient/v1/project_settings.proto
+++ b/components/ambient-api-server/proto/ambient/v1/project_settings.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ambient.v1;
 
-option go_package = "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
+option go_package = "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
 
 import "ambient/v1/common.proto";
 

--- a/components/ambient-api-server/proto/ambient/v1/projects.proto
+++ b/components/ambient-api-server/proto/ambient/v1/projects.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ambient.v1;
 
-option go_package = "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
+option go_package = "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
 
 import "ambient/v1/common.proto";
 

--- a/components/ambient-api-server/proto/ambient/v1/sessions.proto
+++ b/components/ambient-api-server/proto/ambient/v1/sessions.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ambient.v1;
 
-option go_package = "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
+option go_package = "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
 
 import "ambient/v1/common.proto";
 import "google/protobuf/timestamp.proto";

--- a/components/ambient-api-server/proto/ambient/v1/users.proto
+++ b/components/ambient-api-server/proto/ambient/v1/users.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ambient.v1;
 
-option go_package = "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
+option go_package = "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1";
 
 import "ambient/v1/common.proto";
 

--- a/components/ambient-api-server/scripts/generator.go
+++ b/components/ambient-api-server/scripts/generator.go
@@ -29,7 +29,7 @@ TODO: all of it can be better
 
 var (
 	kind                        = "Asteroid"
-	repo                        = "github.com/ambient/platform/components"
+	repo                        = "github.com/ambient-code/platform/components"
 	project                     = "ambient-api-server"
 	fields                      = ""
 	plural                      = ""
@@ -49,7 +49,7 @@ func init() {
 	flags.AddGoFlagSet(flag.CommandLine)
 
 	flags.StringVar(&kind, "kind", kind, "the name of the kind.  e.g Account or User")
-	flags.StringVar(&repo, "repo", repo, "the module path of the repo (e.g. github.com/ambient/platform/components)")
+	flags.StringVar(&repo, "repo", repo, "the module path of the repo (e.g. github.com/ambient-code/platform/components)")
 	flags.StringVar(&project, "project", project, "the name of the project.  e.g ambient-api-server")
 	flags.StringVar(&fields, "fields", fields, "comma-separated list of custom fields in format name:type (e.g. 'name:string,age:int,active:bool')")
 	flags.StringVar(&plural, "plural", plural, "the plural form of the kind. If not provided, uses irregular plurals map or adds 's'")

--- a/components/ambient-api-server/test/example/main.go
+++ b/components/ambient-api-server/test/example/main.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	pb "github.com/ambient/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
-	openapi "github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	pb "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/grpc/ambient/v1"
+	openapi "github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )

--- a/components/ambient-api-server/test/helper.go
+++ b/components/ambient-api-server/test/helper.go
@@ -14,9 +14,9 @@ import (
 
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 
-	"github.com/ambient/platform/components/ambient-api-server/cmd/ambient-api-server/environments"
-	localapi "github.com/ambient/platform/components/ambient-api-server/pkg/api"
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/cmd/ambient-api-server/environments"
+	localapi "github.com/ambient-code/platform/components/ambient-api-server/pkg/api"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	pkgserver "github.com/openshift-online/rh-trex-ai/pkg/server"
 	"github.com/openshift-online/rh-trex-ai/pkg/testutil"
 )

--- a/components/ambient-api-server/test/integration/integration_test.go
+++ b/components/ambient-api-server/test/integration/integration_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/ambient/platform/components/ambient-api-server/test"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
 
 	// Backend-compatible plugins only
-	_ "github.com/ambient/platform/components/ambient-api-server/plugins/projectSettings"
-	_ "github.com/ambient/platform/components/ambient-api-server/plugins/projects"
-	_ "github.com/ambient/platform/components/ambient-api-server/plugins/sessions"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/plugins/projectSettings"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/plugins/projects"
+	_ "github.com/ambient-code/platform/components/ambient-api-server/plugins/sessions"
 	_ "github.com/openshift-online/rh-trex-ai/plugins/events"
 	_ "github.com/openshift-online/rh-trex-ai/plugins/generic"
 )

--- a/components/ambient-api-server/test/registration.go
+++ b/components/ambient-api-server/test/registration.go
@@ -5,7 +5,7 @@ import (
 
 	gm "github.com/onsi/gomega"
 
-	"github.com/ambient/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 )
 
 func RegisterIntegration(t *testing.T) (*Helper, *openapi.APIClient) {


### PR DESCRIPTION
## Summary

The `ambient-api-server` Go module path is declared as `github.com/ambient/platform/components/ambient-api-server`, but the actual GitHub repository is `github.com/ambient-code/platform`. This mismatch means:

- `go get github.com/ambient-code/platform/components/ambient-api-server/...` **fails** because Go resolves the module path literally and `github.com/ambient/platform` does not exist as a repository
- Any external consumer (SDK, CLI, control-plane) that tries to import the gRPC proto package or any other package from this module via the real GitHub URL cannot resolve the dependency
- The SDK's `go.mod` currently works only via local `replace` directives, masking this bug — but it will break the moment anyone removes the replace or tries to consume this module from a clean environment

## Changes

Renames **all** Go module references from `github.com/ambient/platform` → `github.com/ambient-code/platform` across:

- `go.mod` module declaration
- 46 `.go` source files (imports)
- 5 `.proto` files (`go_package` option)
- `Makefile` (ldflags)
- Documentation (`CLAUDE.md`, `README.md`, `docs/code-generation.md`)

**53 files changed**, mechanical find-and-replace with no logic changes.

### Note on generated .pb.go files

The generated `.pb.go` files contain the old `go_package` path embedded in their raw protobuf descriptor byte strings. These are **binary wire-format data** and must not be text-replaced — doing so corrupts the descriptor and causes a runtime panic. The `.proto` source files have been updated, so the next `protoc` regeneration will produce correct descriptors. The Go protobuf runtime resolves package paths via `reflect.TypeOf(x{}).PkgPath()`, not from the descriptor, so this is safe at runtime.

## Downstream impact

This is a **breaking change** for any module that imports `github.com/ambient/platform/components/ambient-api-server/...`. The following components will need matching updates:

 < /dev/null |  Component | Branch | Agent |
|-----------|--------|-------|
| `ambient-sdk` (go-sdk) | `feat/ambient-sdk` | SDK |
| `ambient-cli` | `feat/ambient-cli` | CLI |
| `ambient-control-plane` | `feat/ambient-control-plane` | CP |

These components should update their imports and `replace` directives after this PR merges.

## Test plan

- [x] `go build ./...` — clean
- [x] `go fmt ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — clean
- [x] 81 tests passing (21 middleware + 60 integration)