### PR TITLE
fix: add events read permission to project RBAC roles

### DIFF
--- a/components/manifests/base/rbac/ambient-project-admin-clusterrole.yaml
+++ b/components/manifests/base/rbac/ambient-project-admin-clusterrole.yaml
@@ -40,6 +40,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch"]
+# Events (pod event monitoring)
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
 # OpenShift Projects (read-only to list projects - OpenShift filters to only projects user has access to)
 - apiGroups: ["project.openshift.io"]
   resources: ["projects"]

--- a/components/manifests/base/rbac/ambient-project-edit-clusterrole.yaml
+++ b/components/manifests/base/rbac/ambient-project-edit-clusterrole.yaml
@@ -35,6 +35,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch"]
+# Events (pod event monitoring)
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
 # PersistentVolumeClaims (workspace storage - read access for monitoring)
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]

--- a/components/manifests/base/rbac/ambient-project-view-clusterrole.yaml
+++ b/components/manifests/base/rbac/ambient-project-view-clusterrole.yaml
@@ -21,6 +21,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch"]
+# Events (pod event monitoring)
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
 # PersistentVolumeClaims, Services, Deployments (read-only monitoring)
 - apiGroups: [""]
   resources: ["persistentvolumeclaims", "services"]

--- a/components/manifests/base/rbac/cluster-roles.yaml
+++ b/components/manifests/base/rbac/cluster-roles.yaml
@@ -15,6 +15,11 @@ rules:
     resources: ["agenticsessions"]
     verbs: ["get", "list", "watch"]
 
+  # Events (pod event monitoring)
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+
 ---
 # ClusterRole for ambient-project-edit (edit access to project resources)
 apiVersion: rbac.authorization.k8s.io/v1
@@ -36,6 +41,11 @@ rules:
     resources: ["secrets"]
     verbs: ["create", "update", "patch", "delete"]
     resourceNames: ["github-token-*", "runner-*"]
+
+  # Events (pod event monitoring)
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
 
 ---
 # ClusterRole for ambient-project-admin (admin access to project resources)
@@ -63,3 +73,8 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create", "update", "patch", "delete", "get", "list"]
+
+  # Events (pod event monitoring)
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary
- Adds `events` read access (`get`, `list`, `watch`) to `ambient-project-view`, `ambient-project-edit`, and `ambient-project-admin` ClusterRoles
- Fixes 403 error when the frontend calls `GetSessionPodEvents` — the handler uses the user's own K8s token but the RBAC roles were missing permission to list `events` in the core API group

## Test plan
- [ ] Deploy updated ClusterRoles to a cluster
- [ ] Verify a user with any project role can view pod events for a session in the frontend without a 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)