### PR TITLE
feat(ci): add Jira ↔ GitHub sync workflow

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -357,15 +357,9 @@ jobs:
 
             ## FINAL — Summary Report
 
-            Create a single GitHub issue summarizing the run. Only create it if at least one action was taken or there are outliers. If everything was already in sync, print a one-line log to stdout and exit.
+            Print a summary report to the conversation. Use this format:
 
-            ```bash
-            gh issue create \
-              --repo ambient-code/platform \
-              --title "[Jira Sync] $(date -u +%Y-%m-%d)" \
-              --label "jira-sync" \
-              --body "## Jira ↔ GitHub Sync — $(date -u +%Y-%m-%d)
-
+            ## Jira ↔ GitHub Sync — <date>
 
             ### Phase 1 — Open PRs
             - ✅ Already in sync: N
@@ -391,8 +385,6 @@ jobs:
             | Key | Summary | Status |
             |-----|---------|--------|
             | RHOAIENG-XXXXX | ... | In Progress |
-            "
-            ```
 
             ## Error handling
 


### PR DESCRIPTION
**Jira:** [RHOAIENG-51880](https://issues.redhat.com/browse/RHOAIENG-51880)

## Summary

Adds `jira-sync.yml` — an agentic CI workflow that uses Claude Code to autonomously keep GitHub PRs, GitHub Issues, and Jira in two-way sync.

**Triggers:** daily at 8 AM UTC (weekdays) + `workflow_dispatch` + PR lifecycle events (`opened`, `ready_for_review`, `closed`)

## What it does

### Phase 1 — Open PR Health Check
- Skips: drafts, dependabot, non-contributor bots (Amber PRs treated as normal, no assignee)
- Stale check (14 days inactivity) → adds `stale` label, skips further processing
- If no Jira link in title/body → searches Jira by keywords → creates ticket if no match
- Newly created tickets added to active sprint; author mapped to Jira account where possible
- Jira key prepended to PR body (first line)
- Uses Jira **remote link API** (not body text) for two-way linking
- If Jira status is `New`/`Backlog` and PR is open → transitions to `In Progress`

### Phase 2 — Merged PR Audit (last 7 days)
- PRs with a Jira → transitions to `Resolved`, adds merge commit as Jira comment
- PRs with no Jira → noted in summary (no retroactive action)

### Phase 3 — GitHub Issue Sync (all authors)
- Issues already referencing a Jira key → skipped
- Searches Jira for match → links in issue description if found
- Creates new Jira if no match; Jira key prepended to issue description

### Phase 4 — Sprint Epic Alignment
- For each active sprint item with no epic link → keyword-matches against team epics
- Confident match → links to epic via `customfield_10014`
- No match → added to outlier list in the run summary

### Summary Report
A GitHub issue is created summarizing all actions taken and listing sprint outliers needing human triage.

## Required secrets to add

| Secret | Value |
|--------|-------|
| `JIRA_BASE_URL` | `https://issues.redhat.com` |
| `JIRA_USERNAME` | your Jira email/username |
| `JIRA_API_TOKEN` | your Jira API token |
| `JIRA_BOARD_ID` | `23005` (or leave unset, defaults to 23005) |

`CLAUDE_CODE_OAUTH_TOKEN` already exists ✅

## Test plan
- [ ] Add the 4 secrets to repo settings
- [ ] Run manually via `workflow_dispatch` on a test branch
- [ ] Verify PR bodies get Jira keys prepended correctly
- [ ] Verify Jira remote links appear on issues
- [ ] Verify sprint outlier summary is created

🤖 Generated with [Claude Code](https://claude.ai/claude-code)