### PR TITLE
feat: create model flags enabled with 100% rollout by default

### DIFF
--- a/components/backend/cmd/sync_flags.go
+++ b/components/backend/cmd/sync_flags.go
@@ -34,12 +34,14 @@ type FlagTag struct {
 }
 
 // FlagSpec describes a feature flag to sync to Unleash.
-// All flags are created disabled with type "release" and a flexibleRollout
-// strategy at 0%. Tags are optional and per-flag.
+// Flags are created with type "release" and a flexibleRollout strategy.
+// When EnabledByDefault is true, the flag is enabled in the environment
+// with 100% rollout; otherwise it is created disabled at 0%.
 type FlagSpec struct {
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Tags        []FlagTag `json:"tags,omitempty"`
+	Name             string    `json:"name"`
+	Description      string    `json:"description"`
+	Tags             []FlagTag `json:"tags,omitempty"`
+	EnabledByDefault bool      `json:"enabledByDefault,omitempty"`
 }
 
 // FlagsConfig is the JSON structure for the generic flags config file.
@@ -69,9 +71,10 @@ func FlagsFromManifest(manifest *types.ModelManifest) []FlagSpec {
 			continue
 		}
 		specs = append(specs, FlagSpec{
-			Name:        fmt.Sprintf("model.%s.enabled", model.ID),
-			Description: sanitizeLogString(fmt.Sprintf("Enable %s (%s) for users", model.Label, model.ID)),
-			Tags:        []FlagTag{{Type: "scope", Value: "workspace"}},
+			Name:             fmt.Sprintf("model.%s.enabled", model.ID),
+			Description:      sanitizeLogString(fmt.Sprintf("Enable %s (%s) for users", model.Label, model.ID)),
+			Tags:             []FlagTag{{Type: "scope", Value: "workspace"}},
+			EnabledByDefault: true,
 		})
 	}
 	return specs
@@ -307,11 +310,22 @@ func SyncFlags(ctx context.Context, flags []FlagSpec) error {
 			}
 		}
 
-		if err := addRolloutStrategy(ctx, client, adminURL, project, environment, flag.Name, adminToken); err != nil {
+		rollout := "0"
+		if flag.EnabledByDefault {
+			rollout = "100"
+		}
+		if err := addRolloutStrategy(ctx, client, adminURL, project, environment, flag.Name, rollout, adminToken); err != nil {
 			log.Printf("  WARNING: created %s but failed to add rollout strategy: %v", flag.Name, err)
 		}
 
-		log.Printf("  %s: created (disabled, 0%% rollout)", flag.Name)
+		if flag.EnabledByDefault {
+			if err := enableFlagInEnv(ctx, client, adminURL, project, environment, flag.Name, adminToken); err != nil {
+				log.Printf("  WARNING: created %s but failed to enable in %s: %v", flag.Name, environment, err)
+			}
+			log.Printf("  %s: created (enabled, 100%% rollout)", flag.Name)
+		} else {
+			log.Printf("  %s: created (disabled, 0%% rollout)", flag.Name)
+		}
 		created++
 	}
 
@@ -489,13 +503,13 @@ func addFlagTag(ctx context.Context, client *http.Client, adminURL, flagName str
 	return nil
 }
 
-func addRolloutStrategy(ctx context.Context, client *http.Client, adminURL, project, environment, flagName, token string) error {
+func addRolloutStrategy(ctx context.Context, client *http.Client, adminURL, project, environment, flagName, rollout string, token string) error {
 	reqURL := fmt.Sprintf("%s/api/admin/projects/%s/features/%s/environments/%s/strategies",
 		adminURL, url.PathEscape(project), url.PathEscape(flagName), url.PathEscape(environment))
 	body, err := json.Marshal(map[string]any{
 		"name": "flexibleRollout",
 		"parameters": map[string]string{
-			"rollout":    "0",
+			"rollout":    rollout,
 			"stickiness": "default",
 			"groupId":    flagName,
 		},
@@ -512,6 +526,25 @@ func addRolloutStrategy(ctx context.Context, client *http.Client, adminURL, proj
 	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func enableFlagInEnv(ctx context.Context, client *http.Client, adminURL, project, environment, flagName, token string) error {
+	reqURL := fmt.Sprintf("%s/api/admin/projects/%s/features/%s/environments/%s/on",
+		adminURL, url.PathEscape(project), url.PathEscape(flagName), url.PathEscape(environment))
+	resp, err := doRequest(ctx, client, "POST", reqURL, token, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("HTTP %d (failed to read body: %w)", resp.StatusCode, readErr)
+		}
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 	return nil

--- a/components/backend/cmd/sync_flags_test.go
+++ b/components/backend/cmd/sync_flags_test.go
@@ -622,3 +622,46 @@ func TestCollectTagTypes(t *testing.T) {
 		t.Error("expected 'env' in tag types")
 	}
 }
+
+// --- enableFlagInEnv ---
+
+func TestEnableFlagInEnv_Success(t *testing.T) {
+	var enablePath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && strings.Contains(r.URL.Path, "/on") {
+			enablePath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	err := enableFlagInEnv(context.Background(), server.Client(), server.URL, "default", "development", "model.test.enabled", "test-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(enablePath, "model.test.enabled") {
+		t.Errorf("expected path to contain flag name, got %s", enablePath)
+	}
+	if !strings.HasSuffix(enablePath, "/on") {
+		t.Errorf("expected path to end with /on, got %s", enablePath)
+	}
+}
+
+func TestEnableFlagInEnv_NonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	err := enableFlagInEnv(context.Background(), server.Client(), server.URL, "default", "development", "model.test.enabled", "test-token")
+	if err == nil {
+		t.Error("expected error for non-success status")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected 403 in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
[RHOAIENG-52102](https://issues.redhat.com/browse/RHOAIENG-52102)

Model flags are now created enabled in the environment with 100% rollout instead of disabled at 0%. This means newly discovered models are available to users immediately after the flag sync, rather than requiring manual enablement in the Unleash admin UI.

Add EnabledByDefault field to FlagSpec. When true, addRolloutStrategy uses 100% rollout and enableFlagInEnv toggles the flag on in the environment after creation. Non-model flags (from flags.json) retain the existing disabled/0% behavior.

Add enableFlagInEnv helper that calls POST .../environments/{env}/on. Response body is only read on error to avoid unnecessary consumption.