### PR TITLE
feat: add CODEOWNERS file for maintainer approval requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CODEOWNERS - Code ownership and review requirements
+#
+# This file defines code ownership and review requirements for the Ambient Code Platform.
+# When "Require review from Code Owners" is enabled in the repository settings
+# (Settings > Branches > Branch protection rules), GitHub will automatically
+# require approval from the specified owners before PRs can be merged.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Pattern format:
+#   - Use gitignore-style patterns
+#   - Order matters: last matching pattern takes precedence
+#   - Use @org/team-name or @username for owners
+#
+# Future consideration:
+# When we introduce automation bots for PR approvals, we can maintain human
+# oversight on critical files while allowing bot approvals on most code:
+#
+# Example future configuration:
+#   # Default: bot can approve most files
+#   *  @ambient-bot
+#
+#   # Critical files require human maintainer approval
+#   CLAUDE.md                        @ambient-maintainers
+#   .github/CODEOWNERS               @ambient-maintainers
+#   components/manifests/base/crds/  @ambient-maintainers
+#   components/operator/             @ambient-maintainers
+#
+
+# Current configuration: All files require maintainer approval
+* @ambient-maintainers


### PR DESCRIPTION
## Summary
Add CODEOWNERS file to establish code review requirements for the Ambient Code Platform repository.

## Changes
- Creates `.github/CODEOWNERS` with `@ambient-maintainers` as required approvers for all files
- Includes documentation and examples for future bot-based approval workflows
- Documents the pattern where automated approvals could be permitted for most files while restricting critical files (CLAUDE.md, CRDs, operator code) to human maintainer oversight

## Repository Settings Required
⚠️ **This file will only take effect after enabling branch protection:**

1. Go to **Settings** > **Branches** > **Branch protection rules** for `main`
2. Enable **"Require review from Code Owners"**
3. (Optional but recommended) Enable **"Require approvals"** and set minimum number of approvals

Without this setting enabled, the CODEOWNERS file will be informational only and won't block PR merges.

## Documentation
See [GitHub CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more details on the file format and capabilities.