### PR TITLE
fix(manifests): add OpenShift TLS serving cert annotation to api-server Service

### DIFF
--- a/components/manifests/base/ambient-api-server-service.yml
+++ b/components/manifests/base/ambient-api-server-service.yml
@@ -159,6 +159,7 @@ metadata:
     component: api
   annotations:
     description: Exposes the ambient-api-server REST API
+    service.beta.openshift.io/serving-cert-secret-name: ambient-api-server-tls
 spec:
   selector:
     app: ambient-api-server


### PR DESCRIPTION
## Summary

- Adds `service.beta.openshift.io/serving-cert-secret-name: ambient-api-server-tls` annotation to the `ambient-api-server` Service
- This triggers the OpenShift service CA controller to automatically generate and rotate TLS certificates into the `ambient-api-server-tls` Secret
- Required for end-to-end HTTPS encryption between the control plane and the API server (the control plane already has `AMBIENT_API_SERVER_URL: https://...` and `AMBIENT_GRPC_USE_TLS: true` configured)

## Test plan

- [ ] Deploy to OpenShift cluster and verify `ambient-api-server-tls` Secret is created automatically
- [ ] Verify control plane can connect to api-server over HTTPS/gRPC-TLS without certificate errors

🤖 Generated with [Claude Code](https://claude.ai/code)