### PR TITLE
RHOAIENG-51600: Document where to find Vertex AI service account key

### DIFF
--- a/docs/internal/developer/local-development/kind.md
+++ b/docs/internal/developer/local-development/kind.md
@@ -192,6 +192,10 @@ make kind-up LOCAL_VERTEX=true
 **Default credentials:** `~/.config/gcloud/application_default_credentials.json`
 (Created by `gcloud auth application-default login`)
 
+**Service account key (Ambient Code Support team):** Download
+`ambient-code-key.json` from the "Ambient Code Support" collection in
+Bitwarden.
+
 **Override credentials path:**
 ```bash
 make kind-up LOCAL_VERTEX=true GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json


### PR DESCRIPTION
## Summary
- Add a note to the kind local development docs pointing developers to the service account key in Bitwarden
- Previously there was no documentation for where to obtain this file — it was passed along as tribal knowledge

Fixes https://issues.redhat.com/browse/RHOAIENG-51600