### PR TITLE
feat(operator): make default inactivity timeout configurable via env var

### DIFF
--- a/components/manifests/base/operator-deployment.yaml
+++ b/components/manifests/base/operator-deployment.yaml
@@ -115,6 +115,9 @@ spec:
           value: "http://minio.ambient-code.svc:9000"  # In-cluster MinIO (change for external S3)
         - name: S3_BUCKET
           value: "ambient-sessions"  # Create this bucket in MinIO console
+        # Inactivity auto-stop configuration
+        # - name: DEFAULT_INACTIVITY_TIMEOUT
+        #   value: "86400"  # Default inactivity timeout in seconds (24h). Set to 0 to disable.
         # OpenTelemetry configuration
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "otel-collector.ambient-code.svc:4317"  # Deploy OTel collector separately

--- a/components/operator/internal/handlers/inactivity.go
+++ b/components/operator/internal/handlers/inactivity.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -24,10 +26,6 @@ const (
 	// Stopping phase handler can distinguish inactivity from user stops.
 	stopReasonAnnotation = "ambient-code.io/stop-reason"
 
-	// defaultInactivityTimeoutSec is the fallback when neither the session
-	// nor the project specifies an inactivity timeout (24 hours).
-	defaultInactivityTimeoutSec = 86400
-
 	// inactivityTimeoutCacheTTL controls how long cached ProjectSettings
 	// timeout values are valid before re-fetching from the API server.
 	inactivityTimeoutCacheTTL = 5 * time.Minute
@@ -36,6 +34,22 @@ const (
 	// ProjectSettings CR in each namespace.
 	projectSettingsName = "projectsettings"
 )
+
+// defaultInactivityTimeoutSec is the fallback when neither the session
+// nor the project specifies an inactivity timeout. Defaults to 86400 (24 hours).
+// Override via the DEFAULT_INACTIVITY_TIMEOUT env var (value in seconds).
+var defaultInactivityTimeoutSec int64 = 86400
+
+func init() {
+	if v := os.Getenv("DEFAULT_INACTIVITY_TIMEOUT"); v != "" {
+		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil {
+			defaultInactivityTimeoutSec = parsed
+			log.Printf("[Inactivity] Default inactivity timeout set to %ds via DEFAULT_INACTIVITY_TIMEOUT", parsed)
+		} else {
+			log.Printf("[Inactivity] Invalid DEFAULT_INACTIVITY_TIMEOUT value %q, using default %ds", v, defaultInactivityTimeoutSec)
+		}
+	}
+}
 
 // --- Project-level timeout cache ---
 

--- a/components/operator/internal/handlers/inactivity_test.go
+++ b/components/operator/internal/handlers/inactivity_test.go
@@ -285,6 +285,21 @@ func TestResolveInactivityTimeout(t *testing.T) {
 		}
 	})
 
+	t.Run("default timeout respects env var override", func(t *testing.T) {
+		resetTimeoutCache()
+		setupFakeDynamicClient()
+
+		original := defaultInactivityTimeoutSec
+		defaultInactivityTimeoutSec = 7200
+		defer func() { defaultInactivityTimeoutSec = original }()
+
+		obj := newSessionObj("s1", "ns-empty")
+		got := resolveInactivityTimeout(obj)
+		if got != 7200 {
+			t.Errorf("expected 7200 (overridden default), got %d", got)
+		}
+	})
+
 	t.Run("session timeout zero overrides project and default", func(t *testing.T) {
 		resetTimeoutCache()
 


### PR DESCRIPTION
## Summary

- Make the hardcoded 24h default inactivity timeout configurable via the `DEFAULT_INACTIVITY_TIMEOUT` env var on the operator deployment (value in seconds)
- Setting to `0` disables auto-stop globally (session and project overrides still apply)
- Add commented-out env var entry to operator deployment manifest for discoverability

## Test plan

- [x] All existing inactivity tests pass (`go test -race ./internal/handlers/`)
- [x] New test verifies `resolveInactivityTimeout` respects overridden default
- [x] `golangci-lint` and `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)