### PR TITLE
fix: re-apply JSON escaping in junit-summary custom_data

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -147,7 +147,7 @@ jobs:
         if: (!cancelled()) && steps.upload.outcome != 'failure'
         with:
           xml_files: '${{ env.TESTS_DIR }}/reports'
-          custom_data: '{"HTML Report": "${{ steps.upload.outputs.artifact-url }}"}'
+          custom_data: '{\"HTML Report\": \"${{ steps.upload.outputs.artifact-url }}\"}'
         continue-on-error: true
 
       - name: Publish Test Summary


### PR DESCRIPTION
Commit 4f0b0a0 ("restore workflow consolidation reverted by PR #788") re-created unit-tests.yml but lost the JSON escaping fix from 56a196e. The unescaped curly braces and quotes in the custom_data parameter break the kubeflow/pipelines junit-summary action's bash conditional, causing the "Mark Workflow failure if test reporting failed" step to fail even when all tests pass.