### PR TITLE
RHOAIENG-51548: fix: replace dev-* Makefile targets with local-*

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -39,19 +39,20 @@ components/
 
 ### Local Development (Recommended)
 ```bash
-# Single command to start everything
-make dev-start
+# Single command to start everything (minikube)
+make local-up
+
+# Or use Kind (recommended for most development)
+make kind-up
 ```
 
 **Prerequisites:**
-- Minikube: `brew install minikube`
-- Red Hat pull secret: Get free from [console.redhat.com](https://console.redhat.com/openshift/create/local)
+- Minikube (`brew install minikube`) or Kind (`brew install kind`) + Docker
 
 **What you get:**
-- ✅ Complete OpenShift development environment
-- ✅ Frontend: `https://vteam-frontend-vteam-dev.apps-crc.testing`
+- ✅ Complete local development environment
+- ✅ Frontend and backend accessible via localhost
 - ✅ Backend API working with authentication
-- ✅ OpenShift console access
 - ✅ Ready for project creation and agentic sessions
 
 ### Production Deployment
@@ -65,13 +66,12 @@ cd components/manifests
 CONTAINER_REGISTRY=$REGISTRY ./deploy.sh
 ```
 
-### Hot Reloading Development
+### Rebuild Components
 ```bash
-# Terminal 1: Start with development mode
-DEV_MODE=true make dev-start
-
-# Terminal 2: Enable file sync for hot-reloading
-make dev-sync
+make local-rebuild           # Rebuild and reload all components
+make local-reload-backend    # Rebuild and reload backend only
+make local-reload-frontend   # Rebuild and reload frontend only
+make local-reload-operator   # Rebuild and reload operator only
 ```
 
 ## Quick Deploy

--- a/components/frontend/README.md
+++ b/components/frontend/README.md
@@ -34,11 +34,12 @@ go run .
 
 ### Frontend (local) quick start
 
-**Recommended: Use integrated CRC development environment:**
+**Recommended: Use integrated local development environment:**
 ```bash
 # From repository root - single command setup
-make dev-start
-# Access: https://vteam-frontend-vteam-dev.apps-crc.testing
+make local-up    # minikube
+# Or: make kind-up  # kind (recommended)
+# Access: http://localhost:8080
 ```
 
 **Alternative: Standalone frontend development:**

--- a/components/manifests/README.md
+++ b/components/manifests/README.md
@@ -84,7 +84,7 @@ cd e2e
 
 **Deploy**:
 ```bash
-make dev-start
+make local-up
 ```
 
 ## How It Works

--- a/docs/internal/architecture/diagrams/component-structure.mmd
+++ b/docs/internal/architecture/diagrams/component-structure.mmd
@@ -18,8 +18,8 @@ graph LR
     end
 
     subgraph "Development Commands"
-        DevStart[make dev-start<br/>🚀 Complete Stack]
-        DevSync[make dev-sync<br/>♻️ Hot Reloading]
+        LocalUp[make local-up<br/>🚀 Complete Stack]
+        LocalRebuild[make local-rebuild<br/>♻️ Rebuild & Reload]
         Deploy[make deploy<br/>📦 Production]
         BuildPush[make build-all push-all<br/>🏗️ Container Images]
     end
@@ -36,11 +36,11 @@ graph LR
     end
 
     %% Development flow
-    DevStart --> Local
+    LocalUp --> Local
     Local --> FrontendURL
     Local --> BackendAPI
     Local --> Console
-    DevSync -.->|File Sync| Local
+    LocalRebuild -.->|Rebuild & Reload| Local
 
     %% Production flow
     BuildPush --> Prod
@@ -64,6 +64,6 @@ graph LR
 
     class Frontend,Backend,Operator,Manifests component
     class ClaudeRunner runner
-    class DevStart,DevSync,Deploy,BuildPush command
+    class LocalUp,LocalRebuild,Deploy,BuildPush command
     class Local,Prod env
     class FrontendURL,BackendAPI,Console access

--- a/docs/internal/architecture/diagrams/deployment-stack.mmd
+++ b/docs/internal/architecture/diagrams/deployment-stack.mmd
@@ -9,8 +9,8 @@ graph TD
         subgraph "Local Development"
             MK[Minikube]
             CRC[OpenShift Local/CRC]
-            DevCmd[make dev-start]
-            HotReload[DEV_MODE=true<br/>make dev-sync]
+            LocalUp[make local-up]
+            LocalRebuild[make local-rebuild<br/>♻️ Rebuild & Reload]
         end
 
         subgraph "Production"
@@ -83,9 +83,9 @@ graph TD
     end
 
     %% Relationships
-    DevCmd --> MK
-    DevCmd --> CRC
-    HotReload --> CRC
+    LocalUp --> MK
+    LocalUp --> CRC
+    LocalRebuild --> CRC
     ProdCmd --> OCP
     ProdCmd --> K8sCluster
 
@@ -118,7 +118,7 @@ graph TD
     classDef infra fill:#e9d5ff,stroke:#a855f7,stroke-width:2px,color:#581c87
     classDef prereq fill:#fee2e2,stroke:#ef4444,stroke-width:2px,color:#7f1d1d
 
-    class MK,CRC,DevCmd,HotReload dev
+    class MK,CRC,LocalUp,LocalRebuild dev
     class OCP,K8sCluster,Registry,ProdCmd prod
     class Next,Shadcn,TS1,React,TW,Go1,Gin,K8sClient,OIDC,Go2,OperatorSDK,Controller,Python,Claude,MCP,Playwright tech
     class CRD,Jobs,Pods,Services,Routes,CR2,ConfigMaps,Secrets,PVC,OAuth,RBAC,SA,NetPol infra

--- a/docs/internal/developer/local-development/README.md
+++ b/docs/internal/developer/local-development/README.md
@@ -109,8 +109,7 @@ make kind-down
 
 **Quick Start:**
 ```bash
-make dev-start
-# Access at https://vteam-frontend-vteam-dev.apps-crc.testing
+make local-up    # Note: CRC dev-* targets have been replaced with local-* equivalents
 ```
 
 **Full Guide:** [crc.md](crc.md)
@@ -228,7 +227,7 @@ make test-e2e
 ### Need OpenShift-Specific Features?
 Use **CRC** only if you need Routes, BuildConfigs, etc:
 ```bash
-make dev-start  # CRC-based
+make local-up  # Local dev (minikube-based)
 ```
 
 ### Need to Debug with Breakpoints?

--- a/docs/internal/developer/local-development/crc.md
+++ b/docs/internal/developer/local-development/crc.md
@@ -27,7 +27,7 @@ brew install crc
 
 ### 2. Start Development Environment
 ```bash
-make dev-start
+make local-up
 ```
 *First run: ~5-10 minutes. Subsequent runs: ~2-3 minutes.*
 
@@ -38,37 +38,37 @@ make dev-start
 
 ### 4. Verify Everything Works
 ```bash
-make dev-test  # Should show 11/12 tests passing
+make local-test
 ```
 
 ## Hot-Reloading Development
 
 ```bash
-# Terminal 1: Start with development mode
-DEV_MODE=true make dev-start
+# Start local environment
+make local-up
 
-# Terminal 2: Enable file sync
-make dev-sync
+# Rebuild components after changes
+make local-rebuild
 ```
 
 ## Essential Commands
 
 ```bash
 # Day-to-day workflow
-make dev-start          # Start environment
-make dev-test           # Run tests
-make dev-stop           # Stop (keep CRC running)
-make dev-clean          # Full cleanup
+make local-up              # Start environment
+make local-test            # Run tests
+make local-down            # Stop (keep cluster running)
+make local-clean           # Full cleanup
 
 # Logs
-make dev-logs           # All logs
-make dev-logs-backend   # Backend only
-make dev-logs-frontend  # Frontend only
-make dev-logs-operator  # Operator only
+make local-logs            # All logs
+make local-logs-backend    # Backend only
+make local-logs-frontend   # Frontend only
+make local-logs-operator   # Operator only
 
-# Operator management
-make dev-restart-operator  # Restart operator
-make dev-operator-status   # Check operator status
+# Status and troubleshooting
+make local-status          # Show status of local deployment
+make local-troubleshoot    # Show troubleshooting information
 ```
 
 ## Installation Details
@@ -115,7 +115,7 @@ sudo chmod +x /usr/local/bin/crc
 3. Download pull secret
 4. Save to `~/.crc/pull-secret.json`
 
-The `make dev-start` script will automatically use this pull secret.
+The `make local-up` script will automatically use this pull secret.
 
 ## Features
 
@@ -128,7 +128,7 @@ The `make dev-start` script will automatically use this pull secret.
 
 ### ✅ Development Workflow
 - Hot-reloading with `DEV_MODE=true`
-- File sync with `make dev-sync`
+- Rebuild with `make local-rebuild`
 - Quick operator restarts
 - Component-specific log viewing
 
@@ -165,7 +165,7 @@ crc logs
 
 # Reset if needed
 crc delete
-make dev-start
+make local-up
 ```
 
 ### Pods Not Starting
@@ -216,7 +216,7 @@ crc config set memory 16384  # 16GB
 crc config set disk-size 100  # 100GB
 
 # Then start
-make dev-start
+make local-up
 ```
 
 ### Custom Registry
@@ -224,21 +224,17 @@ make dev-start
 ```bash
 # Use external registry instead of internal
 export CONTAINER_REGISTRY=quay.io/your-username
-make dev-start
+make local-up
 ```
 
 ## Cleanup
 
 ```bash
-# Stop but keep CRC running
-make dev-stop
+# Stop but keep cluster running
+make local-down
 
-# Stop and shutdown CRC
-make dev-stop-cluster
-
-# Full cleanup (deletes CRC cluster)
-make dev-clean
-crc delete
+# Full cleanup (deletes cluster)
+make local-clean
 ```
 
 ## See Also


### PR DESCRIPTION
The CRC-based dev-* targets (dev-logs, dev-start, dev-stop, etc.) were replaced with local-* equivalents in 5553056 but docs were never updated to reflect this changes.