### PR TITLE
feat(frontend): complete UI reskin with semantic design tokens

### DIFF
--- a/components/frontend/src/app/admin/runtimes/page.tsx
+++ b/components/frontend/src/app/admin/runtimes/page.tsx
@@ -45,7 +45,7 @@ function RuntimeDetailPanel({ runtime }: { runtime: RunnerType }) {
             </div>
             <div className="flex gap-2">
               <span className="text-muted-foreground">Key logic:</span>
-              <Badge variant="outline" className="text-xs">
+              <Badge variant="outline" className="text-sm">
                 {runtime.auth?.secretKeyLogic ?? "any"}
               </Badge>
             </div>
@@ -57,14 +57,14 @@ function RuntimeDetailPanel({ runtime }: { runtime: RunnerType }) {
         </div>
         <div>
           <h4 className="text-sm font-medium mb-2">Provider</h4>
-          <Badge variant="outline" className="text-xs">
+          <Badge variant="outline" className="text-sm">
             {runtime.provider}
           </Badge>
         </div>
       </div>
       <div>
         <h4 className="text-sm font-medium mb-2">Full Configuration</h4>
-        <pre className="text-xs bg-muted rounded-md p-3 overflow-x-auto max-h-64 overflow-y-auto font-mono">
+        <pre className="text-sm bg-muted rounded-md p-3 overflow-x-auto max-h-64 overflow-y-auto font-mono">
           {configJson}
         </pre>
       </div>
@@ -227,7 +227,7 @@ function RuntimeRow({
         </TableCell>
         <TableCell>
           <div className="font-medium">{runtime.displayName}</div>
-          <div className="text-xs text-muted-foreground font-mono">{runtime.id}</div>
+          <div className="text-sm text-muted-foreground font-mono">{runtime.id}</div>
         </TableCell>
         <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
           {runtime.description || "\u2014"}

--- a/components/frontend/src/app/evaluate/page.tsx
+++ b/components/frontend/src/app/evaluate/page.tsx
@@ -159,7 +159,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Button</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">51 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">51 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -190,7 +190,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Badge</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">15 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">15 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -212,7 +212,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Input</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">18 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">18 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -231,7 +231,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Table</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">6 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">6 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -268,7 +268,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Tabs</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">4 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">4 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -300,7 +300,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Accordion</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">6 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">6 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -330,7 +330,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Select</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">4 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">4 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -356,7 +356,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Alert</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">9 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">9 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -377,7 +377,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Tooltip</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">3 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">3 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -413,7 +413,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Dropdown Menu</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">6 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">6 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -444,7 +444,7 @@ function InstalledComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Skeleton</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">2 imports</Badge>
+                <Badge variant="outline" className="text-sm font-normal">2 imports</Badge>
                 <TierBadge tier="installed" />
               </div>
             </div>
@@ -469,7 +469,7 @@ function InstalledComponentsSection() {
           <CardContent>
             <div className="flex flex-wrap gap-2">
               {["Dialog", "Form", "Checkbox", "Switch", "Label", "Textarea", "Progress", "Popover", "Separator", "Avatar", "Resizable", "Toast"].map((name) => (
-                <Badge key={name} variant="outline" className="text-xs">{name}</Badge>
+                <Badge key={name} variant="outline" className="text-sm">{name}</Badge>
               ))}
             </div>
             <div className="mt-4 space-y-3">
@@ -514,7 +514,7 @@ function ReplaceComponentsSection() {
               <TierBadge tier="replace" />
             </div>
             <CardDescription>
-              Replace custom <code className="text-xs bg-muted px-1 py-0.5 rounded">breadcrumbs.tsx</code> (153 lines) with shadcn standard.
+              Replace custom <code className="text-sm bg-muted px-1 py-0.5 rounded">breadcrumbs.tsx</code> (153 lines) with shadcn standard.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -533,7 +533,7 @@ function ReplaceComponentsSection() {
                 </BreadcrumbItem>
               </BreadcrumbList>
             </Breadcrumb>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Built-in accessibility, separator customization, and ellipsis support for deep nesting.
             </p>
           </CardContent>
@@ -573,7 +573,7 @@ function ReplaceComponentsSection() {
                 </PaginationItem>
               </PaginationContent>
             </Pagination>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Standard pagination with active state, ellipsis, and responsive labels.
             </p>
           </CardContent>
@@ -607,7 +607,7 @@ function ReplaceComponentsSection() {
                 </div>
               </CollapsibleContent>
             </Collapsible>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               No group constraints like Accordion — each section independent.
             </p>
           </CardContent>
@@ -621,7 +621,7 @@ function ReplaceComponentsSection() {
               <TierBadge tier="replace" />
             </div>
             <CardDescription>
-              Replace <code className="text-xs bg-muted px-1 py-0.5 rounded">SimpleDataTable</code> (186 lines) with TanStack Table + shadcn pattern for sorting, filtering, column visibility.
+              Replace <code className="text-sm bg-muted px-1 py-0.5 rounded">SimpleDataTable</code> (186 lines) with TanStack Table + shadcn pattern for sorting, filtering, column visibility.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -652,12 +652,12 @@ function ReplaceComponentsSection() {
               <TableBody>
                 <TableRow>
                   <TableCell className="font-medium">fix-auth-bug</TableCell>
-                  <TableCell><Badge variant="secondary" className="bg-status-success text-status-success-foreground border-0 text-xs">Running</Badge></TableCell>
+                  <TableCell><Badge variant="secondary" className="bg-status-success text-status-success-foreground border-0 text-sm">Running</Badge></TableCell>
                   <TableCell className="text-right text-muted-foreground">3m 42s</TableCell>
                 </TableRow>
               </TableBody>
             </Table>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Adds sorting, filtering, column visibility, and row selection. Requires TanStack Table dependency.
             </p>
           </CardContent>
@@ -689,7 +689,7 @@ function AddComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Sheet / Drawer</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal bg-primary/10">High Value</Badge>
+                <Badge variant="outline" className="text-sm font-normal bg-primary/10">High Value</Badge>
                 <TierBadge tier="add" />
               </div>
             </div>
@@ -736,7 +736,7 @@ function AddComponentsSection() {
                 </div>
               </SheetContent>
             </Sheet>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Accessible slide-out panel with overlay. Supports top/right/bottom/left positioning.
             </p>
           </CardContent>
@@ -748,7 +748,7 @@ function AddComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Command Palette</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal bg-primary/10">High Value</Badge>
+                <Badge variant="outline" className="text-sm font-normal bg-primary/10">High Value</Badge>
                 <TierBadge tier="add" />
               </div>
             </div>
@@ -789,8 +789,8 @@ function AddComponentsSection() {
                 </CommandGroup>
               </CommandList>
             </Command>
-            <p className="text-xs text-muted-foreground">
-              Keyboard-navigable, filterable, groupable. Built on cmdk. Supports dialog mode for <kbd className="border bg-muted px-1 rounded text-[10px]">K</kbd> shortcut.
+            <p className="text-sm text-muted-foreground">
+              Keyboard-navigable, filterable, groupable. Built on cmdk. Supports dialog mode for <kbd className="border bg-muted px-1 rounded text-sm">K</kbd> shortcut.
             </p>
           </CardContent>
         </Card>
@@ -801,7 +801,7 @@ function AddComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">HoverCard</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">Medium Value</Badge>
+                <Badge variant="outline" className="text-sm font-normal">Medium Value</Badge>
                 <TierBadge tier="add" />
               </div>
             </div>
@@ -820,19 +820,19 @@ function AddComponentsSection() {
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">
                     <h4 className="text-sm font-semibold">fix-auth-bug</h4>
-                    <Badge variant="secondary" className="bg-status-success text-status-success-foreground border-0 text-xs">Running</Badge>
+                    <Badge variant="secondary" className="bg-status-success text-status-success-foreground border-0 text-sm">Running</Badge>
                   </div>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     Fixing authentication token refresh logic in the middleware handler.
                   </p>
-                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
                     <span className="flex items-center gap-1"><Clock className="size-3" /> 3m 42s</span>
                     <span className="flex items-center gap-1"><Package className="size-3" /> claude-sonnet-4-6</span>
                   </div>
                 </div>
               </HoverCardContent>
             </HoverCard>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Hover to see details. Great for information density without clicks.
             </p>
           </CardContent>
@@ -844,7 +844,7 @@ function AddComponentsSection() {
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Sonner (Toast)</CardTitle>
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-xs font-normal">Medium Value</Badge>
+                <Badge variant="outline" className="text-sm font-normal">Medium Value</Badge>
                 <TierBadge tier="add" />
               </div>
             </div>
@@ -858,11 +858,11 @@ function AddComponentsSection() {
                 <CheckCircle2 className="size-4 text-status-success-foreground mt-0.5 shrink-0" />
                 <div className="space-y-1">
                   <p className="text-sm font-medium">Session created</p>
-                  <p className="text-xs text-muted-foreground">fix-auth-bug is now running</p>
+                  <p className="text-sm text-muted-foreground">fix-auth-bug is now running</p>
                 </div>
               </div>
             </div>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Drop-in replacement. Supports success/error/loading states, stacking, and promise-based toasts.
             </p>
           </CardContent>
@@ -946,13 +946,13 @@ function ObservationsSection() {
                 GitHub, GitLab, Jira, and Google Drive connection cards are each ~290 lines with heavy duplication.
               </p>
               <div className="flex flex-wrap gap-1">
-                <Badge variant="outline" className="text-xs">github-connection-card.tsx</Badge>
-                <Badge variant="outline" className="text-xs">gitlab-connection-card.tsx</Badge>
-                <Badge variant="outline" className="text-xs">jira-connection-card.tsx</Badge>
-                <Badge variant="outline" className="text-xs">google-drive-connection-card.tsx</Badge>
+                <Badge variant="outline" className="text-sm">github-connection-card.tsx</Badge>
+                <Badge variant="outline" className="text-sm">gitlab-connection-card.tsx</Badge>
+                <Badge variant="outline" className="text-sm">jira-connection-card.tsx</Badge>
+                <Badge variant="outline" className="text-sm">google-drive-connection-card.tsx</Badge>
               </div>
               <p className="text-muted-foreground">
-                Extract a shared <code className="bg-muted px-1 py-0.5 rounded text-xs">IntegrationCard</code> wrapper to cut ~800 lines.
+                Extract a shared <code className="bg-muted px-1 py-0.5 rounded text-sm">IntegrationCard</code> wrapper to cut ~800 lines.
               </p>
             </div>
           </CardContent>
@@ -966,11 +966,11 @@ function ObservationsSection() {
           <CardContent>
             <div className="space-y-2 text-sm text-muted-foreground">
               <div className="flex flex-wrap gap-1">
-                <Badge variant="outline" className="text-xs">message.tsx (272 lines)</Badge>
-                <Badge variant="outline" className="text-xs">tool-message.tsx (736 lines)</Badge>
-                <Badge variant="outline" className="text-xs">stream-message.tsx</Badge>
-                <Badge variant="outline" className="text-xs">thinking-message.tsx</Badge>
-                <Badge variant="outline" className="text-xs">system-message.tsx</Badge>
+                <Badge variant="outline" className="text-sm">message.tsx (272 lines)</Badge>
+                <Badge variant="outline" className="text-sm">tool-message.tsx (736 lines)</Badge>
+                <Badge variant="outline" className="text-sm">stream-message.tsx</Badge>
+                <Badge variant="outline" className="text-sm">thinking-message.tsx</Badge>
+                <Badge variant="outline" className="text-sm">system-message.tsx</Badge>
               </div>
               <p>
                 These are highly specialized chat components. Keep as-is.
@@ -1067,7 +1067,7 @@ export default function EvaluatePage() {
             <p className="text-muted-foreground">
               Evaluation of shadcn components for the Ambient Code Platform frontend.
               <br />
-              <span className="text-xs">
+              <span className="text-sm">
                 New York style &middot; neutral base &middot; OKLch colors &middot; Lucide icons &middot; Tailwind v4
               </span>
             </p>
@@ -1078,16 +1078,16 @@ export default function EvaluatePage() {
           <Tabs defaultValue="installed" className="space-y-6">
             <TabsList>
               <TabsTrigger value="installed">
-                Installed <Badge variant="outline" className="ml-1.5 text-xs h-5">30</Badge>
+                Installed <Badge variant="outline" className="ml-1.5 text-sm h-5">30</Badge>
               </TabsTrigger>
               <TabsTrigger value="replace">
-                Replace <Badge variant="destructive" className="ml-1.5 text-xs h-5">4</Badge>
+                Replace <Badge variant="destructive" className="ml-1.5 text-sm h-5">4</Badge>
               </TabsTrigger>
               <TabsTrigger value="add">
-                Add <Badge className="ml-1.5 text-xs h-5">4</Badge>
+                Add <Badge className="ml-1.5 text-sm h-5">4</Badge>
               </TabsTrigger>
               <TabsTrigger value="skip">
-                Skip <Badge variant="secondary" className="ml-1.5 text-xs h-5">8</Badge>
+                Skip <Badge variant="secondary" className="ml-1.5 text-sm h-5">8</Badge>
               </TabsTrigger>
               <TabsTrigger value="observations">
                 Observations

--- a/components/frontend/src/app/globals.css
+++ b/components/frontend/src/app/globals.css
@@ -58,131 +58,149 @@
   --color-role-edit-foreground: var(--role-edit-foreground);
   --color-role-admin: var(--role-admin);
   --color-role-admin-foreground: var(--role-admin-foreground);
+  --color-code-bg: var(--code-bg);
+  --color-code-foreground: var(--code-foreground);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 }
 
+/*
+ * Light theme — cool neutrals (slate undertone)
+ * Accents derived from spinner: blue #0066B1, purple #522DAE, red #F40000
+ */
 :root {
   --radius: 0.625rem;
-  --background: oklch(0.99 0.002 250);
-  --foreground: oklch(0.13 0.01 250);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.13 0.01 250);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.13 0.01 250);
-  --primary: oklch(0.5 0.22 264);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.965 0.003 250);
-  --secondary-foreground: oklch(0.205 0.008 250);
-  --muted: oklch(0.965 0.003 250);
-  --muted-foreground: oklch(0.556 0.005 250);
-  --accent: oklch(0.965 0.003 250);
-  --accent-foreground: oklch(0.205 0.008 250);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.91 0.005 250);
-  --input: oklch(0.91 0.005 250);
-  --ring: oklch(0.5 0.22 264);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.98 0.003 250);
-  --sidebar-foreground: oklch(0.13 0.01 250);
-  --sidebar-primary: oklch(0.5 0.22 264);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.965 0.003 250);
-  --sidebar-accent-foreground: oklch(0.205 0.008 250);
-  --sidebar-border: oklch(0.91 0.005 250);
-  --sidebar-ring: oklch(0.5 0.22 264);
+  --background: oklch(0.98 0.003 250);
+  --foreground: oklch(0.18 0.01 250);
+  --card: oklch(0.995 0.001 250);
+  --card-foreground: oklch(0.18 0.01 250);
+  --popover: oklch(0.995 0.001 250);
+  --popover-foreground: oklch(0.18 0.01 250);
+  --primary: oklch(0.48 0.18 255);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.955 0.005 250);
+  --secondary-foreground: oklch(0.25 0.008 250);
+  --muted: oklch(0.955 0.005 250);
+  --muted-foreground: oklch(0.50 0.008 250);
+  --accent: oklch(0.945 0.008 250);
+  --accent-foreground: oklch(0.22 0.008 250);
+  --destructive: oklch(0.55 0.22 25);
+  --border: oklch(0.915 0.006 250);
+  --input: oklch(0.915 0.006 250);
+  --ring: oklch(0.48 0.18 255);
+  --chart-1: oklch(0.48 0.18 255);
+  --chart-2: oklch(0.45 0.20 290);
+  --chart-3: oklch(0.55 0.22 25);
+  --chart-4: oklch(0.60 0.12 185);
+  --chart-5: oklch(0.65 0.14 145);
+  --sidebar: oklch(0.97 0.004 250);
+  --sidebar-foreground: oklch(0.18 0.01 250);
+  --sidebar-primary: oklch(0.48 0.18 255);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.945 0.008 250);
+  --sidebar-accent-foreground: oklch(0.22 0.008 250);
+  --sidebar-border: oklch(0.915 0.006 250);
+  --sidebar-ring: oklch(0.48 0.18 255);
 
-  /* Status badge semantic colors - Light theme (pastel backgrounds) */
-  --status-success: oklch(0.95 0.05 145);
-  --status-success-foreground: oklch(0.35 0.15 145);
-  --status-success-border: oklch(0.85 0.08 145);
-  --status-error: oklch(0.95 0.05 27);
-  --status-error-foreground: oklch(0.45 0.2 27);
-  --status-error-border: oklch(0.85 0.08 27);
-  --status-warning: oklch(0.95 0.1 85);
-  --status-warning-foreground: oklch(0.4 0.15 85);
-  --status-warning-border: oklch(0.85 0.12 85);
-  --status-info: oklch(0.95 0.05 240);
-  --status-info-foreground: oklch(0.45 0.15 240);
-  --status-info-border: oklch(0.85 0.08 240);
+  /* Status colors — soft pastels */
+  --status-success: oklch(0.94 0.04 150);
+  --status-success-foreground: oklch(0.35 0.12 150);
+  --status-success-border: oklch(0.86 0.06 150);
+  --status-error: oklch(0.94 0.04 25);
+  --status-error-foreground: oklch(0.45 0.18 25);
+  --status-error-border: oklch(0.86 0.06 25);
+  --status-warning: oklch(0.94 0.08 85);
+  --status-warning-foreground: oklch(0.42 0.12 85);
+  --status-warning-border: oklch(0.86 0.10 85);
+  --status-info: oklch(0.94 0.04 250);
+  --status-info-foreground: oklch(0.42 0.14 250);
+  --status-info-border: oklch(0.86 0.06 250);
 
-  /* Semantic link colors - Light theme */
-  --link: oklch(0.45 0.15 240);           /* Blue link color */
-  --link-hover: oklch(0.35 0.18 240);     /* Darker blue on hover */
+  /* Links */
+  --link: oklch(0.48 0.18 255);
+  --link-hover: oklch(0.40 0.20 255);
 
-  /* Role badge colors - Light theme (pastel backgrounds) */
-  --role-view: oklch(0.95 0.05 240);           /* Blue for view role */
-  --role-view-foreground: oklch(0.45 0.15 240);
-  --role-edit: oklch(0.95 0.05 145);           /* Green for edit role */
-  --role-edit-foreground: oklch(0.35 0.15 145);
-  --role-admin: oklch(0.95 0.1 290);           /* Purple for admin role */
-  --role-admin-foreground: oklch(0.4 0.15 290);
+  /* Role badges */
+  --role-view: oklch(0.94 0.04 250);
+  --role-view-foreground: oklch(0.42 0.14 250);
+  --role-edit: oklch(0.94 0.04 150);
+  --role-edit-foreground: oklch(0.35 0.12 150);
+  --role-admin: oklch(0.94 0.06 290);
+  --role-admin-foreground: oklch(0.42 0.14 290);
+
+  /* Code blocks — soft neutral instead of harsh black */
+  --code-bg: oklch(0.945 0.005 250);
+  --code-foreground: oklch(0.25 0.01 250);
 }
 
+/*
+ * Dark theme — soft charcoal with cool undertone
+ * Not pure black; warm enough to feel comfortable, cool enough to stay professional
+ */
 .dark {
-  --background: oklch(0.13 0.008 250);
-  --foreground: oklch(0.985 0.002 250);
-  --card: oklch(0.17 0.01 250);
-  --card-foreground: oklch(0.985 0.002 250);
-  --popover: oklch(0.17 0.01 250);
-  --popover-foreground: oklch(0.985 0.002 250);
-  --primary: oklch(0.6 0.2 264);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.25 0.008 250);
-  --secondary-foreground: oklch(0.985 0.002 250);
-  --muted: oklch(0.25 0.008 250);
-  --muted-foreground: oklch(0.708 0.005 250);
-  --accent: oklch(0.25 0.008 250);
-  --accent-foreground: oklch(0.985 0.002 250);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0.005 250 / 12%);
-  --input: oklch(1 0.005 250 / 15%);
-  --ring: oklch(0.6 0.2 264);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.17 0.01 250);
-  --sidebar-foreground: oklch(0.985 0.002 250);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.25 0.008 250);
-  --sidebar-accent-foreground: oklch(0.985 0.002 250);
-  --sidebar-border: oklch(1 0.005 250 / 12%);
-  --sidebar-ring: oklch(0.6 0.2 264);
+  --background: oklch(0.16 0.010 250);
+  --foreground: oklch(0.93 0.005 250);
+  --card: oklch(0.19 0.012 250);
+  --card-foreground: oklch(0.93 0.005 250);
+  --popover: oklch(0.19 0.012 250);
+  --popover-foreground: oklch(0.93 0.005 250);
+  --primary: oklch(0.62 0.17 255);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.23 0.010 250);
+  --secondary-foreground: oklch(0.93 0.005 250);
+  --muted: oklch(0.23 0.010 250);
+  --muted-foreground: oklch(0.65 0.008 250);
+  --accent: oklch(0.23 0.010 250);
+  --accent-foreground: oklch(0.93 0.005 250);
+  --destructive: oklch(0.65 0.18 22);
+  --border: oklch(0.28 0.010 250);
+  --input: oklch(0.28 0.010 250);
+  --ring: oklch(0.62 0.17 255);
+  --chart-1: oklch(0.62 0.17 255);
+  --chart-2: oklch(0.58 0.18 290);
+  --chart-3: oklch(0.65 0.18 22);
+  --chart-4: oklch(0.65 0.14 185);
+  --chart-5: oklch(0.68 0.15 145);
+  --sidebar: oklch(0.17 0.010 250);
+  --sidebar-foreground: oklch(0.93 0.005 250);
+  --sidebar-primary: oklch(0.62 0.17 255);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.23 0.010 250);
+  --sidebar-accent-foreground: oklch(0.93 0.005 250);
+  --sidebar-border: oklch(0.28 0.010 250);
+  --sidebar-ring: oklch(0.62 0.17 255);
 
-  /* Status badge semantic colors - Dark theme (solid backgrounds with white text) */
-  --status-success: oklch(0.35 0.15 145);
-  --status-success-foreground: oklch(0.985 0 0);
-  --status-success-border: oklch(0.35 0.15 145);
-  --status-error: oklch(0.45 0.2 27);
-  --status-error-foreground: oklch(0.985 0 0);
-  --status-error-border: oklch(0.45 0.2 27);
-  --status-warning: oklch(0.5 0.15 85);
-  --status-warning-foreground: oklch(0.985 0 0);
-  --status-warning-border: oklch(0.5 0.15 85);
-  --status-info: oklch(0.5 0.15 240);
-  --status-info-foreground: oklch(0.985 0 0);
-  --status-info-border: oklch(0.5 0.15 240);
+  /* Status colors — muted solids */
+  --status-success: oklch(0.32 0.10 150);
+  --status-success-foreground: oklch(0.88 0.04 150);
+  --status-success-border: oklch(0.32 0.10 150);
+  --status-error: oklch(0.38 0.14 25);
+  --status-error-foreground: oklch(0.90 0.03 25);
+  --status-error-border: oklch(0.38 0.14 25);
+  --status-warning: oklch(0.42 0.12 85);
+  --status-warning-foreground: oklch(0.92 0.04 85);
+  --status-warning-border: oklch(0.42 0.12 85);
+  --status-info: oklch(0.40 0.12 250);
+  --status-info-foreground: oklch(0.90 0.03 250);
+  --status-info-border: oklch(0.40 0.12 250);
 
-  /* Semantic link colors - Dark theme */
-  --link: oklch(0.65 0.15 240);           /* Lighter blue for dark mode */
-  --link-hover: oklch(0.75 0.12 240);     /* Even lighter on hover */
+  /* Links */
+  --link: oklch(0.68 0.14 255);
+  --link-hover: oklch(0.76 0.11 255);
 
-  /* Role badge colors - Dark theme (solid backgrounds with white text) */
-  --role-view: oklch(0.5 0.15 240);           /* Solid blue for view role */
-  --role-view-foreground: oklch(0.985 0 0);
-  --role-edit: oklch(0.35 0.15 145);          /* Solid green for edit role */
-  --role-edit-foreground: oklch(0.985 0 0);
-  --role-admin: oklch(0.5 0.15 290);          /* Solid purple for admin role */
-  --role-admin-foreground: oklch(0.985 0 0);
+  /* Role badges */
+  --role-view: oklch(0.40 0.12 250);
+  --role-view-foreground: oklch(0.90 0.03 250);
+  --role-edit: oklch(0.32 0.10 150);
+  --role-edit-foreground: oklch(0.88 0.04 150);
+  --role-admin: oklch(0.40 0.12 290);
+  --role-admin-foreground: oklch(0.90 0.03 290);
+
+  /* Code blocks — soft dark instead of pure black */
+  --code-bg: oklch(0.14 0.008 250);
+  --code-foreground: oklch(0.82 0.006 250);
 }
 
 @layer base {
@@ -226,54 +244,48 @@
 
 /* Thin scrollbar styling - Cross-browser support */
 .scrollbar-thin {
-  /* Firefox */
   scrollbar-width: thin;
-  scrollbar-color: var(--muted-foreground) var(--muted);
+  scrollbar-color: var(--muted-foreground) transparent;
 }
 
 .dark .scrollbar-thin {
-  /* Firefox dark mode */
-  scrollbar-color: var(--muted-foreground) var(--background);
+  scrollbar-color: var(--muted-foreground) transparent;
 }
 
-/* WebKit browsers (Chrome, Safari, Edge) */
 .scrollbar-thin::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-track {
-  background: var(--muted);
-  border-radius: 4px;
+  background: transparent;
+  border-radius: 3px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background: var(--muted-foreground);
-  border-radius: 4px;
+  background: var(--border);
+  border-radius: 3px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background: var(--foreground);
-}
-
-/* WebKit dark mode */
-.dark .scrollbar-thin::-webkit-scrollbar-track {
-  background: var(--background);
-}
-
-.dark .scrollbar-thin::-webkit-scrollbar-thumb {
   background: var(--muted-foreground);
 }
 
+.dark .scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dark .scrollbar-thin::-webkit-scrollbar-thumb {
+  background: var(--border);
+}
+
 .dark .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background: var(--foreground);
+  background: var(--muted-foreground);
 }
 
 /* Hide scrollbar while maintaining scroll functionality */
 .scrollbar-hide {
-  /* Firefox */
   scrollbar-width: none;
-  /* WebKit browsers (Chrome, Safari, Edge) */
   -ms-overflow-style: none;
 }
 

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/artifacts-accordion.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/artifacts-accordion.tsx
@@ -67,7 +67,7 @@ export function ArtifactsAccordion({
           <div className="overflow-hidden">
             {/* Header with breadcrumbs and actions */}
             <div className="px-2 py-1.5 border-y flex items-center justify-between bg-muted/30">
-              <div className="flex items-center gap-1 text-xs text-muted-foreground min-w-0 flex-1">
+              <div className="flex items-center gap-1 text-sm text-muted-foreground min-w-0 flex-1">
                 {/* Back button when in subfolder or viewing file */}
                 {(currentSubPath || viewingFile) && (
                   <Button
@@ -82,7 +82,7 @@ export function ArtifactsAccordion({
 
                 {/* Breadcrumb path */}
                 <Folder className="inline h-3 w-3 mr-1 flex-shrink-0" />
-                <code className="bg-muted px-1 py-0.5 rounded text-xs truncate">
+                <code className="bg-muted px-1 py-0.5 rounded text-sm truncate">
                   artifacts
                   {currentSubPath && `/${currentSubPath}`}
                   {viewingFile && `/${viewingFile.path}`}
@@ -122,7 +122,7 @@ export function ArtifactsAccordion({
                 </div>
               ) : viewingFile ? (
                 /* File content view */
-                <div className="text-xs">
+                <div className="text-sm">
                   <pre className="bg-muted/50 p-2 rounded overflow-x-auto">
                     <code>{viewingFile.content}</code>
                   </pre>
@@ -132,7 +132,7 @@ export function ArtifactsAccordion({
                 <div className="text-center py-4 text-sm text-muted-foreground">
                   <NotepadText className="h-8 w-8 mx-auto mb-2 opacity-30" />
                   <p>No artifacts yet</p>
-                  <p className="text-xs mt-1">AI-generated artifacts will appear here</p>
+                  <p className="text-sm mt-1">AI-generated artifacts will appear here</p>
                 </div>
               ) : (
                 /* File tree */

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/mcp-integrations-accordion.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/mcp-integrations-accordion.tsx
@@ -62,9 +62,9 @@ export function McpServersAccordion({
     switch (server.status) {
       case 'configured':
       case 'connected':
-        return <CheckCircle2 className="h-4 w-4 text-green-600" />
+        return <CheckCircle2 className="h-4 w-4 text-status-success-foreground" />
       case 'error':
-        return <XCircle className="h-4 w-4 text-red-600" />
+        return <XCircle className="h-4 w-4 text-destructive" />
       case 'disconnected':
       default:
         return <AlertCircle className="h-4 w-4 text-muted-foreground" />
@@ -75,26 +75,26 @@ export function McpServersAccordion({
     switch (server.status) {
       case 'configured':
         return (
-          <Badge variant="outline" className="text-xs bg-blue-50 text-blue-700 border-blue-200">
+          <Badge variant="outline" className="text-sm bg-status-info text-status-info-foreground border-status-info-border">
             Configured
           </Badge>
         )
       case 'connected':
         return (
-          <Badge variant="outline" className="text-xs bg-green-50 text-green-700 border-green-200">
+          <Badge variant="outline" className="text-sm bg-status-success text-status-success-foreground border-status-success-border">
             Connected
           </Badge>
         )
       case 'error':
         return (
-          <Badge variant="outline" className="text-xs bg-red-50 text-red-700 border-red-200">
+          <Badge variant="outline" className="text-sm bg-status-error text-status-error-foreground border-status-error-border">
             Error
           </Badge>
         )
       case 'disconnected':
       default:
         return (
-          <Badge variant="outline" className="text-xs bg-muted text-muted-foreground border-border">
+          <Badge variant="outline" className="text-sm bg-muted text-muted-foreground border-border">
             Disconnected
           </Badge>
         )
@@ -120,10 +120,10 @@ export function McpServersAccordion({
     <Badge
       key={key}
       variant="outline"
-      className={`text-[10px] px-1.5 py-0 font-normal gap-0.5 ${
+      className={`text-sm px-1.5 py-0 font-normal gap-0.5 ${
         value
-          ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-950/30 dark:text-green-400 dark:border-green-800'
-          : 'bg-red-50 text-red-700 border-red-200 dark:bg-red-950/30 dark:text-red-400 dark:border-red-800'
+          ? 'bg-status-success text-status-success-foreground border-status-success-border'
+          : 'bg-status-error text-status-error-foreground border-status-error-border'
       }`}
     >
       {value ? <Check className="h-2.5 w-2.5" /> : <X className="h-2.5 w-2.5" />}
@@ -137,7 +137,7 @@ export function McpServersAccordion({
     )
     return (
       <div key={tool.name} className="flex items-center justify-between gap-3 px-3 py-2">
-        <code className="text-xs truncate">{tool.name}</code>
+        <code className="text-sm truncate">{tool.name}</code>
         {annotations.length > 0 && (
           <div className="flex items-center gap-1 flex-shrink-0">
             {annotations.map(([k, v]) => renderAnnotationBadge(k, v as boolean))}
@@ -165,14 +165,14 @@ export function McpServersAccordion({
           </div>
           <div className="flex items-center gap-2 mt-1 ml-6">
             {server.version && (
-              <span className="text-[10px] text-muted-foreground">v{server.version}</span>
+              <span className="text-sm text-muted-foreground">v{server.version}</span>
             )}
             {toolCount > 0 && (
               <Popover>
                 <PopoverTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                    className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
                   >
                     <Info className="h-3 w-3" />
                     <span>{toolCount} {toolCount === 1 ? 'tool' : 'tools'}</span>
@@ -183,7 +183,7 @@ export function McpServersAccordion({
                   className="w-80 p-0"
                 >
                   <div className="px-3 py-2.5 border-b bg-muted/30">
-                    <p className="text-xs font-medium">
+                    <p className="text-sm font-medium">
                       {server.displayName} — {toolCount} {toolCount === 1 ? 'tool' : 'tools'}
                     </p>
                   </div>
@@ -209,7 +209,7 @@ export function McpServersAccordion({
           <Plug className="h-4 w-4" />
           <span>MCP Servers</span>
           {!showPlaceholders && mcpServers.length > 0 && (
-            <Badge variant="outline" className="text-[10px] px-2 py-0.5">
+            <Badge variant="outline" className="text-sm px-2 py-0.5">
               {mcpServers.length}
             </Badge>
           )}
@@ -225,7 +225,7 @@ export function McpServersAccordion({
           ) : mcpServers.length > 0 ? (
             mcpServers.map((server) => renderServerCard(server))
           ) : (
-            <p className="text-xs text-muted-foreground py-2">
+            <p className="text-sm text-muted-foreground py-2">
               No MCP servers available for this session.
             </p>
           )}
@@ -298,13 +298,13 @@ export function IntegrationsAccordion() {
         <div className="flex items-center gap-2">
           <div className="flex-shrink-0">
             {integration.configured ? (
-              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              <CheckCircle2 className="h-4 w-4 text-status-success-foreground" />
             ) : (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="inline-flex">
-                      <AlertTriangle className="h-4 w-4 text-amber-500" />
+                      <AlertTriangle className="h-4 w-4 text-status-warning-foreground" />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -316,7 +316,7 @@ export function IntegrationsAccordion() {
           </div>
           <h4 className="font-medium text-sm">{integration.name}</h4>
         </div>
-        <p className="text-xs text-muted-foreground mt-0.5">
+        <p className="text-sm text-muted-foreground mt-0.5">
           {integration.configured ? (
             integration.configuredMessage
           ) : (
@@ -340,7 +340,7 @@ export function IntegrationsAccordion() {
           <Link2 className="h-4 w-4" />
           <span>Integrations</span>
           {!isPending && (
-            <Badge variant="outline" className="text-[10px] px-2 py-0.5">
+            <Badge variant="outline" className="text-sm px-2 py-0.5">
               {configuredCount}/{integrations.length}
             </Badge>
           )}

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/repositories-accordion.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/repositories-accordion.tsx
@@ -89,7 +89,7 @@ export function RepositoriesAccordion({
               variant="secondary"
               className={`ml-auto mr-2 transition-all duration-300 ${
                 badgePulse
-                  ? "bg-green-500 text-white shadow-[0_0_8px_rgba(34,197,94,0.6)] scale-110"
+                  ? "bg-chart-5 text-white shadow-[0_0_8px_rgba(104,195,160,0.6)] scale-110"
                   : ""
               }`}
             >
@@ -159,27 +159,27 @@ export function RepositoriesAccordion({
                         <div className="flex items-center gap-2 flex-wrap">
                           <div className="text-sm font-medium truncate">{repoName}</div>
                           {repo.status === "Cloning" ? (
-                            <Badge variant="outline" className="text-xs px-1.5 py-0.5 bg-yellow-50 dark:bg-yellow-950 border-yellow-300 dark:border-yellow-800 text-yellow-700 dark:text-yellow-400">
+                            <Badge variant="outline" className="text-sm px-1.5 py-0.5 bg-status-warning text-status-warning-foreground border-status-warning-border">
                               <Loader2 className="h-3 w-3 animate-spin mr-1" />
                               Cloning...
                             </Badge>
                           ) : repo.status === "Removing" ? (
-                            <Badge variant="outline" className="text-xs px-1.5 py-0.5 bg-orange-50 dark:bg-orange-950 border-orange-300 dark:border-orange-800 text-orange-700 dark:text-orange-400">
+                            <Badge variant="outline" className="text-sm px-1.5 py-0.5 bg-status-warning text-status-warning-foreground border-status-warning-border">
                               <Loader2 className="h-3 w-3 animate-spin mr-1" />
                               Removing...
                             </Badge>
                           ) : repo.status === "Failed" ? (
-                            <Badge variant="outline" className="text-xs px-1.5 py-0.5 bg-red-50 dark:bg-red-950 border-red-300 dark:border-red-800 text-red-700 dark:text-red-400">
+                            <Badge variant="outline" className="text-sm px-1.5 py-0.5 bg-status-error text-status-error-foreground border-status-error-border">
                               <AlertTriangle className="h-3 w-3 mr-1" />
                               Clone failed
                             </Badge>
                           ) : currentBranch ? (
-                            <Badge variant="outline" className="text-xs px-1.5 py-0.5 max-w-full !whitespace-normal !overflow-visible break-words bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800">
+                            <Badge variant="outline" className="text-sm px-1.5 py-0.5 max-w-full !whitespace-normal !overflow-visible break-words bg-status-info text-status-info-foreground border-status-info-border">
                               {currentBranch}
                             </Badge>
                           ) : null}
                         </div>
-                        <div className="text-xs text-muted-foreground truncate">{repo.url}</div>
+                        <div className="text-sm text-muted-foreground truncate">{repo.url}</div>
                       </div>
                       <Button
                         variant="ghost"
@@ -199,16 +199,16 @@ export function RepositoriesAccordion({
                     {/* Expandable branches list */}
                     {isExpanded && hasBranches && (
                       <div className="px-2 pb-2 pl-10 space-y-1">
-                        <div className="text-xs text-muted-foreground mb-1">Available branches:</div>
+                        <div className="text-sm text-muted-foreground mb-1">Available branches:</div>
                         {repo.branches!.map((branch, branchIdx) => (
                           <div
                             key={branchIdx}
-                            className="text-xs py-1 px-2 rounded bg-muted/50 flex items-center gap-2"
+                            className="text-sm py-1 px-2 rounded bg-muted/50 flex items-center gap-2"
                           >
                             <GitBranch className="h-3 w-3 text-muted-foreground" />
                             <span className="font-mono">{branch}</span>
                             {branch === currentBranch && (
-                              <Badge variant="secondary" className="text-xs px-1 py-0 h-4 ml-auto">
+                              <Badge variant="secondary" className="text-sm px-1 py-0 h-4 ml-auto">
                                 active
                               </Badge>
                             )}
@@ -227,11 +227,11 @@ export function RepositoriesAccordion({
 
                 return (
                   <div key={`file-${idx}`} className="flex items-center gap-2 p-2 border rounded bg-muted/30 hover:bg-muted/50 transition-colors">
-                    <CloudUpload className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                    <CloudUpload className="h-4 w-4 text-primary flex-shrink-0" />
                     <div className="flex-1 min-w-0">
                       <div className="text-sm font-medium truncate">{file.name}</div>
                       {fileSizeKB && (
-                        <div className="text-xs text-muted-foreground">{fileSizeKB} KB</div>
+                        <div className="text-sm text-muted-foreground">{fileSizeKB} KB</div>
                       )}
                     </div>
                     {onRemoveFile && (

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/workflows-accordion.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/accordions/workflows-accordion.tsx
@@ -90,7 +90,7 @@ export function WorkflowsAccordion({
           <Workflow className="h-4 w-4" />
           <span>Workflows</span>
           {activeWorkflow && !isExpanded && (
-            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-300 dark:border-green-800">
+            <Badge variant="outline" className="bg-status-success text-status-success-foreground border-status-success-border">
               {ootbWorkflows.find(w => w.id === activeWorkflow)?.name || "Custom Workflow"}
             </Badge>
           )}
@@ -110,10 +110,10 @@ export function WorkflowsAccordion({
               <Button
                 onClick={onResume}
                 size="sm"
-                className="hover:border-green-600 hover:bg-green-50 group"
+                className="hover:border-chart-5 hover:bg-chart-5/10 group"
                 variant="outline"
               >
-                <Play className="w-4 h-4 mr-2 fill-green-200 stroke-green-600 group-hover:fill-green-500 group-hover:stroke-green-700 transition-colors" />
+                <Play className="w-4 h-4 mr-2 fill-chart-5/30 stroke-chart-5 group-hover:fill-chart-5 group-hover:stroke-chart-5 transition-colors" />
                 Resume Session
               </Button>
             )}
@@ -148,7 +148,7 @@ export function WorkflowsAccordion({
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
                           <span>Switching workflow...</span>
                         </div>
-                        <span className="text-xs text-muted-foreground font-normal">
+                        <span className="text-sm text-muted-foreground font-normal">
                           This may take a few seconds...
                         </span>
                       </div>
@@ -156,7 +156,7 @@ export function WorkflowsAccordion({
                       <div className="flex items-start justify-between w-full gap-2">
                         <div className="flex flex-col items-start gap-0.5 text-left flex-1 min-w-0">
                           <span className="font-medium truncate w-full">{getSelectedWorkflowInfo().name}</span>
-                          <span className="text-xs text-muted-foreground font-normal line-clamp-2 w-full">
+                          <span className="text-sm text-muted-foreground font-normal line-clamp-2 w-full">
                             {getSelectedWorkflowInfo().description}
                           </span>
                         </div>
@@ -198,7 +198,7 @@ export function WorkflowsAccordion({
                         >
                           <div className="flex flex-col items-start gap-0.5 py-1">
                             <span className="text-sm">General chat</span>
-                            <span className="text-xs text-muted-foreground font-normal line-clamp-2">
+                            <span className="text-sm text-muted-foreground font-normal line-clamp-2">
                               A general chat session with no structured workflow.
                             </span>
                           </div>
@@ -219,7 +219,7 @@ export function WorkflowsAccordion({
                       >
                         <div className="flex flex-col items-start gap-0.5 py-1">
                           <span className="text-sm">{workflow.name}</span>
-                          <span className="text-xs text-muted-foreground font-normal line-clamp-2">
+                          <span className="text-sm text-muted-foreground font-normal line-clamp-2">
                             {workflow.description}
                           </span>
                         </div>
@@ -238,7 +238,7 @@ export function WorkflowsAccordion({
                       >
                         <div className="flex flex-col items-start gap-0.5 py-1">
                           <span className="text-sm">Custom workflow...</span>
-                          <span className="text-xs text-muted-foreground font-normal line-clamp-2">
+                          <span className="text-sm text-muted-foreground font-normal line-clamp-2">
                             Load a workflow from a custom Git repository
                           </span>
                         </div>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/k8s-resource-tree.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/k8s-resource-tree.tsx
@@ -58,7 +58,7 @@ export function K8sResourceTree({
     const [open, setOpen] = useState(false);
     return (
       <Dialog open={open} onOpenChange={setOpen}>
-        <Button variant="outline" size="sm" className="h-6 text-xs" onClick={() => setOpen(true)}>
+        <Button variant="outline" size="sm" className="h-6 text-sm" onClick={() => setOpen(true)}>
           Events ({events.length})
         </Button>
         <DialogContent className="max-w-2xl max-h-[600px] overflow-y-auto">
@@ -71,7 +71,7 @@ export function K8sResourceTree({
               <p className="text-sm text-muted-foreground">No events</p>
             ) : (
               events.map((event, idx) => (
-                <div key={idx} className="text-xs font-mono bg-muted/50 p-2 rounded border">
+                <div key={idx} className="text-sm font-mono bg-muted/50 p-2 rounded border">
                   {event}
                 </div>
               ))
@@ -114,12 +114,12 @@ export function K8sResourceTree({
                 <ChevronRight className="w-4 h-4 text-muted-foreground" />
               )}
             </button>
-            <Badge variant="outline" className="text-xs">
+            <Badge variant="outline" className="text-sm">
               <Box className="w-3 h-3 mr-1" />
               Job
             </Badge>
             <span className="text-sm font-mono">{jobName}</span>
-            <Badge className={`text-xs ${getK8sResourceStatusColor(jobStatus)}`}>
+            <Badge className={`text-sm ${getK8sResourceStatusColor(jobStatus)}`}>
               {getStatusIcon(jobStatus)}
               <span className="ml-1">{jobStatus}</span>
             </Badge>
@@ -142,14 +142,14 @@ export function K8sResourceTree({
                         <ChevronRight className="w-4 h-4 text-muted-foreground" />
                       )}
                     </button>
-                    <Badge variant="outline" className="text-xs">
+                    <Badge variant="outline" className="text-sm">
                       <Container className="w-3 h-3 mr-1" />
                       Pod
                     </Badge>
                     <span className="text-sm font-mono truncate max-w-xs" title={pod.name}>
                       {pod.name}
                     </span>
-                    <Badge className={`text-xs ${getK8sResourceStatusColor(pod.phase)}`}>
+                    <Badge className={`text-sm ${getK8sResourceStatusColor(pod.phase)}`}>
                       {getStatusIcon(pod.phase)}
                       <span className="ml-1">{pod.phase}</span>
                     </Badge>
@@ -163,20 +163,20 @@ export function K8sResourceTree({
                       {/* Containers */}
                       {pod.containers.map((container) => (
                         <div key={container.name} className="flex items-center gap-2">
-                          <Badge variant="outline" className="text-xs">
+                          <Badge variant="outline" className="text-sm">
                             <Box className="w-3 h-3 mr-1" />
                             Container
                           </Badge>
                           <span className="text-sm font-mono">{container.name}</span>
-                          <Badge className={`text-xs ${getK8sResourceStatusColor(container.state)}`}>
+                          <Badge className={`text-sm ${getK8sResourceStatusColor(container.state)}`}>
                             {getStatusIcon(container.state)}
                             <span className="ml-1">{container.state}</span>
                           </Badge>
                           {container.exitCode !== undefined && (
-                            <span className="text-xs text-muted-foreground">Exit: {container.exitCode}</span>
+                            <span className="text-sm text-muted-foreground">Exit: {container.exitCode}</span>
                           )}
                           {container.reason && (
-                            <span className="text-xs text-muted-foreground">({container.reason})</span>
+                            <span className="text-sm text-muted-foreground">({container.reason})</span>
                           )}
                         </div>
                       ))}
@@ -188,15 +188,15 @@ export function K8sResourceTree({
               {/* PVC */}
               {pvcName && (
                 <div className="flex items-center gap-2">
-                  <Badge variant="outline" className="text-xs">
+                  <Badge variant="outline" className="text-sm">
                     <HardDrive className="w-3 h-3 mr-1" />
                     PVC
                   </Badge>
                   <span className="text-sm font-mono">{pvcName}</span>
-                  <Badge className={`text-xs ${pvcExists ? STATUS_COLORS.success : STATUS_COLORS.error}`}>
+                  <Badge className={`text-sm ${pvcExists ? STATUS_COLORS.success : STATUS_COLORS.error}`}>
                     {pvcExists ? 'Exists' : 'Not Found'}
                   </Badge>
-                  {pvcSize && <span className="text-xs text-muted-foreground">{pvcSize}</span>}
+                  {pvcSize && <span className="text-sm text-muted-foreground">{pvcSize}</span>}
                 </div>
               )}
             </div>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/add-context-modal.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/add-context-modal.tsx
@@ -87,7 +87,7 @@ export function AddContextModal({
               value={contextUrl}
               onChange={(e) => setContextUrl(e.target.value)}
             />
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Currently supports GitHub repositories for code context
             </p>
           </div>
@@ -101,7 +101,7 @@ export function AddContextModal({
               value={contextBranch}
               onChange={(e) => setContextBranch(e.target.value)}
             />
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               If left empty, a unique feature branch will be created for this session
             </p>
           </div>
@@ -119,7 +119,7 @@ export function AddContextModal({
               >
                 Enable auto-push
               </Label>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 Instructs Claude to commit and push changes made to this
                 repository during the session. Requires git credentials to be
                 configured.
@@ -132,7 +132,7 @@ export function AddContextModal({
               <Separator className="my-4" />
               <div className="space-y-2">
                 <Label>Upload Files</Label>
-                <p className="text-xs text-muted-foreground mb-2">
+                <p className="text-sm text-muted-foreground mb-2">
                   Upload files directly to your workspace for use as context
                 </p>
                 <Button

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/custom-workflow-dialog.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/custom-workflow-dialog.tsx
@@ -88,7 +88,7 @@ export function CustomWorkflowDialog({
               onChange={(e) => setCustomWorkflowPath(e.target.value)}
               disabled={isActivating}
             />
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Optional subdirectory within the repository containing the workflow
             </p>
           </div>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/github-connect-modal.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/github-connect-modal.tsx
@@ -113,7 +113,7 @@ export function GitHubConnectModal({
           </div>
           <div className="space-y-2">
             <Label htmlFor="github-connect-git-token">GITHUB_TOKEN</Label>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               GitHub personal access token or fine-grained token for git operations and API access
             </p>
             <div className="flex items-center gap-2">

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/manage-remote-dialog.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/modals/manage-remote-dialog.tsx
@@ -67,7 +67,7 @@ export function ManageRemoteDialog({
                 }
               }}
             />
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Use a repository you have write access to
             </p>
           </div>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/welcome-experience.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/welcome-experience.tsx
@@ -154,7 +154,7 @@ export function WelcomeExperience({
               {/* Avatar */}
               <div className="flex-shrink-0">
                 <div className="w-8 h-8 rounded-full flex items-center justify-center bg-primary ring-2 ring-background">
-                  <span className="text-white text-xs font-semibold">AI</span>
+                  <span className="text-white text-sm font-semibold">AI</span>
                 </div>
               </div>
 
@@ -214,7 +214,7 @@ export function WelcomeExperience({
                         {workflow.name}
                       </h3>
                       <p className={cn(
-                        "text-xs line-clamp-2",
+                        "text-sm line-clamp-2",
                         selectedWorkflowId !== null && selectedWorkflowId !== workflow.id
                           ? "text-muted-foreground/40"
                           : "text-muted-foreground"
@@ -279,7 +279,7 @@ export function WelcomeExperience({
                           >
                             <div className="flex flex-col items-start gap-0.5 py-1 w-full">
                               <span>General chat</span>
-                              <span className="text-xs text-muted-foreground font-normal line-clamp-2">
+                              <span className="text-sm text-muted-foreground font-normal line-clamp-2">
                                 A general chat session with no structured workflow.
                               </span>
                             </div>
@@ -295,7 +295,7 @@ export function WelcomeExperience({
                         >
                           <div className="flex flex-col items-start gap-0.5 py-1 w-full">
                             <span>{workflow.name}</span>
-                            <span className="text-xs text-muted-foreground font-normal line-clamp-2">
+                            <span className="text-sm text-muted-foreground font-normal line-clamp-2">
                               {workflow.description}
                             </span>
                           </div>
@@ -311,7 +311,7 @@ export function WelcomeExperience({
                         >
                           <div className="flex flex-col items-start gap-0.5 py-1 w-full">
                             <span>Custom workflow...</span>
-                            <span className="text-xs text-muted-foreground font-normal line-clamp-2">
+                            <span className="text-sm text-muted-foreground font-normal line-clamp-2">
                               Load a workflow from a custom Git repository
                             </span>
                           </div>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -1431,9 +1431,9 @@ export default function ProjectSessionDetailPage({
         </div>
         <div className="flex-grow overflow-hidden">
           <div className="h-full container mx-auto px-6 py-6">
-            <Card className="border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/50">
+            <Card className="border-status-error-border bg-status-error">
               <CardContent className="pt-6">
-                <p className="text-red-700 dark:text-red-300">
+                <p className="text-status-error-foreground">
                   Error:{" "}
                   {error instanceof Error ? error.message : "Session not found"}
                 </p>
@@ -1476,7 +1476,7 @@ export default function ProjectSessionDetailPage({
                       {session.status?.phase || "Pending"}
                     </Badge>
                     {agentName && (
-                      <Badge variant="outline" className="text-xs font-normal">
+                      <Badge variant="outline" className="text-sm font-normal">
                         {agentName} / {session.spec.llmSettings.model}
                       </Badge>
                     )}
@@ -1593,7 +1593,7 @@ export default function ProjectSessionDetailPage({
                         {/* Starting states */}
                         {["Creating", "Pending"].includes(phase) && (
                           <>
-                            <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-blue-600" />
+                            <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-primary" />
                             <h3 className="font-semibold text-lg mb-1">Starting Session</h3>
                             <p className="text-sm text-muted-foreground">
                               Setting up your workspace...
@@ -1604,7 +1604,7 @@ export default function ProjectSessionDetailPage({
                         {/* Stopping state */}
                         {phase === "Stopping" && (
                           <>
-                            <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-orange-600" />
+                            <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-status-warning-foreground" />
                             <h3 className="font-semibold text-lg mb-1">Stopping Session</h3>
                             <p className="text-sm text-muted-foreground">
                               Saving workspace state...
@@ -1626,8 +1626,8 @@ export default function ProjectSessionDetailPage({
                             <div className="space-y-3 mb-6 text-left">
                               {workflowManagement.activeWorkflow && (
                                 <div>
-                                  <p className="text-xs font-medium text-muted-foreground mb-1.5">Workflow</p>
-                                  <Badge variant="secondary" className="text-xs">
+                                  <p className="text-sm font-medium text-muted-foreground mb-1.5">Workflow</p>
+                                  <Badge variant="secondary" className="text-sm">
                                     {workflowManagement.activeWorkflow}
                                   </Badge>
                                 </div>
@@ -1635,7 +1635,7 @@ export default function ProjectSessionDetailPage({
 
                               {session?.spec?.repos && session.spec.repos.length > 0 && (
                                 <div>
-                                  <p className="text-xs font-medium text-muted-foreground mb-1.5">
+                                  <p className="text-sm font-medium text-muted-foreground mb-1.5">
                                     Repositories ({session.spec.repos.length})
                                   </p>
                                   <div className="text-sm text-foreground/80 space-y-1">
@@ -1645,7 +1645,7 @@ export default function ProjectSessionDetailPage({
                                       </div>
                                     ))}
                                     {session.spec.repos.length > 3 && (
-                                      <div className="text-xs text-muted-foreground mt-1">
+                                      <div className="text-sm text-muted-foreground mt-1">
                                         +{session.spec.repos.length - 3} more
                                       </div>
                                     )}
@@ -1655,7 +1655,7 @@ export default function ProjectSessionDetailPage({
 
                               {(!workflowManagement.activeWorkflow && (!session?.spec?.repos || session.spec.repos.length === 0)) && (
                                 <div className="text-center py-2">
-                                  <p className="text-xs text-muted-foreground">
+                                  <p className="text-sm text-muted-foreground">
                                     No workflow or repositories configured
                                   </p>
                                 </div>
@@ -1766,7 +1766,7 @@ export default function ProjectSessionDetailPage({
                           <span>File Explorer</span>
                           <Badge
                             variant="outline"
-                            className="text-[10px] px-2 py-0.5"
+                            className="text-sm px-2 py-0.5"
                           >
                             EXPERIMENTAL
                           </Badge>
@@ -1775,7 +1775,7 @@ export default function ProjectSessionDetailPage({
                               {(gitOps.gitStatus?.totalAdded ?? 0) > 0 && (
                                 <Badge
                                   variant="outline"
-                                  className="bg-green-50 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-300 dark:border-green-800"
+                                  className="bg-status-success text-status-success-foreground border-status-success-border"
                                 >
                                   +{gitOps.gitStatus.totalAdded}
                                 </Badge>
@@ -1783,7 +1783,7 @@ export default function ProjectSessionDetailPage({
                               {(gitOps.gitStatus?.totalRemoved ?? 0) > 0 && (
                                 <Badge
                                   variant="outline"
-                                  className="bg-red-50 text-red-700 border-red-200 dark:bg-red-950/50 dark:text-red-300 dark:border-red-800"
+                                  className="bg-status-error text-status-error-foreground border-status-error-border"
                                 >
                                   -{gitOps.gitStatus.totalRemoved}
                                 </Badge>
@@ -1802,7 +1802,7 @@ export default function ProjectSessionDetailPage({
 
                           {/* Directory Selector */}
                           <div className="flex items-center justify-between gap-2">
-                            <Label className="text-xs text-muted-foreground">
+                            <Label className="text-sm text-muted-foreground">
                               Directory:
                             </Label>
                             <Select
@@ -1867,11 +1867,11 @@ export default function ProjectSessionDetailPage({
                                         {opt.type === "workflow" && (
                                           <Sparkles className="h-3 w-3" />
                                         )}
-                                        <span className="text-xs">
+                                        <span className="text-sm">
                                           {opt.name}
                                         </span>
                                         {branchName && (
-                                          <Badge variant="outline" className="text-xs px-1.5 py-0.5 max-w-full !whitespace-normal !overflow-visible break-words bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800">
+                                          <Badge variant="outline" className="text-sm px-1.5 py-0.5 max-w-full !whitespace-normal !overflow-visible break-words bg-status-info border-status-info-border">
                                             {branchName}
                                           </Badge>
                                         )}
@@ -1886,7 +1886,7 @@ export default function ProjectSessionDetailPage({
                           {/* File Browser */}
                           <div className="overflow-hidden">
                             <div className="px-2 py-1.5 border-y flex items-center justify-between bg-muted/30">
-                              <div className="flex items-center gap-1 text-xs text-muted-foreground min-w-0 flex-1">
+                              <div className="flex items-center gap-1 text-sm text-muted-foreground min-w-0 flex-1">
                                 {(fileOps.currentSubPath ||
                                   fileOps.viewingFile) && (
                                   <Button
@@ -1900,7 +1900,7 @@ export default function ProjectSessionDetailPage({
                                 )}
 
                                 <Folder className="inline h-3 w-3 mr-1 flex-shrink-0" />
-                                <code className="bg-muted px-1 py-0.5 rounded text-xs truncate">
+                                <code className="bg-muted px-1 py-0.5 rounded text-sm truncate">
                                   {selectedDirectory.path}
                                   {fileOps.currentSubPath &&
                                     `/${fileOps.currentSubPath}`}
@@ -1933,13 +1933,13 @@ export default function ProjectSessionDetailPage({
                                     <DropdownMenuContent align="end">
                                       <DropdownMenuItem
                                         disabled
-                                        className="text-xs text-muted-foreground"
+                                        className="text-sm text-muted-foreground"
                                       >
                                         Sync to Jira - Coming soon
                                       </DropdownMenuItem>
                                       <DropdownMenuItem
                                         disabled
-                                        className="text-xs text-muted-foreground"
+                                        className="text-sm text-muted-foreground"
                                       >
                                         Sync to GDrive - Coming soon
                                       </DropdownMenuItem>
@@ -1976,7 +1976,7 @@ export default function ProjectSessionDetailPage({
                                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                                 </div>
                               ) : fileOps.viewingFile ? (
-                                <div className="text-xs">
+                                <div className="text-sm">
                                   <pre className="bg-muted/50 p-2 rounded overflow-x-auto">
                                     <code>{fileOps.viewingFile.content}</code>
                                   </pre>
@@ -1985,7 +1985,7 @@ export default function ProjectSessionDetailPage({
                                 <div className="text-center py-4 text-sm text-muted-foreground">
                                   <FolderTree className="h-8 w-8 mx-auto mb-2 opacity-30" />
                                   <p>No files yet</p>
-                                  <p className="text-xs mt-1">
+                                  <p className="text-sm mt-1">
                                     Files will appear here
                                   </p>
                                 </div>
@@ -2018,14 +2018,14 @@ export default function ProjectSessionDetailPage({
                           <div className="space-y-2">
                             {/* GitHub Not Configured Warning */}
                             {!githubConfigured && (
-                              <Alert variant="default" className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/50">
-                                <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-500" />
-                                <AlertTitle className="text-amber-900 dark:text-amber-100">GitHub Not Configured</AlertTitle>
-                                <AlertDescription className="text-amber-800 dark:text-amber-200">
+                              <Alert variant="warning">
+                                <AlertTriangle className="h-4 w-4 text-status-warning-foreground" />
+                                <AlertTitle className="text-status-warning-foreground">GitHub Not Configured</AlertTitle>
+                                <AlertDescription className="text-status-warning-foreground/80">
                                   Configure GitHub integration in{" "}
                                   <a
                                     href={`/projects/${projectName}?section=settings`}
-                                    className="underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
+                                    className="underline font-medium hover:text-status-warning-foreground"
                                     onClick={(e) => e.stopPropagation()}
                                   >
                                     workspace settings
@@ -2043,7 +2043,7 @@ export default function ProjectSessionDetailPage({
                             ) : !hasRemote ? (
                               /* State 2: Has Git, No Remote */
                               <div className="space-y-2">
-                                <div className="border rounded-md px-2 py-1.5 text-xs">
+                                <div className="border rounded-md px-2 py-1.5 text-sm">
                                   <div className="flex items-center gap-1.5 text-muted-foreground">
                                     <GitBranch className="h-3 w-3" />
                                     <span>{currentBranch}</span>
@@ -2065,7 +2065,7 @@ export default function ProjectSessionDetailPage({
                               /* State 3: Has Git + Remote */
                               <div className="border rounded-md px-2 py-1.5 space-y-1">
                                 {/* Remote Repository */}
-                                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
                                   <Cloud className="h-3 w-3 flex-shrink-0" />
                                   <span className="truncate">
                                     {remoteUrl
@@ -2077,7 +2077,7 @@ export default function ProjectSessionDetailPage({
                                 </div>
 
                                 {/* Branch Tracking */}
-                                <div className="flex items-center gap-1.5 text-xs">
+                                <div className="flex items-center gap-1.5 text-sm">
                                   <GitBranch className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
                                   <span className="text-muted-foreground">
                                     {currentBranch}
@@ -2137,14 +2137,14 @@ export default function ProjectSessionDetailPage({
                           <div className="text-center">
                             {["Creating", "Pending"].includes(phase) && (
                               <>
-                                <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-blue-600" />
+                                <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-primary" />
                                 <h3 className="font-semibold text-lg mb-1">Starting Session</h3>
                                 <p className="text-sm text-muted-foreground">Setting up your workspace...</p>
                               </>
                             )}
                             {phase === "Stopping" && (
                               <>
-                                <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-orange-600" />
+                                <Loader2 className="h-10 w-10 mx-auto mb-3 animate-spin text-status-warning-foreground" />
                                 <h3 className="font-semibold text-lg mb-1">Stopping Session</h3>
                                 <p className="text-sm text-muted-foreground">Saving workspace state...</p>
                               </>
@@ -2236,7 +2236,7 @@ export default function ProjectSessionDetailPage({
                                 <span>File Explorer</span>
                                 <Badge
                                   variant="outline"
-                                  className="text-[10px] px-2 py-0.5"
+                                  className="text-sm px-2 py-0.5"
                                 >
                                   EXPERIMENTAL
                                 </Badge>
@@ -2245,7 +2245,7 @@ export default function ProjectSessionDetailPage({
                                     {(gitOps.gitStatus?.totalAdded ?? 0) > 0 && (
                                       <Badge
                                         variant="outline"
-                                        className="bg-green-50 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-300 dark:border-green-800"
+                                        className="bg-status-success text-status-success-foreground border-status-success-border"
                                       >
                                         +{gitOps.gitStatus.totalAdded}
                                       </Badge>
@@ -2253,7 +2253,7 @@ export default function ProjectSessionDetailPage({
                                     {(gitOps.gitStatus?.totalRemoved ?? 0) > 0 && (
                                       <Badge
                                         variant="outline"
-                                        className="bg-red-50 text-red-700 border-red-200 dark:bg-red-950/50 dark:text-red-300 dark:border-red-800"
+                                        className="bg-status-error text-status-error-foreground border-status-error-border"
                                       >
                                         -{gitOps.gitStatus.totalRemoved}
                                       </Badge>
@@ -2272,7 +2272,7 @@ export default function ProjectSessionDetailPage({
 
                                 {/* Directory Selector */}
                                 <div className="flex items-center justify-between gap-2">
-                                  <Label className="text-xs text-muted-foreground">
+                                  <Label className="text-sm text-muted-foreground">
                                     Directory:
                                   </Label>
                                   <Select
@@ -2331,11 +2331,11 @@ export default function ProjectSessionDetailPage({
                                               {opt.type === "workflow" && (
                                                 <Sparkles className="h-3 w-3" />
                                               )}
-                                              <span className="text-xs">
+                                              <span className="text-sm">
                                                 {opt.name}
                                               </span>
                                               {branchName && (
-                                                <Badge variant="outline" className="text-xs px-1.5 py-0.5 max-w-full !whitespace-normal !overflow-visible break-words bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800">
+                                                <Badge variant="outline" className="text-sm px-1.5 py-0.5 max-w-full !whitespace-normal !overflow-visible break-words bg-status-info border-status-info-border">
                                                   {branchName}
                                                 </Badge>
                                               )}
@@ -2350,7 +2350,7 @@ export default function ProjectSessionDetailPage({
                                 {/* File Browser */}
                                 <div className="overflow-hidden">
                                   <div className="px-2 py-1.5 border-y flex items-center justify-between bg-muted/30">
-                                    <div className="flex items-center gap-1 text-xs text-muted-foreground min-w-0 flex-1">
+                                    <div className="flex items-center gap-1 text-sm text-muted-foreground min-w-0 flex-1">
                                       {(fileOps.currentSubPath ||
                                         fileOps.viewingFile) && (
                                         <Button
@@ -2364,7 +2364,7 @@ export default function ProjectSessionDetailPage({
                                       )}
 
                                       <Folder className="inline h-3 w-3 mr-1 flex-shrink-0" />
-                                      <code className="bg-muted px-1 py-0.5 rounded text-xs truncate">
+                                      <code className="bg-muted px-1 py-0.5 rounded text-sm truncate">
                                         {selectedDirectory.path}
                                         {fileOps.currentSubPath &&
                                           `/${fileOps.currentSubPath}`}
@@ -2397,13 +2397,13 @@ export default function ProjectSessionDetailPage({
                                           <DropdownMenuContent align="end">
                                             <DropdownMenuItem
                                               disabled
-                                              className="text-xs text-muted-foreground"
+                                              className="text-sm text-muted-foreground"
                                             >
                                               Sync to Jira - Coming soon
                                             </DropdownMenuItem>
                                             <DropdownMenuItem
                                               disabled
-                                              className="text-xs text-muted-foreground"
+                                              className="text-sm text-muted-foreground"
                                             >
                                               Sync to GDrive - Coming soon
                                             </DropdownMenuItem>
@@ -2440,7 +2440,7 @@ export default function ProjectSessionDetailPage({
                                         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                                       </div>
                                     ) : fileOps.viewingFile ? (
-                                      <div className="text-xs">
+                                      <div className="text-sm">
                                         <pre className="bg-muted/50 p-2 rounded overflow-x-auto">
                                           <code>{fileOps.viewingFile.content}</code>
                                         </pre>
@@ -2449,7 +2449,7 @@ export default function ProjectSessionDetailPage({
                                       <div className="text-center py-4 text-sm text-muted-foreground">
                                         <FolderTree className="h-8 w-8 mx-auto mb-2 opacity-30" />
                                         <p>No files yet</p>
-                                        <p className="text-xs mt-1">
+                                        <p className="text-sm mt-1">
                                           Files will appear here
                                         </p>
                                       </div>
@@ -2478,14 +2478,14 @@ export default function ProjectSessionDetailPage({
                                 <div className="space-y-2">
                                   {/* GitHub Not Configured Warning */}
                                   {!githubConfigured && (
-                                    <Alert variant="default" className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/50">
-                                      <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-500" />
-                                      <AlertTitle className="text-amber-900 dark:text-amber-100">GitHub Not Configured</AlertTitle>
-                                      <AlertDescription className="text-amber-800 dark:text-amber-200">
+                                    <Alert variant="warning">
+                                      <AlertTriangle className="h-4 w-4 text-status-warning-foreground" />
+                                      <AlertTitle className="text-status-warning-foreground">GitHub Not Configured</AlertTitle>
+                                      <AlertDescription className="text-status-warning-foreground/80">
                                         Configure GitHub integration in{" "}
                                         <a
                                           href={`/projects/${projectName}?section=settings`}
-                                          className="underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
+                                          className="underline font-medium hover:text-status-warning-foreground"
                                           onClick={(e) => e.stopPropagation()}
                                         >
                                           workspace settings
@@ -2503,7 +2503,7 @@ export default function ProjectSessionDetailPage({
                                   ) : !hasRemote ? (
                                     /* State 2: Has Git, No Remote */
                                     <div className="space-y-2">
-                                      <div className="border rounded-md px-2 py-1.5 text-xs">
+                                      <div className="border rounded-md px-2 py-1.5 text-sm">
                                         <div className="flex items-center gap-1.5 text-muted-foreground">
                                           <GitBranch className="h-3 w-3" />
                                           <span>{currentBranch}</span>
@@ -2525,7 +2525,7 @@ export default function ProjectSessionDetailPage({
                                     /* State 3: Has Git + Remote */
                                     <div className="border rounded-md px-2 py-1.5 space-y-1">
                                       {/* Remote Repository */}
-                                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                      <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
                                         <Cloud className="h-3 w-3 flex-shrink-0" />
                                         <span className="truncate">
                                           {remoteUrl
@@ -2537,7 +2537,7 @@ export default function ProjectSessionDetailPage({
                                       </div>
 
                                       {/* Branch Tracking */}
-                                      <div className="flex items-center gap-1.5 text-xs">
+                                      <div className="flex items-center gap-1.5 text-sm">
                                         <GitBranch className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
                                         <span className="text-muted-foreground">
                                           {currentBranch}
@@ -2561,7 +2561,7 @@ export default function ProjectSessionDetailPage({
                           className="text-muted-foreground hover:text-foreground"
                   >
                           <ChevronLeft className="h-4 w-4 mr-1" />
-                    <span className="text-xs">Hide panel</span>
+                    <span className="text-sm">Hide panel</span>
                   </Button>
                 </div>
               </div>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
@@ -241,7 +241,7 @@ export function SessionHeader({
                 <DropdownMenuItem
                   onClick={onDelete}
                   disabled={actionLoading === "deleting"}
-                  className="text-red-600 dark:text-red-400"
+                  className="text-destructive"
                 >
                   <Trash2 className="w-4 h-4 mr-2" />
                   {actionLoading === "deleting" ? "Deleting..." : "Delete"}
@@ -289,9 +289,9 @@ export function SessionHeader({
                 size="sm"
                 onClick={onStop}
                 disabled={actionLoading === "stopping"}
-                className="hover:border-red-600 hover:bg-red-50 group"
+                className="hover:border-destructive hover:bg-status-error group"
               >
-                <Octagon className="w-4 h-4 mr-2 fill-red-200 stroke-red-500 group-hover:fill-red-500 group-hover:stroke-red-700 transition-colors" />
+                <Octagon className="w-4 h-4 mr-2 fill-destructive/20 stroke-destructive group-hover:fill-destructive group-hover:stroke-destructive transition-colors" />
                 Stop
               </Button>
             )}
@@ -301,9 +301,9 @@ export function SessionHeader({
                 size="sm"
                 onClick={onContinue}
                 disabled={actionLoading === "resuming"}
-                className="hover:border-green-600 hover:bg-green-50 group"
+                className="hover:border-status-success-border hover:bg-status-success group"
               >
-                <Play className="w-4 h-4 mr-2 fill-green-200 stroke-green-600 group-hover:fill-green-500 group-hover:stroke-green-700 transition-colors" />
+                <Play className="w-4 h-4 mr-2 fill-chart-5/20 stroke-chart-5 group-hover:fill-chart-5 group-hover:stroke-chart-5 transition-colors" />
                 Resume
               </Button>
             )}
@@ -341,9 +341,9 @@ export function SessionHeader({
               size="sm"
               onClick={onStop}
               disabled={actionLoading === "stopping"}
-              className="hover:border-red-600 hover:bg-red-50 group"
+              className="hover:border-destructive hover:bg-status-error group"
             >
-              <Octagon className="w-4 h-4 mr-2 fill-red-200 stroke-red-500 group-hover:fill-red-500 group-hover:stroke-red-700 transition-colors" />
+              <Octagon className="w-4 h-4 mr-2 fill-destructive/20 stroke-destructive group-hover:fill-destructive group-hover:stroke-destructive transition-colors" />
               Stop
             </Button>
           )}
@@ -353,9 +353,9 @@ export function SessionHeader({
               size="sm"
               onClick={onContinue}
               disabled={actionLoading === "resuming"}
-              className="hover:border-green-600 hover:bg-green-50 group"
+              className="hover:border-status-success-border hover:bg-status-success group"
             >
-              <Play className="w-4 h-4 mr-2 fill-green-200 stroke-green-600 group-hover:fill-green-500 group-hover:stroke-green-700 transition-colors" />
+              <Play className="w-4 h-4 mr-2 fill-chart-5/20 stroke-chart-5 group-hover:fill-chart-5 group-hover:stroke-chart-5 transition-colors" />
               Resume
             </Button>
           )}
@@ -394,7 +394,7 @@ export function SessionHeader({
                   <DropdownMenuItem
                     onClick={onDelete}
                     disabled={actionLoading === "deleting"}
-                    className="text-red-600 dark:text-red-400"
+                    className="text-destructive"
                   >
                     <Trash2 className="w-4 h-4 mr-2" />
                     {actionLoading === "deleting" ? "Deleting..." : "Delete"}

--- a/components/frontend/src/app/projects/page.tsx
+++ b/components/frontend/src/app/projects/page.tsx
@@ -250,7 +250,7 @@ export default function ProjectsPage() {
                                 <div className="font-medium">
                                   {project.displayName || project.name}
                                 </div>
-                                <div className="text-xs text-muted-foreground font-normal">
+                                <div className="text-sm text-muted-foreground font-normal">
                                   {project.name}
                                 </div>
                               </div>

--- a/components/frontend/src/components/RepoBrowser.tsx
+++ b/components/frontend/src/components/RepoBrowser.tsx
@@ -180,8 +180,8 @@ export default function RepoBrowser({
             {fileContent ? (
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <div className="text-xs text-muted-foreground">{selectedPath}</div>
-                  <div className="text-xs text-muted-foreground">
+                  <div className="text-sm text-muted-foreground">{selectedPath}</div>
+                  <div className="text-sm text-muted-foreground">
                     Size: {formatFileSize(fileContent.size)} | Encoding: {fileContent.encoding}
                   </div>
                 </div>

--- a/components/frontend/src/components/chat/AttachmentPreview.tsx
+++ b/components/frontend/src/components/chat/AttachmentPreview.tsx
@@ -52,14 +52,14 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
             )}
 
             <div className="flex-1 min-w-0">
-              <p className="text-xs font-medium truncate" title={attachment.file.name}>
+              <p className="text-sm font-medium truncate" title={attachment.file.name}>
                 {attachment.file.name}
               </p>
-              <p className="text-[10px] text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 {formatFileSize(attachment.file.size)}
               </p>
               {attachment.error && (
-                <p className="text-[10px] text-destructive truncate">{attachment.error}</p>
+                <p className="text-sm text-destructive truncate">{attachment.error}</p>
               )}
             </div>
 

--- a/components/frontend/src/components/chat/AutocompletePopover.tsx
+++ b/components/frontend/src/components/chat/AutocompletePopover.tsx
@@ -63,7 +63,7 @@ export const AutocompletePopover: React.FC<AutocompletePopoverProps> = ({
   return (
     <div
       ref={containerRef}
-      className="absolute z-[100] bg-card border-2 border-blue-500 rounded-md shadow-lg max-h-60 overflow-y-auto w-80"
+      className="absolute z-[100] bg-card border-2 border-primary rounded-md shadow-lg max-h-60 overflow-y-auto w-80"
       style={{
         bottom: "100%",
         left: "0px",
@@ -73,11 +73,11 @@ export const AutocompletePopover: React.FC<AutocompletePopoverProps> = ({
       {/* Header */}
       <div className="sticky top-0 bg-card border-b px-3 py-2 flex items-center gap-2">
         <TypeIcon className="h-4 w-4 text-muted-foreground" />
-        <span className="text-xs font-medium text-muted-foreground">
+        <span className="text-sm font-medium text-muted-foreground">
           {type === "agent" ? "Mention an agent" : "Run a command"}
         </span>
         {filter && (
-          <span className="text-xs text-blue-500 ml-auto">
+          <span className="text-sm text-primary ml-auto">
             &quot;{filter}&quot;
           </span>
         )}
@@ -86,7 +86,7 @@ export const AutocompletePopover: React.FC<AutocompletePopoverProps> = ({
       {items.length === 0 ? (
         <div className="px-3 py-4 text-sm text-muted-foreground text-center">
           No {typeLabel} found
-          {filter && <span className="block text-xs mt-1">Try a different search</span>}
+          {filter && <span className="block text-sm mt-1">Try a different search</span>}
         </div>
       ) : (
         <div className="py-1">
@@ -108,8 +108,8 @@ export const AutocompletePopover: React.FC<AutocompletePopoverProps> = ({
               >
                 <div className="flex items-center gap-2">
                   {isAgent && (
-                    <div className="w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
-                      <span className="text-[10px] font-bold text-blue-600 dark:text-blue-300">
+                    <div className="w-6 h-6 rounded-full bg-primary/10 dark:bg-primary/15 flex items-center justify-center">
+                      <span className="text-sm font-bold text-primary">
                         {getShortName(agent!.name).charAt(0).toUpperCase()}
                       </span>
                     </div>
@@ -118,13 +118,13 @@ export const AutocompletePopover: React.FC<AutocompletePopoverProps> = ({
                     <div className="font-medium text-sm">
                       {isAgent ? `@${getShortName(agent!.name)}` : cmd!.slashCommand}
                     </div>
-                    <div className="text-xs text-muted-foreground truncate">
+                    <div className="text-sm text-muted-foreground truncate">
                       {isAgent ? agent!.name : cmd!.name}
                     </div>
                   </div>
                 </div>
                 {item.description && (
-                  <p className="text-xs text-muted-foreground mt-1 line-clamp-2 pl-8">
+                  <p className="text-sm text-muted-foreground mt-1 line-clamp-2 pl-8">
                     {item.description}
                   </p>
                 )}
@@ -135,7 +135,7 @@ export const AutocompletePopover: React.FC<AutocompletePopoverProps> = ({
       )}
 
       {/* Footer hint */}
-      <div className="sticky bottom-0 bg-card border-t px-3 py-1.5 text-[10px] text-muted-foreground flex gap-3">
+      <div className="sticky bottom-0 bg-card border-t px-3 py-1.5 text-sm text-muted-foreground flex gap-3">
         <span>
           <kbd className="px-1 bg-muted rounded">↑↓</kbd> navigate
         </span>

--- a/components/frontend/src/components/chat/ChatInputBox.tsx
+++ b/components/frontend/src/components/chat/ChatInputBox.tsx
@@ -101,11 +101,11 @@ const ToolbarItemList: React.FC<ToolbarItemListProps> = ({ items, type, onInsert
     <div className="space-y-3">
       <div className="space-y-2">
         <h4 className="font-medium text-sm">{heading}</h4>
-        <p className="text-xs text-muted-foreground">{subtitle}</p>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
       </div>
       <div className="max-h-[400px] overflow-y-scroll space-y-2 pr-2 scrollbar-thin">
         {items.length === 0 ? (
-          <p className="text-xs text-muted-foreground py-2">{emptyLabel}</p>
+          <p className="text-sm text-muted-foreground py-2">{emptyLabel}</p>
         ) : (
           items.map((item) => {
             const isAgent = type === "agent";
@@ -121,7 +121,7 @@ const ToolbarItemList: React.FC<ToolbarItemListProps> = ({ items, type, onInsert
                     <Button
                       variant="outline"
                       size="sm"
-                      className="flex-shrink-0 h-7 text-xs"
+                      className="flex-shrink-0 h-7 text-sm"
                       onClick={() => onInsertAgent?.(shortName)}
                     >
                       @{shortName}
@@ -130,7 +130,7 @@ const ToolbarItemList: React.FC<ToolbarItemListProps> = ({ items, type, onInsert
                     <Button
                       variant="outline"
                       size="sm"
-                      className="flex-shrink-0 h-7 text-xs"
+                      className="flex-shrink-0 h-7 text-sm"
                       onClick={() => onRunCommand?.(cmd!.slashCommand)}
                     >
                       Run {cmd!.slashCommand}
@@ -138,7 +138,7 @@ const ToolbarItemList: React.FC<ToolbarItemListProps> = ({ items, type, onInsert
                   )}
                 </div>
                 {item.description && (
-                  <p className="text-xs text-muted-foreground">{item.description}</p>
+                  <p className="text-sm text-muted-foreground">{item.description}</p>
                 )}
               </div>
             );
@@ -463,8 +463,8 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
   };
 
   const getTextareaStyle = () => {
-    if (editingQueuedId) return "border-blue-400/50 bg-blue-50/30 dark:bg-blue-950/10";
-    if (isRunActive) return "border-amber-400/50 bg-amber-50/30 dark:bg-amber-950/10";
+    if (editingQueuedId) return "border-status-info-border bg-status-info/30";
+    if (isRunActive) return "border-status-warning-border bg-status-warning/30";
     return "";
   };
 
@@ -473,13 +473,13 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
       <div className="px-2 pt-2 pb-0 space-y-1.5 max-w-[90%] mx-auto mb-4">
         {/* Phase status banner */}
         {isCreating && (
-          <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-muted text-xs text-muted-foreground">
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-muted text-sm text-muted-foreground">
             <Loader2 className="h-3 w-3 animate-spin" />
             Session is starting up. Messages will be queued.
           </div>
         )}
         {isTerminalState && (
-          <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-muted text-xs text-muted-foreground">
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-muted text-sm text-muted-foreground">
             Session has {sessionPhase.toLowerCase()}.
             {onContinue && (
               <button onClick={onContinue} className="text-link hover:underline font-medium">
@@ -491,12 +491,12 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
 
         {/* Editing queued message indicator */}
         {editingQueuedId && (
-          <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 text-xs text-blue-700 dark:text-blue-300">
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-status-info border border-status-info-border text-sm text-status-info-foreground">
             <Pencil className="h-3 w-3" />
             Editing queued message
             <button
               onClick={() => { onChange(draftInput); resetHistory(); }}
-              className="ml-auto hover:text-blue-900 dark:hover:text-blue-100"
+              className="ml-auto hover:text-foreground"
             >
               <X className="h-3 w-3" />
             </button>
@@ -519,13 +519,13 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
 
           {/* Queue indicator with clear button */}
           {isRunActive && queuedCount > 0 && (
-            <div className="absolute -top-6 left-0 flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+            <div className="absolute -top-6 left-0 flex items-center gap-1 text-sm text-status-warning-foreground">
               <Clock className="h-3 w-3" />
               {queuedCount} message{queuedCount > 1 ? "s" : ""} queued
               {onClearQueue && (
                 <button
                   onClick={onClearQueue}
-                  className="ml-1 flex items-center gap-0.5 hover:text-amber-800 dark:hover:text-amber-200"
+                  className="ml-1 flex items-center gap-0.5 hover:text-foreground"
                   title="Clear all queued messages"
                 >
                   <X className="h-3 w-3" />
@@ -618,7 +618,7 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
                   <Users className="h-3.5 w-3.5" />
                   Agents
                   {agents.length > 0 && (
-                    <Badge variant="secondary" className="ml-0.5 h-4 px-1.5 text-[10px] font-medium">
+                    <Badge variant="secondary" className="ml-0.5 h-4 px-1.5 text-sm font-medium">
                       {agents.length}
                     </Badge>
                   )}
@@ -644,7 +644,7 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
                   <Terminal className="h-3.5 w-3.5" />
                   Commands
                   {commands.length > 0 && (
-                    <Badge variant="secondary" className="ml-0.5 h-4 px-1.5 text-[10px] font-medium">
+                    <Badge variant="secondary" className="ml-0.5 h-4 px-1.5 text-sm font-medium">
                       {commands.length}
                     </Badge>
                   )}
@@ -675,7 +675,7 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
                 <button
                   onClick={handleSendAsNew}
                   disabled={!hasContent || isSending}
-                  className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                  className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
                 >
                   Send as new
                 </button>

--- a/components/frontend/src/components/chat/QueuedMessageBubble.tsx
+++ b/components/frontend/src/components/chat/QueuedMessageBubble.tsx
@@ -29,21 +29,21 @@ export const QueuedMessageBubble: React.FC<QueuedMessageBubbleProps> = ({
         {/* User Avatar */}
         <div className="flex-shrink-0">
           <div className="w-8 h-8 rounded-full flex items-center justify-center bg-muted">
-            <span className="text-muted-foreground text-xs font-semibold">You</span>
+            <span className="text-muted-foreground text-sm font-semibold">You</span>
           </div>
         </div>
 
         {/* Message Content */}
         <div className="flex-1 min-w-0">
           {/* Timestamp */}
-          <div className="text-[10px] text-muted-foreground/60 mb-1">{timeAgo}</div>
+          <div className="text-sm text-muted-foreground/60 mb-1">{timeAgo}</div>
 
           {/* Queued message with distinct styling */}
-          <div className="bg-amber-50 dark:bg-amber-950/30 border-l-2 border-amber-400 rounded-r-md p-3">
+          <div className="bg-status-warning border-l-2 border-status-warning-border rounded-r-md p-3">
             <div className="flex items-center justify-between mb-1">
               <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-                <span className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                <Clock className="h-4 w-4 text-status-warning-foreground" />
+                <span className="text-sm font-medium text-status-warning-foreground">
                   Queued
                 </span>
               </div>

--- a/components/frontend/src/components/chat/WelcomeExperience.tsx
+++ b/components/frontend/src/components/chat/WelcomeExperience.tsx
@@ -82,16 +82,16 @@ export const WelcomeExperience: React.FC<WelcomeExperienceProps> = ({
                 </div>
                 <span className="font-medium">{prompt.label}</span>
               </div>
-              <p className="text-xs text-muted-foreground">{prompt.description}</p>
+              <p className="text-sm text-muted-foreground">{prompt.description}</p>
             </Button>
           );
         })}
       </div>
 
       {/* Hint */}
-      <p className="text-xs text-muted-foreground mt-6">
-        Type <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">@</kbd> to mention an agent or{" "}
-        <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">/</kbd> for commands
+      <p className="text-sm text-muted-foreground mt-6">
+        Type <kbd className="px-1 py-0.5 bg-muted rounded text-sm">@</kbd> to mention an agent or{" "}
+        <kbd className="px-1 py-0.5 bg-muted rounded text-sm">/</kbd> for commands
       </p>
     </div>
   );

--- a/components/frontend/src/components/clone-session-dialog.tsx
+++ b/components/frontend/src/components/clone-session-dialog.tsx
@@ -163,8 +163,8 @@ export function CloneSessionDialog({
             />)}
 
             {error && (
-              <div className="bg-red-50 border border-red-200 rounded-md p-3">
-                <p className="text-red-700 dark:text-red-300 text-sm">{error}</p>
+              <div className="bg-status-error border border-status-error-border rounded-md p-3">
+                <p className="text-status-error-foreground text-sm">{error}</p>
               </div>
             )}
 

--- a/components/frontend/src/components/create-session-dialog.tsx
+++ b/components/frontend/src/components/create-session-dialog.tsx
@@ -195,7 +195,7 @@ export function CreateSessionDialog({
                         disabled={createSessionMutation.isPending}
                       />
                     </FormControl>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-sm text-muted-foreground">
                       {(field.value ?? "").length}/50 characters. Optional; you can rename later from the session menu.
                     </p>
                     <FormMessage />
@@ -244,7 +244,7 @@ export function CreateSessionDialog({
                       </Select>
                     )}
                     {selectedRunner && (
-                      <p className="text-xs text-muted-foreground">
+                      <p className="text-sm text-muted-foreground">
                         {selectedRunner.description}
                       </p>
                     )}
@@ -304,11 +304,11 @@ export function CreateSessionDialog({
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <div className="flex-shrink-0">
-                          <CheckCircle2 className="h-4 w-4 text-green-600" />
+                          <CheckCircle2 className="h-4 w-4 text-chart-5" />
                         </div>
                         <h4 className="font-medium text-sm">GitHub</h4>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Authenticated. Git push and repository access enabled.
                       </p>
                     </div>
@@ -316,11 +316,11 @@ export function CreateSessionDialog({
                 ) : (
                   <div className="flex items-start gap-3 p-3 border rounded-lg bg-background/50">
                     <div className="flex-shrink-0">
-                      <AlertTriangle className="h-4 w-4 text-amber-500" />
+                      <AlertTriangle className="h-4 w-4 text-status-warning-foreground" />
                     </div>
                     <div className="flex-1 min-w-0">
                       <h4 className="font-medium text-sm">GitHub</h4>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Not connected.{" "}
                         <Link href="/integrations" className="text-primary hover:underline">
                           Set up
@@ -336,11 +336,11 @@ export function CreateSessionDialog({
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <div className="flex-shrink-0">
-                          <CheckCircle2 className="h-4 w-4 text-green-600" />
+                          <CheckCircle2 className="h-4 w-4 text-chart-5" />
                         </div>
                         <h4 className="font-medium text-sm">GitLab</h4>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Authenticated. Git push and repository access enabled.
                       </p>
                     </div>
@@ -348,11 +348,11 @@ export function CreateSessionDialog({
                 ) : (
                   <div className="flex items-start gap-3 p-3 border rounded-lg bg-background/50">
                     <div className="flex-shrink-0">
-                      <AlertTriangle className="h-4 w-4 text-amber-500" />
+                      <AlertTriangle className="h-4 w-4 text-status-warning-foreground" />
                     </div>
                     <div className="flex-1 min-w-0">
                       <h4 className="font-medium text-sm">GitLab</h4>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Not connected.{" "}
                         <Link href="/integrations" className="text-primary hover:underline">
                           Set up
@@ -368,11 +368,11 @@ export function CreateSessionDialog({
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <div className="flex-shrink-0">
-                          <CheckCircle2 className="h-4 w-4 text-green-600" />
+                          <CheckCircle2 className="h-4 w-4 text-chart-5" />
                         </div>
                         <h4 className="font-medium text-sm">Google Workspace</h4>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Authenticated. Drive, Calendar, and Gmail access enabled.
                       </p>
                     </div>
@@ -380,11 +380,11 @@ export function CreateSessionDialog({
                 ) : (
                   <div className="flex items-start gap-3 p-3 border rounded-lg bg-background/50">
                     <div className="flex-shrink-0">
-                      <AlertTriangle className="h-4 w-4 text-amber-500" />
+                      <AlertTriangle className="h-4 w-4 text-status-warning-foreground" />
                     </div>
                     <div className="flex-1 min-w-0">
                       <h4 className="font-medium text-sm">Google Workspace</h4>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Not connected.{" "}
                         <Link href="/integrations" className="text-primary hover:underline">
                           Set up
@@ -400,11 +400,11 @@ export function CreateSessionDialog({
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <div className="flex-shrink-0">
-                          <CheckCircle2 className="h-4 w-4 text-green-600" />
+                          <CheckCircle2 className="h-4 w-4 text-chart-5" />
                         </div>
                         <h4 className="font-medium text-sm">Jira</h4>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Authenticated. Issue and project access enabled.
                       </p>
                     </div>
@@ -412,11 +412,11 @@ export function CreateSessionDialog({
                 ) : (
                   <div className="flex items-start gap-3 p-3 border rounded-lg bg-background/50">
                     <div className="flex-shrink-0">
-                      <AlertTriangle className="h-4 w-4 text-amber-500" />
+                      <AlertTriangle className="h-4 w-4 text-status-warning-foreground" />
                     </div>
                     <div className="flex-1 min-w-0">
                       <h4 className="font-medium text-sm">Jira</h4>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                      <p className="text-sm text-muted-foreground mt-0.5">
                         Not connected.{" "}
                         <Link
                           href="/integrations"

--- a/components/frontend/src/components/create-workspace-dialog.tsx
+++ b/components/frontend/src/components/create-workspace-dialog.tsx
@@ -213,9 +213,9 @@ export function CreateWorkspaceDialog({
                     setNameError(validateProjectName(name));
                   }}
                   placeholder="my-research-workspace"
-                  className={nameError ? "border-red-500" : ""}
+                  className={nameError ? "border-destructive" : ""}
                 />
-                {nameError && <p className="text-sm text-red-600 dark:text-red-400">{nameError}</p>}
+                {nameError && <p className="text-sm text-status-error-foreground">{nameError}</p>}
                 <p className="text-sm text-muted-foreground">
                   Lowercase alphanumeric with hyphens.
                 </p>
@@ -244,8 +244,8 @@ export function CreateWorkspaceDialog({
           </div>
 
           {error && (
-            <div className="p-4 bg-red-50 border border-red-200 rounded-md dark:bg-red-950/50 dark:border-red-800">
-              <p className="text-red-700 dark:text-red-300">{error}</p>
+            <div className="p-4 bg-status-error border border-status-error-border rounded-md">
+              <p className="text-status-error-foreground">{error}</p>
             </div>
           )}
 

--- a/components/frontend/src/components/edit-session-name-dialog.tsx
+++ b/components/frontend/src/components/edit-session-name-dialog.tsx
@@ -80,7 +80,7 @@ export function EditSessionNameDialog({
               disabled={isLoading}
               autoFocus
             />
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               {name.length}/50 characters
             </p>
           </div>

--- a/components/frontend/src/components/feedback/FeedbackButtons.tsx
+++ b/components/frontend/src/components/feedback/FeedbackButtons.tsx
@@ -77,10 +77,10 @@ export function FeedbackButtons({
                 disabled={isPositiveSubmitted}
                 className={cn(
                   "p-1.5 rounded-md transition-all duration-200",
-                  "hover:bg-green-500/10 focus:outline-none focus:ring-2 focus:ring-green-500/30",
+                  "hover:bg-chart-5/10 focus:outline-none focus:ring-2 focus:ring-chart-5/30",
                   isPositiveSubmitted
-                    ? "text-green-500 bg-green-500/10 cursor-default"
-                    : "text-muted-foreground hover:text-green-500 cursor-pointer"
+                    ? "text-chart-5 bg-chart-5/10 cursor-default"
+                    : "text-muted-foreground hover:text-chart-5 cursor-pointer"
                 )}
                 aria-label={isPositiveSubmitted ? "Positive feedback submitted" : "This response was helpful"}
               >
@@ -94,7 +94,7 @@ export function FeedbackButtons({
                 )}
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top" className="text-xs">
+            <TooltipContent side="top" className="text-sm">
               {isPositiveSubmitted ? "Thanks for your feedback!" : "This was helpful"}
             </TooltipContent>
           </Tooltip>
@@ -107,10 +107,10 @@ export function FeedbackButtons({
                 disabled={isNegativeSubmitted}
                 className={cn(
                   "p-1.5 rounded-md transition-all duration-200",
-                  "hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/30",
+                  "hover:bg-destructive/10 focus:outline-none focus:ring-2 focus:ring-destructive/30",
                   isNegativeSubmitted
-                    ? "text-red-500 bg-red-500/10 cursor-default"
-                    : "text-muted-foreground hover:text-red-500 cursor-pointer"
+                    ? "text-destructive bg-destructive/10 cursor-default"
+                    : "text-muted-foreground hover:text-destructive cursor-pointer"
                 )}
                 aria-label={isNegativeSubmitted ? "Negative feedback submitted" : "This response was not helpful"}
               >
@@ -124,7 +124,7 @@ export function FeedbackButtons({
                 )}
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top" className="text-xs">
+            <TooltipContent side="top" className="text-sm">
               {isNegativeSubmitted ? "Thanks for your feedback!" : "This wasn't helpful"}
             </TooltipContent>
           </Tooltip>

--- a/components/frontend/src/components/feedback/FeedbackModal.tsx
+++ b/components/frontend/src/components/feedback/FeedbackModal.tsx
@@ -134,9 +134,9 @@ export function FeedbackModal({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             {isPositive ? (
-              <ThumbsUp className="h-5 w-5 text-green-500" />
+              <ThumbsUp className="h-5 w-5 text-chart-5" />
             ) : (
-              <ThumbsDown className="h-5 w-5 text-red-500" />
+              <ThumbsDown className="h-5 w-5 text-destructive" />
             )}
             <span>Share feedback</span>
           </DialogTitle>
@@ -168,7 +168,7 @@ export function FeedbackModal({
           </div>
 
           {/* Privacy disclaimer */}
-          <div className="rounded-md border border-border/50 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+          <div className="rounded-md border border-border/50 bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground">
             <div className="flex items-center gap-1.5 mb-1">
               <Info className="h-3.5 w-3.5 flex-shrink-0" />
               <span className="font-medium">Privacy</span>

--- a/components/frontend/src/components/file-tree.tsx
+++ b/components/frontend/src/components/file-tree.tsx
@@ -78,9 +78,9 @@ function FileTreeItem({ node, selectedPath, onSelect, onToggle, depth = 0 }: Ite
       >
         {node.type === "folder" ? (
           expanded ? (
-            <FolderOpen className="h-4 w-4 text-blue-600" />
+            <FolderOpen className="h-4 w-4 text-primary" />
           ) : (
-            <Folder className="h-4 w-4 text-blue-600" />
+            <Folder className="h-4 w-4 text-primary" />
           )
         ) : (
           <FileText className="h-4 w-4 text-muted-foreground" />
@@ -89,13 +89,13 @@ function FileTreeItem({ node, selectedPath, onSelect, onToggle, depth = 0 }: Ite
         <span className={`flex-1 ${isSelected ? "font-medium" : ""}`}>{node.name}</span>
 
         {node.branch && (
-          <Badge variant="outline" className="text-xs px-1.5 py-0 h-5 bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800">
+          <Badge variant="outline" className="text-sm px-1.5 py-0 h-5 bg-status-info border-status-info-border">
             {node.branch}
           </Badge>
         )}
 
         {typeof node.sizeKb === "number" && (
-          <span className="text-xs text-muted-foreground">{node.sizeKb.toFixed(1)}K</span>
+          <span className="text-sm text-muted-foreground">{node.sizeKb.toFixed(1)}K</span>
         )}
       </div>
 

--- a/components/frontend/src/components/github-connection-card.tsx
+++ b/components/frontend/src/components/github-connection-card.tsx
@@ -100,7 +100,7 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
       <div className="p-6 flex flex-col flex-1">
         {/* Header section with icon and title */}
         <div className="flex items-start gap-4 mb-6">
-          <div className="flex-shrink-0 w-16 h-16 bg-slate-950 dark:bg-black rounded-lg flex items-center justify-center">
+          <div className="flex-shrink-0 w-16 h-16 bg-foreground/90 dark:bg-foreground/80 rounded-lg flex items-center justify-center">
             <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
             </svg>
@@ -114,7 +114,7 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
         {/* Status section */}
         <div className="mb-4">
           <div className="flex items-center gap-2 mb-2">
-            <span className={`w-2 h-2 rounded-full ${status?.installed || patStatus?.configured ? 'bg-green-500' : 'bg-gray-400'}`}></span>
+            <span className={`w-2 h-2 rounded-full ${status?.installed || patStatus?.configured ? 'bg-chart-5' : 'bg-muted-foreground/40'}`}></span>
             <span className="text-sm font-medium text-foreground/80">
               {status?.installed ? (
                 <>Connected{status.githubUserId ? ` as ${status.githubUserId}` : ''}</>
@@ -126,12 +126,12 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
             </span>
           </div>
           {patStatus?.configured && (
-            <p className="text-xs text-muted-foreground mb-2">
+            <p className="text-sm text-muted-foreground mb-2">
               Active: Personal Access Token (overrides GitHub App)
             </p>
           )}
           {status?.installed && !patStatus?.configured && (
-            <p className="text-xs text-muted-foreground mb-2">
+            <p className="text-sm text-muted-foreground mb-2">
               Active: GitHub App
             </p>
           )}
@@ -144,7 +144,7 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
         {status?.installed && (
           <div className="mb-4 pb-4 border-b">
             <h4 className="text-sm font-semibold mb-2">GitHub App</h4>
-            <p className="text-xs text-muted-foreground mb-3">
+            <p className="text-sm text-muted-foreground mb-3">
               Connected as {status.githubUserId}
             </p>
             <div className="flex gap-2">
@@ -181,8 +181,8 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
           </button>
 
           {showPATSection && (
-            <div className="space-y-3 pl-6 border-l-2 border-blue-500/20">
-              <p className="text-xs text-muted-foreground">
+            <div className="space-y-3 pl-6 border-l-2 border-primary/20">
+              <p className="text-sm text-muted-foreground">
                 {patStatus?.configured
                   ? 'PAT is configured and will be used instead of GitHub App for all operations'
                   : 'Alternative to GitHub App. If set, PAT takes precedence over GitHub App.'}
@@ -191,11 +191,11 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
               {patStatus?.configured ? (
                 <div className="space-y-2">
                   {patStatus?.valid === false ? (
-                    <p className="text-xs text-yellow-600 dark:text-yellow-400">
+                    <p className="text-sm text-status-warning-foreground">
                       ⚠️ Token appears invalid or expired
                     </p>
                   ) : (
-                    <p className="text-xs text-green-600 dark:text-green-400">
+                    <p className="text-sm text-status-success-foreground">
                       Configured (updated {patStatus.updatedAt ? new Date(patStatus.updatedAt).toLocaleDateString() : 'recently'})
                     </p>
                   )}
@@ -218,7 +218,7 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
               ) : (
                 <div className="space-y-3">
                   <div className="space-y-1">
-                    <Label htmlFor="github-pat" className="text-xs">Token</Label>
+                    <Label htmlFor="github-pat" className="text-sm">Token</Label>
                     <div className="flex gap-2">
                       <Input
                         id="github-pat"
@@ -239,7 +239,7 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
                         {showToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                       </Button>
                     </div>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-sm text-muted-foreground">
                       Create a token with <code>repo</code> scope at{' '}
                       <a
                         href="https://github.com/settings/tokens/new"

--- a/components/frontend/src/components/gitlab-connection-card.tsx
+++ b/components/frontend/src/components/gitlab-connection-card.tsx
@@ -76,7 +76,7 @@ export function GitLabConnectionCard({ status, onRefresh }: Props) {
       <div className="p-6 flex flex-col flex-1">
         {/* Header section with icon and title */}
         <div className="flex items-start gap-4 mb-6">
-          <div className="flex-shrink-0 w-16 h-16 bg-orange-600 rounded-lg flex items-center justify-center">
+          <div className="flex-shrink-0 w-16 h-16 bg-destructive rounded-lg flex items-center justify-center">
             <svg className="w-10 h-10 text-white" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M23.6004 9.5927l-.0337-.0862L20.3.9814a.851.851 0 00-.3362-.405.8748.8748 0 00-.9997.0539.8748.8748 0 00-.29.4399l-2.2055 6.748H7.5375l-2.2057-6.748a.8573.8573 0 00-.29-.4412.8748.8748 0 00-.9997-.0537.8585.8585 0 00-.3362.4049L.4332 9.5015l-.0325.0862a6.0657 6.0657 0 002.0119 7.0105l.0113.0087.03.0213 4.976 3.7264 2.462 1.8633 1.4995 1.1321a1.0085 1.0085 0 001.2197 0l1.4995-1.1321 2.4619-1.8633 5.006-3.7489.0125-.01a6.0682 6.0682 0 002.0094-7.003z"/>
             </svg>
@@ -90,13 +90,13 @@ export function GitLabConnectionCard({ status, onRefresh }: Props) {
         {/* Status section */}
         <div className="mb-4">
           <div className="flex items-center gap-2 mb-2">
-            <span className={`w-2 h-2 rounded-full ${status?.connected && status.valid !== false ? 'bg-green-500' : status?.connected ? 'bg-yellow-500' : 'bg-gray-400'}`}></span>
+            <span className={`w-2 h-2 rounded-full ${status?.connected && status.valid !== false ? 'bg-chart-5' : status?.connected ? 'bg-status-warning-foreground' : 'bg-muted-foreground/40'}`}></span>
             <span className="text-sm font-medium text-foreground/80">
               {status?.connected ? 'Connected' : 'Not Connected'}
             </span>
           </div>
           {status?.connected && status.valid === false && (
-            <p className="text-xs text-yellow-600 dark:text-yellow-400 mb-2">
+            <p className="text-sm text-status-warning-foreground mb-2">
               ⚠️ Token appears invalid - click Edit to update
             </p>
           )}
@@ -124,7 +124,7 @@ export function GitLabConnectionCard({ status, onRefresh }: Props) {
                 disabled={connectMutation.isPending}
                 className="mt-1"
               />
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-sm text-muted-foreground mt-1">
                 Use https://gitlab.com for GitLab.com or your self-hosted instance URL
               </p>
             </div>
@@ -149,7 +149,7 @@ export function GitLabConnectionCard({ status, onRefresh }: Props) {
                   {showToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                 </Button>
               </div>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-sm text-muted-foreground mt-1">
                 Create a token with <code>api</code>, <code>read_api</code>, <code>read_user</code>, and{' '}
                 <code>write_repository</code> scopes at{' '}
                 <a

--- a/components/frontend/src/components/google-drive-connection-card.tsx
+++ b/components/frontend/src/components/google-drive-connection-card.tsx
@@ -136,7 +136,7 @@ export function GoogleDriveConnectionCard({ showManageButton = true, status, onR
         {/* Status section */}
         <div className="mb-4">
           <div className="flex items-center gap-2 mb-2">
-            <span className={`w-2 h-2 rounded-full ${error ? 'bg-red-500' : status?.connected ? 'bg-green-500' : 'bg-gray-400'}`}></span>
+            <span className={`w-2 h-2 rounded-full ${error ? 'bg-destructive' : status?.connected ? 'bg-chart-5' : 'bg-muted-foreground/40'}`}></span>
             <span className="text-sm font-medium text-foreground/80">
               {error ? (
                 'Connection Error'

--- a/components/frontend/src/components/jira-connection-card.tsx
+++ b/components/frontend/src/components/jira-connection-card.tsx
@@ -112,7 +112,7 @@ export function JiraConnectionCard({ status, onRefresh }: Props) {
         {/* Status section */}
         <div className="mb-4">
           <div className="flex items-center gap-2 mb-2">
-            <span className={`w-2 h-2 rounded-full ${status?.connected && status.valid !== false ? 'bg-green-500' : status?.connected ? 'bg-yellow-500' : 'bg-gray-400'}`}></span>
+            <span className={`w-2 h-2 rounded-full ${status?.connected && status.valid !== false ? 'bg-chart-5' : status?.connected ? 'bg-status-warning-foreground' : 'bg-muted-foreground/40'}`}></span>
             <span className="text-sm font-medium text-foreground/80">
               {status?.connected ? (
                 <>Connected{status.email ? ` as ${status.email}` : ''}</>
@@ -122,7 +122,7 @@ export function JiraConnectionCard({ status, onRefresh }: Props) {
             </span>
           </div>
           {status?.connected && status.valid === false && (
-            <p className="text-xs text-yellow-600 dark:text-yellow-400 mb-2">
+            <p className="text-sm text-status-warning-foreground mb-2">
               ⚠️ Token appears invalid - click Edit to update
             </p>
           )}
@@ -162,7 +162,7 @@ export function JiraConnectionCard({ status, onRefresh }: Props) {
                 disabled={connectMutation.isPending}
                 className="mt-1"
               />
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-sm text-muted-foreground mt-1">
                 Your Jira login username (e.g., rh-dept-kerberos)
               </p>
             </div>
@@ -187,7 +187,7 @@ export function JiraConnectionCard({ status, onRefresh }: Props) {
                   {showToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                 </Button>
               </div>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-sm text-muted-foreground mt-1">
                 Create an API token at{' '}
                 <a
                   href={url ? `${url}/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens` : 'https://id.atlassian.com/manage-profile/security/api-tokens'}

--- a/components/frontend/src/components/multi-agent-selection.tsx
+++ b/components/frontend/src/components/multi-agent-selection.tsx
@@ -52,7 +52,7 @@ export function MultiAgentSelection({ agents, selectedAgents, onChange, maxAgent
                 >
                   <div className="flex flex-col">
                     <span className="text-sm">{agent.name}</span>
-                    <span className="text-xs text-muted-foreground">{agent.role}</span>
+                    <span className="text-sm text-muted-foreground">{agent.role}</span>
                   </div>
                 </DropdownMenuCheckboxItem>
               );

--- a/components/frontend/src/components/navigation.tsx
+++ b/components/frontend/src/components/navigation.tsx
@@ -57,7 +57,7 @@ export function Navigation({ feedbackUrl }: NavigationProps) {
                     <SheetTitle>
                       <span className="text-lg font-bold">ACP</span>
                       {version && (
-                        <span className="ml-2 text-xs text-muted-foreground">{version}</span>
+                        <span className="ml-2 text-sm text-muted-foreground">{version}</span>
                       )}
                     </SheetTitle>
                   </SheetHeader>
@@ -114,7 +114,7 @@ export function Navigation({ feedbackUrl }: NavigationProps) {
                   href="https://github.com/ambient-code/platform/releases"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-[0.65rem] text-muted-foreground/60 pb-0.75 hover:text-muted-foreground transition-colors"
+                  className="text-sm text-muted-foreground/60 pb-0.75 hover:text-muted-foreground transition-colors"
                 >
                   <span>{version}</span>
                 </a>

--- a/components/frontend/src/components/session-details-modal.tsx
+++ b/components/frontend/src/components/session-details-modal.tsx
@@ -137,7 +137,7 @@ export function SessionDetailsModal({
 
           {session.status?.conditions && session.status.conditions.length > 0 && (
             <div className="pt-4">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground mb-2">Reconciliation Conditions</div>
+              <div className="text-sm uppercase tracking-wide text-muted-foreground mb-2">Reconciliation Conditions</div>
               <Accordion type="multiple" className="w-full">
                 {session.status.conditions.map((condition, index) => (
                   <AccordionItem key={`${condition.type}-${index}`} value={`condition-${index}`}>
@@ -165,7 +165,7 @@ export function SessionDetailsModal({
                           </div>
                         )}
                         {condition.lastTransitionTime && (
-                          <div className="text-xs text-muted-foreground pt-2">
+                          <div className="text-sm text-muted-foreground pt-2">
                             Updated {new Date(condition.lastTransitionTime).toLocaleString()}
                           </div>
                         )}

--- a/components/frontend/src/components/session/MessagesTab.tsx
+++ b/components/frontend/src/components/session/MessagesTab.tsx
@@ -155,11 +155,11 @@ const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chat
             <div className="flex space-x-3 items-start">
               <div className="flex-shrink-0">
                 <div className="w-8 h-8 rounded-full flex items-center justify-center bg-primary ring-2 ring-background">
-                  <span className="text-white text-xs font-semibold">AI</span>
+                  <span className="text-white text-sm font-semibold">AI</span>
                 </div>
               </div>
               <div className="flex-1 min-w-0">
-                <div className="text-[10px] text-muted-foreground/60 mb-1">just now</div>
+                <div className="text-sm text-muted-foreground/60 mb-1">just now</div>
                 <div className="rounded-lg bg-card">
                   <p className="text-sm text-muted-foreground leading-relaxed mb-[0.2rem]">
                     Please wait one moment{".".repeat(waitingDotCount)}
@@ -180,7 +180,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({ session, streamMessages, chat
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
             <MessageSquare className="w-8 h-8 mx-auto mb-2 opacity-50" />
             <p className="text-sm">No messages yet</p>
-            <p className="text-xs mt-1">
+            <p className="text-sm mt-1">
               {isTerminalState
                 ? `Session has ${phase.toLowerCase()}.`
                 : "Start by sending a message below."}

--- a/components/frontend/src/components/session/SessionStartingEvents.tsx
+++ b/components/frontend/src/components/session/SessionStartingEvents.tsx
@@ -14,13 +14,13 @@ type SessionStartingEventsProps = {
 
 function EventIcon({ type, reason }: { type: string; reason: string }) {
   if (type === "Warning") {
-    return <AlertTriangle className="h-3.5 w-3.5 text-amber-500 shrink-0" />;
+    return <AlertTriangle className="h-3.5 w-3.5 text-status-warning-foreground shrink-0" />;
   }
   if (["Pulled", "Created", "Started", "Scheduled"].includes(reason)) {
-    return <CheckCircle2 className="h-3.5 w-3.5 text-green-500 shrink-0" />;
+    return <CheckCircle2 className="h-3.5 w-3.5 text-chart-5 shrink-0" />;
   }
   if (reason === "Pulling") {
-    return <Loader2 className="h-3.5 w-3.5 text-blue-500 animate-spin shrink-0" />;
+    return <Loader2 className="h-3.5 w-3.5 text-primary animate-spin shrink-0" />;
   }
   return <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0" />;
 }
@@ -29,15 +29,15 @@ function EventRow({ event }: { event: PodEvent }) {
   return (
     <div
       className={cn(
-        "flex items-start gap-2 text-xs",
+        "flex items-start gap-2 text-sm",
         event.type === "Warning"
-          ? "text-amber-600 dark:text-amber-400"
+          ? "text-status-warning-foreground"
           : "text-muted-foreground",
       )}
     >
       <EventIcon type={event.type} reason={event.reason} />
       <span className="flex-1 break-words">{event.message}</span>
-      <span className="text-[10px] tabular-nums whitespace-nowrap opacity-60 flex items-center gap-0.5">
+      <span className="text-sm tabular-nums whitespace-nowrap opacity-60 flex items-center gap-0.5">
         <Clock className="h-2.5 w-2.5" />
         {formatTimestamp(event.timestamp)}
       </span>
@@ -66,7 +66,7 @@ export function SessionStartingEvents({
       <div className="w-full max-w-md">
         {/* Header */}
         <div className="flex flex-col items-center mb-6">
-          <Loader2 className="h-10 w-10 animate-spin text-blue-600 mb-3" />
+          <Loader2 className="h-10 w-10 animate-spin text-primary mb-3" />
           <h3 className="font-semibold text-lg">Starting Session</h3>
           <p className="text-sm text-muted-foreground mt-1">
             Setting up your workspace...
@@ -86,7 +86,7 @@ export function SessionStartingEvents({
                 <button
                   type="button"
                   onClick={() => setExpanded((v) => !v)}
-                  className="w-full flex items-center justify-center gap-1 px-3 py-1.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-muted/50 border-t transition-colors"
+                  className="w-full flex items-center justify-center gap-1 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 border-t transition-colors"
                 >
                   {expanded ? (
                     <>
@@ -115,7 +115,7 @@ export function SessionStartingEvents({
 
         {/* No events yet */}
         {!latestEvent && (
-          <div className="text-center text-xs text-muted-foreground">
+          <div className="text-center text-sm text-muted-foreground">
             <p>Waiting for pod events...</p>
           </div>
         )}

--- a/components/frontend/src/components/ui/alert.tsx
+++ b/components/frontend/src/components/ui/alert.tsx
@@ -11,8 +11,8 @@ const alertVariants = cva(
         default: "bg-card text-card-foreground",
         destructive:
           "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
-        info: "bg-blue-50 border-blue-200 text-blue-900 [&>svg]:text-blue-600 *:data-[slot=alert-description]:text-blue-800 dark:bg-blue-950/50 dark:border-blue-800 dark:text-blue-300 dark:[&>svg]:text-blue-400 dark:*:data-[slot=alert-description]:text-blue-300",
-        warning: "bg-amber-50 border-amber-200 text-amber-900 [&>svg]:text-amber-600 *:data-[slot=alert-description]:text-amber-800 dark:bg-amber-950/50 dark:border-amber-800 dark:text-amber-300 dark:[&>svg]:text-amber-400 dark:*:data-[slot=alert-description]:text-amber-300",
+        info: "bg-status-info border-status-info-border text-status-info-foreground [&>svg]:text-status-info-foreground *:data-[slot=alert-description]:text-status-info-foreground/80",
+        warning: "bg-status-warning border-status-warning-border text-status-warning-foreground [&>svg]:text-status-warning-foreground *:data-[slot=alert-description]:text-status-warning-foreground/80",
       },
     },
     defaultVariants: {

--- a/components/frontend/src/components/ui/badge.tsx
+++ b/components/frontend/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-md border px-2.5 py-0.5 text-sm font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3.5 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {

--- a/components/frontend/src/components/ui/button.tsx
+++ b/components/frontend/src/components/ui/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        xs: "h-6 gap-1 rounded-md px-2 text-sm has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",

--- a/components/frontend/src/components/ui/command.tsx
+++ b/components/frontend/src/components/ui/command.tsx
@@ -118,7 +118,7 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-sm [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
         className
       )}
       {...props}
@@ -163,7 +163,7 @@ function CommandShortcut({
     <span
       data-slot="command-shortcut"
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        "ml-auto text-sm tracking-widest text-muted-foreground",
         className
       )}
       {...props}

--- a/components/frontend/src/components/ui/dropdown-menu.tsx
+++ b/components/frontend/src/components/ui/dropdown-menu.tsx
@@ -174,7 +174,7 @@ const DropdownMenuShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      className={cn("ml-auto text-sm tracking-widest opacity-60", className)}
       {...props}
     />
   );

--- a/components/frontend/src/components/ui/message.tsx
+++ b/components/frontend/src/components/ui/message.tsx
@@ -46,7 +46,7 @@ const defaultComponents: Components = {
     if (inline || isShortCode) {
       return (
         <code
-          className="bg-muted px-1.5 py-0.5 rounded text-xs font-mono"
+          className="bg-code-bg text-code-foreground px-1.5 py-0.5 rounded text-[0.9em] font-mono"
           {...(props as React.HTMLAttributes<HTMLElement>)}
         >
           {children}
@@ -56,7 +56,7 @@ const defaultComponents: Components = {
 
     // Full code blocks for longer content
     return (
-      <pre className="bg-muted text-foreground py-3 rounded text-xs overflow-x-auto border my-2">
+      <pre className="bg-code-bg text-code-foreground py-3 px-3 rounded-lg text-[0.9em] overflow-x-auto border border-border/50 my-2">
         <code
           className={className}
           {...(props as React.HTMLAttributes<HTMLElement>)}
@@ -67,22 +67,22 @@ const defaultComponents: Components = {
     );
   },
   p: ({ children }) => (
-    <div className="text-muted-foreground leading-relaxed mb-[0.2rem] text-sm">{children}</div>
+    <div className="text-foreground/80 leading-relaxed mb-1 text-base">{children}</div>
   ),
   h1: ({ children }) => (
-    <h1 className="text-lg font-bold text-foreground mb-2">{children}</h1>
+    <h1 className="text-xl font-bold text-foreground mb-2">{children}</h1>
   ),
   h2: ({ children }) => (
-    <h2 className="text-md font-semibold text-foreground mb-2">{children}</h2>
+    <h2 className="text-lg font-semibold text-foreground mb-2">{children}</h2>
   ),
   h3: ({ children }) => (
-    <h3 className="text-sm font-medium text-foreground mb-1">{children}</h3>
+    <h3 className="text-base font-medium text-foreground mb-1">{children}</h3>
   ),
   ul: ({ children }) => (
-    <ul className="list-disc list-outside ml-4 mb-2 space-y-1 text-muted-foreground text-sm">{children}</ul>
+    <ul className="list-disc list-outside ml-4 mb-2 space-y-1 text-foreground/80 text-base">{children}</ul>
   ),
   ol: ({ children }) => (
-    <ol className="list-decimal list-outside ml-4 mb-2 space-y-1 text-muted-foreground text-sm">{children}</ol>
+    <ol className="list-decimal list-outside ml-4 mb-2 space-y-1 text-foreground/80 text-base">{children}</ol>
   ),
   li: ({ children }) => (
     <li className="leading-relaxed">{children}</li>
@@ -92,7 +92,7 @@ const defaultComponents: Components = {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-primary hover:underline cursor-pointer"
+      className="text-link hover:text-link-hover hover:underline cursor-pointer"
     >
       {children}
     </a>
@@ -124,7 +124,7 @@ function parseMarkdownLinks(text: string): React.ReactNode {
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-primary hover:underline"
+          className="text-link hover:text-link-hover hover:underline"
         >
           {match[1]}
         </a>
@@ -203,34 +203,33 @@ export const LoadingDots = () => {
           className="loading-dot loading-dot-1"
           cx="8"
           cy="8"
-          r="6"
-          fill="#0066B1"
+          r="5"
+          fill="var(--primary)"
         />
         <circle
           className="loading-dot loading-dot-2"
           cx="22"
           cy="8"
-          r="6"
-          fill="#522DAE"
+          r="5"
+          fill="var(--chart-2)"
         />
         <circle
           className="loading-dot loading-dot-3"
           cx="36"
           cy="8"
-          r="6"
-          fill="#F40000"
+          r="5"
+          fill="var(--destructive)"
         />
         <circle
           className="loading-dot loading-dot-4"
           cx="50"
           cy="8"
-          r="6"
-          fill="#FFFFFF"
-          stroke="#9CA3AF"
-          strokeWidth="1"
+          r="5"
+          fill="var(--muted-foreground)"
+          opacity="0.4"
         />
       </svg>
-      <span className="ml-2 text-xs text-muted-foreground">{parseMarkdownLinks(tips[messageIndex])}</span>
+      <span className="ml-2 text-sm text-muted-foreground">{parseMarkdownLinks(tips[messageIndex])}</span>
     </div>
   );
 };
@@ -241,7 +240,7 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
     ref
   ) => {
     const isBot = role === "bot";
-    const avatarBg = isBot ? "bg-primary ring-2 ring-background" : "bg-emerald-600 dark:bg-emerald-500 ring-2 ring-background";
+    const avatarBg = isBot ? "bg-primary" : "bg-chart-2";
     const avatarText = isBot ? "AI" : "U";
     const formattedTime = formatTimestamp(timestamp);
     const isActivelyStreaming = streaming && isBot;
@@ -250,12 +249,12 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
       <div className="flex-shrink-0">
       <div
         className={cn(
-          "w-8 h-8 rounded-full flex items-center justify-center",
+          "w-8 h-8 rounded-full flex items-center justify-center ring-2 ring-background",
           avatarBg,
           (isLoading || isActivelyStreaming) && "animate-pulse"
         )}
       >
-        <span className="text-white text-xs font-semibold">
+        <span className="text-white text-sm font-semibold">
           {avatarText}
         </span>
       </div>
@@ -272,19 +271,19 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
           <div className={cn("flex-1 min-w-0", !isBot && "max-w-[70%]")}>
             {/* Timestamp */}
             {formattedTime && (
-              <div className={cn("text-[10px] text-muted-foreground/60 mb-1", !isBot && "text-right")}>
+              <div className={cn("text-sm text-muted-foreground/60 mb-1", !isBot && "text-right")}>
                 {formattedTime}
               </div>
             )}
             <div className={cn(
               borderless ? "p-0" : "rounded-lg",
-              !borderless && (isBot ? "bg-card" : "bg-primary/10 dark:bg-primary/15")
+              !borderless && (isBot ? "bg-card" : "bg-primary/8 dark:bg-primary/12")
             )}>
               {/* Content */}
-              <div className={cn("text-sm text-foreground font-mono", !isBot && "py-2 px-4")}>
+              <div className={cn("text-base text-foreground", !isBot && "py-2 px-4")}>
                 {isLoading ? (
                   <div>
-                    <div className="text-sm text-muted-foreground mb-2">{content}</div>
+                    <div className="text-base text-muted-foreground mb-2">{content}</div>
                     <LoadingDots />
                   </div>
                 ) : (

--- a/components/frontend/src/components/ui/select.tsx
+++ b/components/frontend/src/components/ui/select.tsx
@@ -92,7 +92,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      className={cn("text-muted-foreground px-2 py-1.5 text-sm", className)}
       {...props}
     />
   )

--- a/components/frontend/src/components/ui/sidebar.tsx
+++ b/components/frontend/src/components/ui/sidebar.tsx
@@ -405,7 +405,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-sm font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -484,7 +484,7 @@ const sidebarMenuButtonVariants = cva(
       },
       size: {
         default: "h-8 text-sm",
-        sm: "h-7 text-xs",
+        sm: "h-7 text-sm",
         lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
       },
     },
@@ -586,7 +586,7 @@ function SidebarMenuBadge({
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-sm font-medium text-sidebar-foreground tabular-nums select-none",
         "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
@@ -688,7 +688,7 @@ function SidebarMenuSubButton({
       className={cn(
         "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
-        size === "sm" && "text-xs",
+        size === "sm" && "text-sm",
         size === "md" && "text-sm",
         "group-data-[collapsible=icon]:hidden",
         className

--- a/components/frontend/src/components/ui/stream-message.tsx
+++ b/components/frontend/src/components/ui/stream-message.tsx
@@ -59,7 +59,7 @@ export const StreamMessage: React.FC<StreamMessageProps> = ({ message, onGoToRes
     case "agent_waiting": {
       if (!isNewest) return null;
       return (
-        <span className="text-xs text-muted-foreground">{getRandomAgentMessage()}</span>
+        <span className="text-sm text-muted-foreground">{getRandomAgentMessage()}</span>
       )
     }
     case "user_message":
@@ -132,7 +132,7 @@ export const StreamMessage: React.FC<StreamMessageProps> = ({ message, onGoToRes
           timestamp={m.timestamp}
           actions={
             <div className="flex items-center justify-between">
-              <div className="text-xs text-muted-foreground">
+              <div className="text-sm text-muted-foreground">
                 Duration: {m.duration_ms} ms • API: {m.duration_api_ms} ms • Turns: {m.num_turns}
               </div>
               <Button variant='link' size="sm" className="ml-3" onClick={onGoToResults}>Go to Results</Button>

--- a/components/frontend/src/components/ui/system-message.tsx
+++ b/components/frontend/src/components/ui/system-message.tsx
@@ -14,13 +14,11 @@ export type SystemMessageProps = {
 };
 
 export const SystemMessage: React.FC<SystemMessageProps> = ({ data, className }) => {
-  // Expect a simple string in data.message; fallback to JSON.stringify
   const text: string = typeof (data?.message) === 'string' ? data.message : (typeof data === 'string' ? data : JSON.stringify(data ?? {}, null, 2));
 
-  // Compact style: Just small grey text, no card, no avatar
   return (
     <div className={cn("my-1 px-2", className)}>
-      <p className="text-xs text-muted-foreground/60 italic">
+      <p className="text-sm text-muted-foreground/60 italic">
         {text}
       </p>
     </div>

--- a/components/frontend/src/components/ui/table.tsx
+++ b/components/frontend/src/components/ui/table.tsx
@@ -68,7 +68,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-xs uppercase tracking-wide [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-sm uppercase tracking-wide [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/components/frontend/src/components/ui/thinking-message.tsx
+++ b/components/frontend/src/components/ui/thinking-message.tsx
@@ -24,18 +24,18 @@ export const ThinkingMessage: React.FC<ThinkingMessageProps> = ({ block, streami
       >
         <ChevronRight
           className={cn(
-            "h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-150",
+            "h-4 w-4 shrink-0 text-muted-foreground/60 transition-transform duration-150",
             expanded && "rotate-90",
           )}
         />
-        <span className="text-xs font-medium text-muted-foreground/70">
+        <span className="text-sm font-medium text-muted-foreground/70">
           Thinking
           {streaming && !expanded && (
             <span className="ml-1 animate-pulse">...</span>
           )}
         </span>
         {!expanded && text && (
-          <span className="text-xs text-muted-foreground/50 truncate min-w-0">
+          <span className="text-sm text-muted-foreground/50 truncate min-w-0">
             &mdash; {text}
           </span>
         )}
@@ -43,7 +43,7 @@ export const ThinkingMessage: React.FC<ThinkingMessageProps> = ({ block, streami
 
       {expanded && (
         <div className="mt-1 ml-5">
-          <pre className="text-xs text-muted-foreground/60 whitespace-pre-wrap break-words leading-relaxed">
+          <pre className="text-sm text-muted-foreground/60 whitespace-pre-wrap break-words leading-relaxed">
             {text}
             {streaming && <span className="animate-pulse">&#9608;</span>}
           </pre>

--- a/components/frontend/src/components/ui/tool-message.tsx
+++ b/components/frontend/src/components/ui/tool-message.tsx
@@ -28,7 +28,6 @@ export type ToolMessageProps = {
 
 const formatToolName = (toolName?: string) => {
   if (!toolName) return "Unknown Tool";
-  // Remove mcp__ prefix and format nicely
   return toolName
     .replace(/^mcp__/, "")
     .replace(/_/g, " ")
@@ -62,7 +61,6 @@ const ExpandableMarkdown: React.FC<ExpandableMarkdownProps> = ({
   const shouldTruncate = content.length > maxLength;
   const display = expanded || !shouldTruncate ? content : content.substring(0, maxLength);
 
-  // Match Message.tsx rendering so headers/code look correct
   const markdownComponents: Components = {
     code: ({
       inline,
@@ -75,21 +73,21 @@ const ExpandableMarkdown: React.FC<ExpandableMarkdownProps> = ({
       children?: React.ReactNode;
     } & React.HTMLAttributes<HTMLElement>) => {
       return inline ? (
-        <code className="bg-muted px-1 py-0.5 rounded text-xs" {...(props as React.HTMLAttributes<HTMLElement>)}>
+        <code className="bg-code-bg text-code-foreground px-1 py-0.5 rounded text-[0.9em]" {...(props as React.HTMLAttributes<HTMLElement>)}>
           {children}
         </code>
       ) : (
-        <pre className="bg-slate-950 dark:bg-black text-slate-50 p-2 rounded text-xs overflow-x-auto">
+        <pre className="bg-code-bg text-code-foreground p-3 rounded-lg text-sm overflow-x-auto border border-border/50">
           <code className={className} {...(props as React.HTMLAttributes<HTMLElement>)}>
             {children}
           </code>
         </pre>
       );
     },
-    p: ({ children }) => <div className="text-muted-foreground leading-relaxed mb-2 text-sm">{children}</div>,
-    h1: ({ children }) => <h1 className="text-lg font-bold text-foreground mb-2">{children}</h1>,
-    h2: ({ children }) => <h2 className="text-md font-semibold text-foreground mb-2">{children}</h2>,
-    h3: ({ children }) => <h3 className="text-sm font-medium text-foreground mb-1">{children}</h3>,
+    p: ({ children }) => <div className="text-foreground/75 leading-relaxed mb-2 text-base">{children}</div>,
+    h1: ({ children }) => <h1 className="text-xl font-bold text-foreground mb-2">{children}</h1>,
+    h2: ({ children }) => <h2 className="text-lg font-semibold text-foreground mb-2">{children}</h2>,
+    h3: ({ children }) => <h3 className="text-base font-medium text-foreground mb-1">{children}</h3>,
   };
 
   return (
@@ -102,7 +100,7 @@ const ExpandableMarkdown: React.FC<ExpandableMarkdownProps> = ({
           <button
             type="button"
             onClick={() => setExpanded(!expanded)}
-            className="text-xs px-2 py-1 rounded border bg-card hover:bg-muted/50 text-foreground/80"
+            className="text-sm px-2.5 py-1 rounded-md border bg-card hover:bg-muted/50 text-foreground/80 transition-colors"
           >
             {expanded ? "Show less" : "Show more"}
           </button>
@@ -124,23 +122,30 @@ const hashStringToNumber = (str: string) => {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
     hash = (hash << 5) - hash + str.charCodeAt(i);
-    hash |= 0; // Convert to 32bit integer
+    hash |= 0;
   }
   return Math.abs(hash);
 };
 
+/*
+ * Refined agent color palette — muted, cohesive tones derived from the
+ * three brand accents (blue 255, purple 290, red 25) plus complementary hues.
+ * Uses semantic design tokens for consistency across themes.
+ */
 const getColorClassesForName = (name: string) => {
   const colorChoices = [
-    { avatarBg: "bg-purple-600", badgeBg: "bg-purple-600", cardBg: "bg-purple-50 dark:bg-purple-950/50", border: "border-purple-200 dark:border-purple-800", badgeText: "text-purple-700 dark:text-purple-300", badgeBorder: "border-purple-200 dark:border-purple-800" },
-    { avatarBg: "bg-blue-600", badgeBg: "bg-blue-600", cardBg: "bg-blue-50 dark:bg-blue-950/50", border: "border-blue-200 dark:border-blue-800", badgeText: "text-blue-700 dark:text-blue-300", badgeBorder: "border-blue-200 dark:border-blue-800" },
-    { avatarBg: "bg-emerald-600", badgeBg: "bg-emerald-600", cardBg: "bg-emerald-50 dark:bg-emerald-950/50", border: "border-emerald-200 dark:border-emerald-800", badgeText: "text-emerald-700 dark:text-emerald-300", badgeBorder: "border-emerald-200 dark:border-emerald-800" },
-    { avatarBg: "bg-teal-600", badgeBg: "bg-teal-600", cardBg: "bg-teal-50 dark:bg-teal-950/50", border: "border-teal-200 dark:border-teal-800", badgeText: "text-teal-700 dark:text-teal-300", badgeBorder: "border-teal-200 dark:border-teal-800" },
-    { avatarBg: "bg-cyan-600", badgeBg: "bg-cyan-600", cardBg: "bg-cyan-50 dark:bg-cyan-950/50", border: "border-cyan-200 dark:border-cyan-800", badgeText: "text-cyan-700 dark:text-cyan-300", badgeBorder: "border-cyan-200 dark:border-cyan-800" },
-    { avatarBg: "bg-sky-600", badgeBg: "bg-sky-600", cardBg: "bg-sky-50 dark:bg-sky-950/50", border: "border-sky-200 dark:border-sky-800", badgeText: "text-sky-700 dark:text-sky-300", badgeBorder: "border-sky-200 dark:border-sky-800" },
-    { avatarBg: "bg-indigo-600", badgeBg: "bg-indigo-600", cardBg: "bg-indigo-50 dark:bg-indigo-950/50", border: "border-indigo-200 dark:border-indigo-800", badgeText: "text-indigo-700 dark:text-indigo-300", badgeBorder: "border-indigo-200 dark:border-indigo-800" },
-    { avatarBg: "bg-fuchsia-600", badgeBg: "bg-fuchsia-600", cardBg: "bg-fuchsia-50 dark:bg-fuchsia-950/50", border: "border-fuchsia-200 dark:border-fuchsia-800", badgeText: "text-fuchsia-700 dark:text-fuchsia-300", badgeBorder: "border-fuchsia-200 dark:border-fuchsia-800" },
-    { avatarBg: "bg-rose-600", badgeBg: "bg-rose-600", cardBg: "bg-rose-50 dark:bg-rose-950/50", border: "border-rose-200 dark:border-rose-800", badgeText: "text-rose-700 dark:text-rose-300", badgeBorder: "border-rose-200 dark:border-rose-800" },
-    { avatarBg: "bg-amber-600", badgeBg: "bg-amber-600", cardBg: "bg-amber-50 dark:bg-amber-950/50", border: "border-amber-200 dark:border-amber-800", badgeText: "text-amber-700 dark:text-amber-300", badgeBorder: "border-amber-200 dark:border-amber-800" },
+    // Blue family (primary)
+    { avatarBg: "bg-primary", badgeBg: "bg-primary", cardBg: "bg-primary/5 dark:bg-primary/8", border: "border-primary/20 dark:border-primary/25", badgeText: "text-primary dark:text-primary", badgeBorder: "border-primary/20 dark:border-primary/25" },
+    // Purple family (chart-2)
+    { avatarBg: "bg-chart-2", badgeBg: "bg-chart-2", cardBg: "bg-chart-2/5 dark:bg-chart-2/8", border: "border-chart-2/20 dark:border-chart-2/25", badgeText: "text-chart-2 dark:text-chart-2", badgeBorder: "border-chart-2/20 dark:border-chart-2/25" },
+    // Teal family (chart-4)
+    { avatarBg: "bg-chart-4", badgeBg: "bg-chart-4", cardBg: "bg-chart-4/5 dark:bg-chart-4/8", border: "border-chart-4/20 dark:border-chart-4/25", badgeText: "text-chart-4 dark:text-chart-4", badgeBorder: "border-chart-4/20 dark:border-chart-4/25" },
+    // Green family (chart-5)
+    { avatarBg: "bg-chart-5", badgeBg: "bg-chart-5", cardBg: "bg-chart-5/5 dark:bg-chart-5/8", border: "border-chart-5/20 dark:border-chart-5/25", badgeText: "text-chart-5 dark:text-chart-5", badgeBorder: "border-chart-5/20 dark:border-chart-5/25" },
+    // Warm accent (destructive / red family)
+    { avatarBg: "bg-destructive", badgeBg: "bg-destructive", cardBg: "bg-destructive/5 dark:bg-destructive/8", border: "border-destructive/20 dark:border-destructive/25", badgeText: "text-destructive dark:text-destructive", badgeBorder: "border-destructive/20 dark:border-destructive/25" },
+    // Muted blue-gray
+    { avatarBg: "bg-muted-foreground", badgeBg: "bg-muted-foreground", cardBg: "bg-muted/50 dark:bg-muted/30", border: "border-border dark:border-border", badgeText: "text-muted-foreground dark:text-muted-foreground", badgeBorder: "border-border dark:border-border" },
   ];
   const idx = hashStringToNumber(name) % colorChoices.length;
   return colorChoices[idx];
@@ -148,9 +153,6 @@ const getColorClassesForName = (name: string) => {
 
 // Helper to convert Python literal to JSON-parseable string
 const pythonLiteralToJson = (pythonStr: string): string => {
-  // This handles Python dict/list notation like [{'type': 'text', 'text': '...'}]
-  // Use a state machine to properly handle quotes and escape sequences
-
   let result = '';
   let inString = false;
   let stringChar = '';
@@ -160,21 +162,15 @@ const pythonLiteralToJson = (pythonStr: string): string => {
     const char = pythonStr[i];
 
     if (escaped) {
-      // Handle escape sequences
       if (inString) {
-        // Inside string - convert Python escapes to JSON escapes
         if (char === "'") {
-          // Python: \' → JSON: ' (no escape needed in double-quoted JSON string)
           result += "'";
         } else if (char === '"') {
-          // Python: \" → JSON: \" (keep escape)
           result += '\\"';
         } else {
-          // All other escapes (\n, \t, \\, etc.) are valid in both
           result += '\\' + char;
         }
       } else {
-        // Outside string - just copy
         result += '\\' + char;
       }
       escaped = false;
@@ -186,38 +182,30 @@ const pythonLiteralToJson = (pythonStr: string): string => {
       continue;
     }
 
-    // Handle quotes
     if (char === "'" || char === '"') {
       if (!inString) {
-        // Starting a string
         inString = true;
         stringChar = char;
-        result += '"'; // Always use double quotes in JSON
+        result += '"';
       } else if (char === stringChar) {
-        // Ending a string
         inString = false;
         stringChar = '';
         result += '"';
       } else {
-        // Different quote inside string
         if (char === '"') {
-          // Double quote inside single-quoted Python string
-          result += '\\"'; // Must escape in JSON
+          result += '\\"';
         } else {
-          // Single quote inside double-quoted string
-          result += "'"; // No escape needed
+          result += "'";
         }
       }
       continue;
     }
 
-    // If we're in a string, just copy characters
     if (inString) {
       result += char;
       continue;
     }
 
-    // Handle Python keywords outside strings
     if (!inString) {
       if (pythonStr.substr(i, 4) === 'True') {
         result += 'true';
@@ -244,23 +232,17 @@ const pythonLiteralToJson = (pythonStr: string): string => {
 
 const extractTextFromResultContent = (content: unknown): string => {
   try {
-    // If string, try to parse as JSON/Python first (handles stringified arrays/objects)
     if (typeof content === "string") {
-      // Try parsing if it looks like JSON/Python
       if (content.trim().startsWith("[") || content.trim().startsWith("{")) {
         try {
-          // FIRST: Try parsing as valid JSON (backend now sends proper JSON)
           const parsed = JSON.parse(content);
           return extractTextFromResultContent(parsed);
         } catch {
-          // FALLBACK: Try converting Python notation to JSON (for old sessions)
           try {
             const jsonStr = pythonLiteralToJson(content);
             const parsed = JSON.parse(jsonStr);
             return extractTextFromResultContent(parsed);
           } catch {
-            // LAST RESORT: Can't parse, just return the raw string
-            // This handles cases where the content is malformed or uses unknown syntax
             console.warn('Failed to parse result content, showing raw text');
             return content;
           }
@@ -269,7 +251,6 @@ const extractTextFromResultContent = (content: unknown): string => {
       return content;
     }
 
-    // Handle arrays of text blocks
     if (Array.isArray(content)) {
       const texts = content
         .map((item) => {
@@ -282,7 +263,6 @@ const extractTextFromResultContent = (content: unknown): string => {
       if (texts.length) return texts.join("\n\n");
     }
 
-    // Handle nested content arrays
     if (content && typeof content === "object") {
       const maybe = (content as Record<string, unknown>).content;
       if (Array.isArray(maybe)) {
@@ -308,25 +288,21 @@ const extractTextFromResultContent = (content: unknown): string => {
 const generateToolSummary = (toolName: string, input?: Record<string, unknown>): string => {
   if (!input || Object.keys(input).length === 0) return formatToolName(toolName);
 
-  // WebSearch - show query
   if (toolName.toLowerCase().includes("websearch") || toolName.toLowerCase().includes("web_search")) {
     const query = input.query as string | undefined;
     if (query) return `Searching the web for "${query}"`;
   }
 
-  // FileRead - show file path
   if (toolName.toLowerCase().includes("read") && (input.file || input.path || input.target_file)) {
     const file = (input.file || input.path || input.target_file) as string;
     return `Reading ${file}`;
   }
 
-  // FileWrite - show file path
   if (toolName.toLowerCase().includes("write") && (input.file || input.path || input.target_file)) {
     const file = (input.file || input.path || input.target_file) as string;
     return `Writing to ${file}`;
   }
 
-  // Grep - show pattern and path
   if (toolName.toLowerCase().includes("grep") || toolName.toLowerCase().includes("search")) {
     const pattern = input.pattern as string | undefined;
     const path = input.path as string | undefined;
@@ -334,7 +310,6 @@ const generateToolSummary = (toolName: string, input?: Record<string, unknown>):
     if (pattern) return `Searching for "${pattern}"`;
   }
 
-  // Command execution
   if (toolName.toLowerCase().includes("command") || toolName.toLowerCase().includes("terminal")) {
     const command = input.command as string | undefined;
     if (command) {
@@ -343,14 +318,12 @@ const generateToolSummary = (toolName: string, input?: Record<string, unknown>):
     }
   }
 
-  // Fallback: show first string value from input (often contains the main parameter)
   const firstStringValue = Object.values(input).find(v => typeof v === 'string' && v.length > 0) as string | undefined;
   if (firstStringValue) {
     const truncated = firstStringValue.length > 60 ? firstStringValue.substring(0, 60) + "..." : firstStringValue;
     return truncated;
   }
 
-  // Last resort: show formatted tool name
   return formatToolName(toolName);
 };
 
@@ -363,23 +336,17 @@ type ChildToolCallProps = {
 const ChildToolCall: React.FC<ChildToolCallProps> = ({ toolUseBlock, resultBlock }) => {
   const [expanded, setExpanded] = useState(false);
 
-  // Check if result has actual content (same logic as parent tool)
   const hasActualResult = Boolean(
     resultBlock &&
     resultBlock.content !== undefined &&
     resultBlock.content !== null &&
     (() => {
       const content = resultBlock.content;
-      // Empty string
       if (content === "") return false;
-      // Empty array
       if (Array.isArray(content) && content.length === 0) return false;
-      // Empty object
       if (typeof content === 'object' && !Array.isArray(content) && Object.keys(content).length === 0) return false;
-      // String that only contains whitespace or quotes
       if (typeof content === 'string' && content.trim() === '') return false;
       if (typeof content === 'string' && (content === '""' || content === "''")) return false;
-      // Has actual content
       return true;
     })()
   );
@@ -390,14 +357,12 @@ const ChildToolCall: React.FC<ChildToolCallProps> = ({ toolUseBlock, resultBlock
 
   const toolName = toolUseBlock?.name || "unknown_tool";
 
-  // Parse input - it might be a string that needs JSON parsing or already an object
   let toolInput: Record<string, unknown> | undefined;
   if (toolUseBlock?.input) {
     if (typeof toolUseBlock.input === 'string') {
       try {
         toolInput = JSON.parse(toolUseBlock.input) as Record<string, unknown>;
       } catch {
-        // If parsing fails, treat the string as a single value
         toolInput = { value: toolUseBlock.input };
       }
     } else {
@@ -405,53 +370,49 @@ const ChildToolCall: React.FC<ChildToolCallProps> = ({ toolUseBlock, resultBlock
     }
   }
 
-  // Generate smart collapsed summary - ALWAYS show the query/input, not the result
-  // Result should only be visible when expanded
   const collapsedSummary = generateToolSummary(toolName, toolInput);
 
   return (
-    <div className="py-1">
+    <div className="py-0.5">
       <div
-        className="flex items-center gap-2 cursor-pointer hover:bg-muted/30 rounded px-2 py-1"
+        className="flex items-center gap-2 cursor-pointer hover:bg-muted/40 rounded-md px-2 py-1.5 transition-colors"
         onClick={() => setExpanded(!expanded)}
       >
-        {isError && <X className="w-3 h-3 text-red-500 flex-shrink-0" />}
-        {isSuccess && <Check className="w-3 h-3 text-green-500 flex-shrink-0" />}
-        {isPending && <Loader2 className="w-3 h-3 animate-spin text-blue-500 flex-shrink-0" />}
+        {isError && <X className="w-3.5 h-3.5 text-destructive flex-shrink-0" />}
+        {isSuccess && <Check className="w-3.5 h-3.5 text-chart-5 flex-shrink-0" />}
+        {isPending && <Loader2 className="w-3.5 h-3.5 animate-spin text-primary flex-shrink-0" />}
 
-        <Badge variant="secondary" className="text-[10px] px-1.5 py-0.5 flex-shrink-0">
+        <Badge variant="secondary" className="text-sm px-2 py-0.5 flex-shrink-0">
           {formatToolName(toolName)}
         </Badge>
 
-        {/* Collapsed summary */}
         {!expanded && (
-          <span className="text-[11px] text-muted-foreground truncate flex-1">
+          <span className="text-sm text-muted-foreground truncate flex-1">
             {collapsedSummary}
           </span>
         )}
 
         <ChevronRight className={cn(
-          "w-3 h-3 text-muted-foreground transition-transform flex-shrink-0",
+          "w-3.5 h-3.5 text-muted-foreground transition-transform flex-shrink-0",
           expanded && "rotate-90"
         )} />
       </div>
 
       {expanded && (
-        <div className="mt-1 ml-5 text-xs space-y-2 bg-muted/20 rounded p-2 border border-border">
+        <div className="mt-1 ml-5 space-y-2 bg-muted/20 rounded-lg p-3 border border-border/50">
           {toolInput && Object.keys(toolInput).length > 0 && (
             <div>
-              <div className="font-medium text-foreground/70 mb-1">Input</div>
-              <pre className="text-[10px] overflow-x-auto text-muted-foreground">
+              <div className="font-medium text-foreground/60 mb-1 text-sm">Input</div>
+              <pre className="text-sm overflow-x-auto text-muted-foreground bg-code-bg rounded-md p-2">
                 {JSON.stringify(toolInput, null, 2)}
               </pre>
             </div>
           )}
           {resultBlock?.content && (
             <div>
-              <div className="font-medium text-foreground/70 mb-1">
-                Result {isError && <span className="text-red-600">(Error)</span>}
+              <div className="font-medium text-foreground/60 mb-1 text-sm">
+                Result {isError && <span className="text-destructive">(Error)</span>}
               </div>
-              {/* Render result as markdown for better formatting */}
               <ExpandableMarkdown
                 className="prose-sm"
                 content={extractTextFromResultContent(resultBlock.content as unknown)}
@@ -471,23 +432,17 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
 
     const toolResultBlock = resultBlock;
 
-    // Check if result has actual content (not just empty object/array/string)
     const hasActualResult = Boolean(
       toolResultBlock &&
       toolResultBlock.content !== undefined &&
       toolResultBlock.content !== null &&
       (() => {
         const content = toolResultBlock.content;
-        // Empty string
         if (content === "") return false;
-        // Empty array
         if (Array.isArray(content) && content.length === 0) return false;
-        // Empty object
         if (typeof content === 'object' && !Array.isArray(content) && Object.keys(content).length === 0) return false;
-        // String that only contains whitespace or quotes
         if (typeof content === 'string' && content.trim() === '') return false;
         if (typeof content === 'string' && (content === '""' || content === "''")) return false;
-        // Has actual content
         return true;
       })()
     );
@@ -495,10 +450,9 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
     const isToolCall = Boolean(toolUseBlock && !hasActualResult);
     const isToolResult = hasActualResult;
 
-    // For tool calls/results, show collapsible interface
     const toolName = formatToolName(toolUseBlock?.name);
     const isError = toolResultBlock?.is_error === true;
-    const isLoading = isToolCall && !isError; // Tool call without result is loading, unless there's an error
+    const isLoading = isToolCall && !isError;
     const isSuccess = isToolResult && !isError;
 
     // Subagent detection and data
@@ -510,7 +464,6 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
     const subagentClasses = subagentType ? getColorClassesForName(subagentType) : undefined;
     const displayName = isSubagent ? subagentType : toolName;
 
-    // Compact mode for simple tool calls (non-subagent)
     const isCompact = !isSubagent;
 
     const formattedTime = formatTimestamp(timestamp);
@@ -522,13 +475,13 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
           <div className="flex-shrink-0">
             {isSubagent ? (
               <div className={cn("w-8 h-8 rounded-full flex items-center justify-center", subagentClasses?.avatarBg)}>
-                <span className="text-white text-xs font-semibold">
+                <span className="text-white text-sm font-semibold">
                   {getInitials(subagentType)}
                 </span>
               </div>
             ) : (
-              <div className="w-8 h-8 rounded-full flex items-center justify-center bg-purple-600">
-                <Cog className="w-4 h-4 text-white" />
+              <div className="w-8 h-8 rounded-full flex items-center justify-center bg-muted-foreground/60">
+                <Cog className="w-4 h-4 text-background" />
               </div>
             )}
           </div>
@@ -537,7 +490,7 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
           <div className="flex-1 min-w-0">
             {/* Timestamp */}
             {formattedTime && (
-              <div className="text-[10px] text-muted-foreground/60 mb-1">
+              <div className="text-sm text-muted-foreground/60 mb-1">
                 {formattedTime}
               </div>
             )}
@@ -551,57 +504,44 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
               {/* Collapsible Header */}
               <div
                 className={cn(
-                  "flex items-center justify-between cursor-pointer hover:bg-muted/50 transition-colors",
-                  isCompact ? "py-1 px-0" : "p-3"
+                  "flex items-center justify-between cursor-pointer hover:bg-muted/40 transition-colors rounded-md",
+                  isCompact ? "py-1.5 px-0" : "p-3"
                 )}
                 onClick={() => setIsExpanded(!isExpanded)}
               >
-                <div className={cn("flex items-center flex-1 min-w-0", isCompact ? "space-x-1.5" : "space-x-2")}>
+                <div className={cn("flex items-center flex-1 min-w-0", isCompact ? "space-x-2" : "space-x-2.5")}>
                   {/* Status Icon */}
-                  {!isCompact && (
-                    <div className="flex-shrink-0">
-                      {isLoading && (
-                        <Loader2 className="w-4 h-4 text-blue-500 animate-spin" />
-                      )}
-                      {isSuccess && <Check className="w-4 h-4 text-green-500" />}
-                      {isError && <X className="w-4 h-4 text-red-500" />}
-                    </div>
-                  )}
-                  {isCompact && (
-                    <div className="flex-shrink-0">
-                      {isLoading && (
-                        <Loader2 className="w-3 h-3 text-blue-500 animate-spin" />
-                      )}
-                      {isSuccess && <Check className="w-3 h-3 text-green-500" />}
-                      {isError && <X className="w-3 h-3 text-red-500" />}
-                    </div>
-                  )}
+                  <div className="flex-shrink-0">
+                    {isLoading && (
+                      <Loader2 className={cn(isCompact ? "w-3.5 h-3.5" : "w-4 h-4", "text-primary animate-spin")} />
+                    )}
+                    {isSuccess && <Check className={cn(isCompact ? "w-3.5 h-3.5" : "w-4 h-4", "text-chart-5")} />}
+                    {isError && <X className={cn(isCompact ? "w-3.5 h-3.5" : "w-4 h-4", "text-destructive")} />}
+                  </div>
 
                   {/* Tool Name Badge */}
                   <div className="flex-shrink-0">
                     <Badge
                       className={cn(
-                        "text-xs text-white",
+                        "text-sm text-white",
                         isLoading && "bg-primary",
                         isError && "bg-destructive",
-                        isSuccess && "bg-emerald-600 dark:bg-emerald-500",
+                        isSuccess && "bg-chart-5",
                         isSubagent && subagentClasses?.badgeBg,
-                        isCompact && "!py-0 px-1.5 leading-tight"
+                        isCompact && "!py-0.5 px-2 leading-tight"
                       )}
                     >
                       {displayName}
                     </Badge>
                   </div>
 
-                  {/* Title/Description - Always visible (collapsed or expanded) */}
-                  <div className="flex-1 min-w-0 text-sm text-muted-foreground truncate">
+                  {/* Title/Description */}
+                  <div className="flex-1 min-w-0 text-base text-muted-foreground truncate">
                     {isSubagent ? (
-                      // Agent: Show description (title)
                       <span className="truncate">
                         {subagentDescription || subagentPrompt || "Working..."}
                       </span>
                     ) : (
-                      // Regular tool: Show query/input summary
                       <span className="truncate">
                         {generateToolSummary(toolUseBlock?.name || "", inputData)}
                       </span>
@@ -611,36 +551,36 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
                   {/* Expand/Collapse Icon */}
                   <div className="flex-shrink-0">
                     {isExpanded ? (
-                      <ChevronDown className={cn(isCompact ? "w-3 h-3" : "w-4 h-4", "text-muted-foreground/60")} />
+                      <ChevronDown className="w-4 h-4 text-muted-foreground/60" />
                     ) : (
-                      <ChevronRight className={cn(isCompact ? "w-3 h-3" : "w-4 h-4", "text-muted-foreground/60")} />
+                      <ChevronRight className="w-4 h-4 text-muted-foreground/60" />
                     )}
                   </div>
                 </div>
               </div>
 
-              {/* Subagent primary content - REORDERED: Input → Activity → Result */}
+              {/* Subagent primary content — Input → Activity → Result */}
               {isSubagent && isExpanded ? (
                 <div className="px-3 pb-3 space-y-3">
-                  {/* 1. INPUT - Show when expanded */}
+                  {/* 1. INPUT */}
                   {subagentPrompt && (
                     <div className="space-y-2">
-                      <h4 className="text-xs font-medium text-foreground/60 uppercase tracking-wide">
+                      <h4 className="text-sm font-medium text-foreground/50 uppercase tracking-wide">
                         Prompt
                       </h4>
-                      <div className="rounded p-2 overflow-x-auto bg-muted/20 border border-border text-xs text-muted-foreground">
+                      <div className="rounded-lg p-3 overflow-x-auto bg-muted/20 border border-border/50 text-base text-foreground/75">
                         <ExpandableMarkdown className="prose-sm" content={subagentPrompt} maxLength={500} />
                       </div>
                     </div>
                   )}
 
-                  {/* 2. ACTIVITY - Agent child tool calls */}
+                  {/* 2. ACTIVITY — Agent child tool calls */}
                   {childToolCalls && childToolCalls.length > 0 && (
                     <div className="space-y-2">
-                      <h4 className="text-xs font-medium text-foreground/60 uppercase tracking-wide">
+                      <h4 className="text-sm font-medium text-foreground/50 uppercase tracking-wide">
                         Activity
                       </h4>
-                      <div className="space-y-1 pl-2 border-l-2 border-purple-200 dark:border-purple-800">
+                      <div className="space-y-0.5 pl-3 border-l-2 border-border">
                         {childToolCalls.map((child, idx) => (
                           <ChildToolCall
                             key={`child-${child.toolUseBlock?.id || idx}`}
@@ -652,10 +592,10 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
                     </div>
                   )}
 
-                  {/* Loading indicator when waiting for result */}
+                  {/* Loading indicator */}
                   {isLoading && (
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <Loader2 className="w-3 h-3 animate-spin" />
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
                       <span>
                         {childToolCalls && childToolCalls.length > 0
                           ? "Processing..."
@@ -664,19 +604,18 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
                     </div>
                   )}
 
-                  {/* 3. RESULT - Only show if there's actual content */}
+                  {/* 3. RESULT */}
                   {hasActualResult && (
                     <div>
-                      <h4 className="text-xs font-medium text-foreground/60 uppercase tracking-wide">
-                        Result {isError && <span className="text-red-600">(Error)</span>}
+                      <h4 className="text-sm font-medium text-foreground/50 uppercase tracking-wide">
+                        Result {isError && <span className="text-destructive">(Error)</span>}
                       </h4>
                       <div className={cn(
-                        "rounded p-2 mt-1 overflow-x-auto border text-xs",
+                        "rounded-lg p-3 mt-1 overflow-x-auto border text-base",
                         isError
-                          ? "bg-red-50 dark:bg-red-950/50 border-red-200 dark:border-red-800"
-                          : "bg-muted/30 border-border"
+                          ? "bg-destructive/5 dark:bg-destructive/8 border-destructive/20 dark:border-destructive/25"
+                          : "bg-muted/20 border-border/50"
                       )}>
-                        {/* CRITICAL: Render result as markdown for better formatting */}
                         <ExpandableMarkdown
                           className="prose-sm"
                           content={extractTextFromResultContent(toolResultBlock?.content as unknown)}
@@ -687,14 +626,14 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
                   )}
                 </div>
               ) : (
-                // Default tool rendering (existing behavior)
+                // Default tool rendering
                 isExpanded && (
-                  <div className="px-3 pb-3 space-y-3 bg-muted/50">
+                  <div className="px-3 pb-3 space-y-3 bg-muted/20 rounded-b-lg">
                     {toolUseBlock?.input && (
                       <div>
-                        <h4 className="text-xs font-medium text-foreground/80 mb-1">Input</h4>
-                        <div className="bg-slate-950 dark:bg-black rounded text-xs p-2 overflow-x-auto">
-                          <pre className="text-gray-100">
+                        <h4 className="text-sm font-medium text-foreground/60 mb-1">Input</h4>
+                        <div className="bg-code-bg rounded-lg p-3 overflow-x-auto border border-border/50">
+                          <pre className="text-code-foreground text-sm">
                             {formatToolInput(JSON.stringify(toolUseBlock.input))}
                           </pre>
                         </div>
@@ -703,13 +642,13 @@ export const ToolMessage = React.forwardRef<HTMLDivElement, ToolMessageProps>(
 
                     {isToolResult && (
                       <div>
-                        <h4 className="text-xs font-medium text-foreground/80 mb-1">
-                          Result {isError && <span className="text-red-600 dark:text-red-400">(Error)</span>}
+                        <h4 className="text-sm font-medium text-foreground/60 mb-1">
+                          Result {isError && <span className="text-destructive">(Error)</span>}
                         </h4>
                         <div
                           className={cn(
-                            "rounded p-2 overflow-x-auto text-foreground",
-                            isError && "bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800"
+                            "rounded-lg p-3 overflow-x-auto text-foreground",
+                            isError && "bg-destructive/5 dark:bg-destructive/8 border border-destructive/20 dark:border-destructive/25"
                           )}
                         >
                           <ExpandableMarkdown

--- a/components/frontend/src/components/ui/tooltip.tsx
+++ b/components/frontend/src/components/ui/tooltip.tsx
@@ -42,7 +42,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-sm text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}

--- a/components/frontend/src/components/workspace-sections/feature-flags-section.tsx
+++ b/components/frontend/src/components/workspace-sections/feature-flags-section.tsx
@@ -330,7 +330,7 @@ export function FeatureFlagsSection({ projectName }: FeatureFlagsSectionProps) {
                   </div>
                   <div className="text-sm text-muted-foreground">
                     {hasChanges ? (
-                      <span className="text-yellow-600 dark:text-yellow-400">
+                      <span className="text-status-warning-foreground">
                         {changedCount} unsaved change{changedCount > 1 ? "s" : ""}
                       </span>
                     ) : (
@@ -369,10 +369,10 @@ function GroupRows({
     <>
       <TableRow className="bg-muted/30 hover:bg-muted/30">
         <TableCell colSpan={5} className="py-2">
-          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          <span className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
             {group.label}
           </span>
-          <span className="ml-2 text-xs text-muted-foreground">
+          <span className="ml-2 text-sm text-muted-foreground">
             ({group.flags.length})
           </span>
         </TableCell>
@@ -389,13 +389,13 @@ function GroupRows({
                   {flag.name}
                 </span>
                 {isChanged && (
-                  <Badge variant="outline" className="text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200">
+                  <Badge variant="outline" className="text-sm bg-status-warning text-status-warning-foreground">
                     Unsaved
                   </Badge>
                 )}
               </div>
               {flag.stale && (
-                <Badge variant="outline" className="mt-1 text-xs">
+                <Badge variant="outline" className="mt-1 text-sm">
                   Stale
                 </Badge>
               )}
@@ -406,7 +406,7 @@ function GroupRows({
               </div>
             </TableCell>
             <TableCell>
-              <Badge variant={flag.enabled ? "secondary" : "outline"} className="text-xs w-fit">
+              <Badge variant={flag.enabled ? "secondary" : "outline"} className="text-sm w-fit">
                 {flag.enabled ? "On" : "Off"}
               </Badge>
             </TableCell>
@@ -449,12 +449,12 @@ function OverrideControl({
           size="sm"
           onClick={() => onChange(opt.val)}
           className={cn(
-            "h-auto px-2.5 py-1 text-xs font-medium rounded-sm transition-colors",
+            "h-auto px-2.5 py-1 text-sm font-medium rounded-sm transition-colors",
             value === opt.val
               ? opt.val === "on"
-                ? "bg-green-600 text-white shadow-sm hover:bg-green-700 hover:text-white"
+                ? "bg-chart-5 text-white shadow-sm hover:bg-chart-5/90 hover:text-white"
                 : opt.val === "off"
-                  ? "bg-red-600 text-white shadow-sm hover:bg-red-700 hover:text-white"
+                  ? "bg-destructive text-white shadow-sm hover:bg-destructive/90 hover:text-white"
                   : "bg-muted text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
           )}

--- a/components/frontend/src/components/workspace-sections/keys-section.tsx
+++ b/components/frontend/src/components/workspace-sections/keys-section.tsx
@@ -315,7 +315,7 @@ export function KeysSection({ projectName }: KeysSectionProps) {
                   ))}
                 </SelectContent>
               </Select>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 How long the token remains valid. Choose &quot;No expiration&quot; for long-lived service keys.
               </p>
             </div>

--- a/components/frontend/src/components/workspace-sections/sessions-section.tsx
+++ b/components/frontend/src/components/workspace-sections/sessions-section.tsx
@@ -287,7 +287,7 @@ export function SessionsSection({ projectName }: SessionsSectionProps) {
                                 <div>
                                   <div className="font-medium">{session.spec.displayName || session.metadata.name}</div>
                                   {session.spec.displayName && (
-                                    <div className="text-xs text-muted-foreground font-normal">{session.metadata.name}</div>
+                                    <div className="text-sm text-muted-foreground font-normal">{session.metadata.name}</div>
                                   )}
                                 </div>
                               </Link>
@@ -301,21 +301,21 @@ export function SessionsSection({ projectName }: SessionsSectionProps) {
                                   <SessionPhaseBadge phase={phase} stoppedReason={session.status?.stoppedReason} />
                                 </div>
                                 {session.spec.displayName && (
-                                  <p className="text-xs text-muted-foreground">{session.metadata.name}</p>
+                                  <p className="text-sm text-muted-foreground">{session.metadata.name}</p>
                                 )}
                                 <div className="flex flex-col gap-1.5 pt-1">
-                                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                  <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
                                     <Cpu className="h-3 w-3" />
                                     <span>{session.spec.llmSettings.model}</span>
                                   </div>
                                   {session.metadata?.creationTimestamp && (
-                                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                    <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
                                       <Clock className="h-3 w-3" />
                                       <span>{formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>
                                     </div>
                                   )}
                                   {session.spec.initialPrompt && (
-                                    <div className="flex items-start gap-1.5 text-xs text-muted-foreground pt-1">
+                                    <div className="flex items-start gap-1.5 text-sm text-muted-foreground pt-1">
                                       <MessageSquare className="h-3 w-3 mt-0.5 shrink-0" />
                                       <span className="line-clamp-3">{session.spec.initialPrompt}</span>
                                     </div>
@@ -336,7 +336,7 @@ export function SessionsSection({ projectName }: SessionsSectionProps) {
                               return (
                                 <>
                                   {runnerLabel && (
-                                    <div className="text-xs font-medium text-foreground">{runnerLabel}</div>
+                                    <div className="text-sm font-medium text-foreground">{runnerLabel}</div>
                                   )}
                                   <div className="text-muted-foreground">{session.spec.llmSettings.model}</div>
                                 </>
@@ -467,7 +467,7 @@ function SessionActions({ sessionName, displayName, phase, onStop, onContinue, o
       label: 'Stop',
       onClick: () => onStop(sessionName),
       icon: <Square className="h-4 w-4" />,
-      className: 'text-orange-600',
+      className: 'text-status-warning-foreground',
     });
   }
 
@@ -477,7 +477,7 @@ function SessionActions({ sessionName, displayName, phase, onStop, onContinue, o
       label: 'Continue',
       onClick: () => onContinue(sessionName),
       icon: <ArrowRight className="h-4 w-4" />,
-      className: 'text-green-600',
+      className: 'text-status-success-foreground',
     });
   }
 
@@ -487,7 +487,7 @@ function SessionActions({ sessionName, displayName, phase, onStop, onContinue, o
       label: 'Delete',
       onClick: () => onDelete(sessionName),
       icon: <Trash2 className="h-4 w-4" />,
-      className: 'text-red-600',
+      className: 'text-destructive',
     });
   }
 

--- a/components/frontend/src/components/workspace-sections/settings-section.tsx
+++ b/components/frontend/src/components/workspace-sections/settings-section.tsx
@@ -335,7 +335,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
               <div className="flex items-center gap-2">
                 {runnerSecretsExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
                 <span className="font-semibold">Runner API Keys</span>
-                {Object.values(runnerSecretValues).some(Boolean) && <span className="text-xs text-muted-foreground">(configured)</span>}
+                {Object.values(runnerSecretValues).some(Boolean) && <span className="text-sm text-muted-foreground">(configured)</span>}
               </div>
             </button>
             {runnerSecretsExpanded && runnerTypesLoading && (
@@ -366,7 +366,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                   return (
                     <div key={secretKey} className="space-y-2">
                       <Label htmlFor={`runner-secret-${secretKey}`}>{secretKey}</Label>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="text-sm text-muted-foreground">
                         {ownerName ? `Required by ${ownerName}` : "Runner API key"} (saved to ambient-runner-secrets)
                       </div>
                       <div className="flex items-center gap-2">
@@ -411,14 +411,14 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
           </div>
 
           {/* Migration Notice */}
-          <div className="border rounded-lg p-4 bg-blue-50 dark:bg-blue-950/20 border-blue-200 dark:border-blue-800">
-            <h3 className="text-sm font-semibold mb-2 text-blue-900 dark:text-blue-100">Integration Credentials Moved</h3>
-            <p className="text-xs text-blue-800 dark:text-blue-200 mb-2">
+          <div className="border rounded-lg p-4 bg-status-info border-status-info-border">
+            <h3 className="text-sm font-semibold mb-2 text-status-info-foreground">Integration Credentials Moved</h3>
+            <p className="text-sm text-status-info-foreground mb-2">
               GitHub, GitLab, Jira, and Google Drive credentials are now managed at the user level on the{' '}
               <Link href="/integrations" className="underline font-medium">Integrations page</Link>.
               This allows you to use the same credentials across all your workspaces.
             </p>
-            <p className="text-xs text-blue-700 dark:text-blue-300">
+            <p className="text-sm text-status-info-foreground">
               Any credentials previously configured here will continue to work as a fallback, but we recommend
               connecting your integrations on the Integrations page for the best experience.
             </p>
@@ -435,7 +435,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
             >
               <div>
                 <Label className="text-base font-semibold cursor-pointer">S3 Storage Configuration</Label>
-                <div className="text-xs text-muted-foreground mt-1">Configure S3-compatible storage for session artifacts and state</div>
+                <div className="text-sm text-muted-foreground mt-1">Configure S3-compatible storage for session artifacts and state</div>
               </div>
               {s3Expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
             </button>
@@ -458,7 +458,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                           Use shared cluster storage (default)
                         </Label>
                       </div>
-                      <div className="text-xs text-muted-foreground ml-6">
+                      <div className="text-sm text-muted-foreground ml-6">
                         Automatically uses in-cluster MinIO. No configuration needed.
                       </div>
                     </div>
@@ -469,7 +469,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                           Use custom S3-compatible storage
                         </Label>
                       </div>
-                      <div className="text-xs text-muted-foreground ml-6">
+                      <div className="text-sm text-muted-foreground ml-6">
                         Configure AWS S3, external MinIO, or other S3-compatible endpoint.
                       </div>
                     </div>
@@ -479,7 +479,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                   <>
                     <div className="space-y-2">
                       <Label htmlFor="s3Endpoint">S3_ENDPOINT</Label>
-                      <div className="text-xs text-muted-foreground mb-1">S3-compatible endpoint (e.g., https://s3.amazonaws.com, http://minio.local:9000)</div>
+                      <div className="text-sm text-muted-foreground mb-1">S3-compatible endpoint (e.g., https://s3.amazonaws.com, http://minio.local:9000)</div>
                       <Input
                         id="s3Endpoint"
                         type="text"
@@ -490,7 +490,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="s3Bucket">S3_BUCKET</Label>
-                      <div className="text-xs text-muted-foreground mb-1">Bucket name for session storage</div>
+                      <div className="text-sm text-muted-foreground mb-1">Bucket name for session storage</div>
                       <Input
                         id="s3Bucket"
                         type="text"
@@ -501,7 +501,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="s3Region">S3_REGION</Label>
-                      <div className="text-xs text-muted-foreground mb-1">AWS region (optional, default: us-east-1)</div>
+                      <div className="text-sm text-muted-foreground mb-1">AWS region (optional, default: us-east-1)</div>
                       <Input
                         id="s3Region"
                         type="text"
@@ -512,7 +512,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="s3AccessKey">S3_ACCESS_KEY</Label>
-                      <div className="text-xs text-muted-foreground mb-1">S3 access key ID</div>
+                      <div className="text-sm text-muted-foreground mb-1">S3 access key ID</div>
                       <Input
                         id="s3AccessKey"
                         type="text"
@@ -523,7 +523,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="s3SecretKey">S3_SECRET_KEY</Label>
-                      <div className="text-xs text-muted-foreground mb-1">S3 secret access key</div>
+                      <div className="text-sm text-muted-foreground mb-1">S3 secret access key</div>
                       <div className="flex items-center gap-2">
                         <Input
                           id="s3SecretKey"
@@ -549,7 +549,7 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
             <div className="flex items-center justify-between">
               <div>
                 <Label className="text-base font-semibold">Custom Environment Variables</Label>
-                <div className="text-xs text-muted-foreground mt-1">Add any additional environment variables for your integrations</div>
+                <div className="text-sm text-muted-foreground mt-1">Add any additional environment variables for your integrations</div>
               </div>
             </div>
             <div className="space-y-2">

--- a/components/frontend/src/components/workspace-sections/sharing-section.tsx
+++ b/components/frontend/src/components/workspace-sections/sharing-section.tsx
@@ -293,7 +293,7 @@ export function SharingSection({ projectName }: SharingSectionProps) {
                 })}
               </div>
             </div>
-            {grantError && <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 p-2 rounded">{grantError}</div>}
+            {grantError && <div className="text-sm text-status-error-foreground bg-status-error p-2 rounded">{grantError}</div>}
           </div>
           <DialogFooter>
             <Button

--- a/components/frontend/src/styles/syntax-highlighting.css
+++ b/components/frontend/src/styles/syntax-highlighting.css
@@ -2,9 +2,9 @@
  * Syntax highlighting themes for highlight.js
  * Bundled locally to avoid external CDN dependencies and security risks
  *
- * Themes copied from highlight.js v11.11.1
- * - Light: github.css (https://github.com/highlightjs/highlight.js)
- * - Dark: github-dark.css
+ * Custom themes tuned for the ACP design system:
+ * - Light: cool neutral background, muted tones
+ * - Dark: soft charcoal background, calming tones
  *
  * Uses data-hljs-theme attribute set by SyntaxThemeProvider to switch between themes
  */
@@ -21,12 +21,11 @@ code.hljs {
 }
 
 /*
- * Light theme (GitHub style)
- * Default theme applied when data-hljs-theme is not "dark"
+ * Light theme — cool neutral tones on soft gray
  */
 :root:not([data-hljs-theme="dark"]) .hljs {
-  color: #24292e;
-  background: #fff;
+  color: #2e3440;
+  background: var(--code-bg, #f0f1f4);
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-doctag,
@@ -36,14 +35,14 @@ code.hljs {
 :root:not([data-hljs-theme="dark"]) .hljs-template-variable,
 :root:not([data-hljs-theme="dark"]) .hljs-type,
 :root:not([data-hljs-theme="dark"]) .hljs-variable.language_ {
-  color: #d73a49;
+  color: #b4456e;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-title,
 :root:not([data-hljs-theme="dark"]) .hljs-title.class_,
 :root:not([data-hljs-theme="dark"]) .hljs-title.class_.inherited__,
 :root:not([data-hljs-theme="dark"]) .hljs-title.function_ {
-  color: #6f42c1;
+  color: #5e4db2;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-attr,
@@ -56,73 +55,72 @@ code.hljs {
 :root:not([data-hljs-theme="dark"]) .hljs-selector-class,
 :root:not([data-hljs-theme="dark"]) .hljs-selector-id,
 :root:not([data-hljs-theme="dark"]) .hljs-variable {
-  color: #005cc5;
+  color: #0066b1;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-meta .hljs-string,
 :root:not([data-hljs-theme="dark"]) .hljs-regexp,
 :root:not([data-hljs-theme="dark"]) .hljs-string {
-  color: #032f62;
+  color: #0f6e54;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-built_in,
 :root:not([data-hljs-theme="dark"]) .hljs-symbol {
-  color: #e36209;
+  color: #c05718;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-code,
 :root:not([data-hljs-theme="dark"]) .hljs-comment,
 :root:not([data-hljs-theme="dark"]) .hljs-formula {
-  color: #6a737d;
+  color: #8590a2;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-name,
 :root:not([data-hljs-theme="dark"]) .hljs-quote,
 :root:not([data-hljs-theme="dark"]) .hljs-selector-pseudo,
 :root:not([data-hljs-theme="dark"]) .hljs-selector-tag {
-  color: #22863a;
+  color: #1a7f5a;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-subst {
-  color: #24292e;
+  color: #2e3440;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-section {
-  color: #005cc5;
+  color: #0066b1;
   font-weight: 700;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-bullet {
-  color: #735c0f;
+  color: #8b6f00;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-emphasis {
-  color: #24292e;
+  color: #2e3440;
   font-style: italic;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-strong {
-  color: #24292e;
+  color: #2e3440;
   font-weight: 700;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-addition {
-  color: #22863a;
-  background-color: #f0fff4;
+  color: #1a7f5a;
+  background-color: #e6f7ef;
 }
 
 :root:not([data-hljs-theme="dark"]) .hljs-deletion {
-  color: #b31d28;
-  background-color: #ffeef0;
+  color: #b4456e;
+  background-color: #fce8ef;
 }
 
 /*
- * Dark theme (GitHub Dark style)
- * Applied when data-hljs-theme="dark"
+ * Dark theme — soft charcoal with calming tones
  */
 [data-hljs-theme="dark"] .hljs {
-  color: #c9d1d9;
-  background: #0d1117;
+  color: #c8cdd5;
+  background: var(--code-bg, #1a1d24);
 }
 
 [data-hljs-theme="dark"] .hljs-doctag,
@@ -132,14 +130,14 @@ code.hljs {
 [data-hljs-theme="dark"] .hljs-template-variable,
 [data-hljs-theme="dark"] .hljs-type,
 [data-hljs-theme="dark"] .hljs-variable.language_ {
-  color: #ff7b72;
+  color: #e0889e;
 }
 
 [data-hljs-theme="dark"] .hljs-title,
 [data-hljs-theme="dark"] .hljs-title.class_,
 [data-hljs-theme="dark"] .hljs-title.class_.inherited__,
 [data-hljs-theme="dark"] .hljs-title.function_ {
-  color: #d2a8ff;
+  color: #c4b5fd;
 }
 
 [data-hljs-theme="dark"] .hljs-attr,
@@ -152,62 +150,62 @@ code.hljs {
 [data-hljs-theme="dark"] .hljs-selector-class,
 [data-hljs-theme="dark"] .hljs-selector-id,
 [data-hljs-theme="dark"] .hljs-variable {
-  color: #79c0ff;
+  color: #7cb8e4;
 }
 
 [data-hljs-theme="dark"] .hljs-meta .hljs-string,
 [data-hljs-theme="dark"] .hljs-regexp,
 [data-hljs-theme="dark"] .hljs-string {
-  color: #a5d6ff;
+  color: #8cd5c0;
 }
 
 [data-hljs-theme="dark"] .hljs-built_in,
 [data-hljs-theme="dark"] .hljs-symbol {
-  color: #ffa657;
+  color: #e8a96c;
 }
 
 [data-hljs-theme="dark"] .hljs-code,
 [data-hljs-theme="dark"] .hljs-comment,
 [data-hljs-theme="dark"] .hljs-formula {
-  color: #8b949e;
+  color: #6b7685;
 }
 
 [data-hljs-theme="dark"] .hljs-name,
 [data-hljs-theme="dark"] .hljs-quote,
 [data-hljs-theme="dark"] .hljs-selector-pseudo,
 [data-hljs-theme="dark"] .hljs-selector-tag {
-  color: #7ee787;
+  color: #6ecba0;
 }
 
 [data-hljs-theme="dark"] .hljs-subst {
-  color: #c9d1d9;
+  color: #c8cdd5;
 }
 
 [data-hljs-theme="dark"] .hljs-section {
-  color: #1f6feb;
+  color: #7cb8e4;
   font-weight: 700;
 }
 
 [data-hljs-theme="dark"] .hljs-bullet {
-  color: #f2cc60;
+  color: #e4cc70;
 }
 
 [data-hljs-theme="dark"] .hljs-emphasis {
-  color: #c9d1d9;
+  color: #c8cdd5;
   font-style: italic;
 }
 
 [data-hljs-theme="dark"] .hljs-strong {
-  color: #c9d1d9;
+  color: #c8cdd5;
   font-weight: 700;
 }
 
 [data-hljs-theme="dark"] .hljs-addition {
-  color: #aff5b4;
-  background-color: #033a16;
+  color: #8cd5c0;
+  background-color: #0d2f22;
 }
 
 [data-hljs-theme="dark"] .hljs-deletion {
-  color: #ffdcd7;
-  background-color: #67060c;
+  color: #e0889e;
+  background-color: #3a1525;
 }


### PR DESCRIPTION
## Summary

- **Theme overhaul**: Rewrote all CSS custom properties in `globals.css` with cool neutral base colors and soft charcoal dark theme. Accent palette derived from loading dots brand colors (blue `#0066B1`, purple `#522DAE`, red `#F40000`)
- **Semantic design tokens**: Replaced every hardcoded Tailwind color class (`text-red-600`, `bg-slate-950`, `border-amber-200`, etc.) with semantic tokens (`text-destructive`, `bg-code-bg`, `border-status-warning-border`) that automatically handle light/dark mode
- **Font size enforcement**: Bumped all `text-xs` / `text-[10px]` / `text-[11px]` to `text-sm` (14px) minimum across 58 files. Body content uses `text-base` (16px)
- **Code blocks**: Removed abrupt `bg-slate-950` / `bg-black` backgrounds, replaced with theme-aware `bg-code-bg` token
- **Agent colors**: Refined from 10 random Tailwind color sets to 6 cohesive semantic sets built from the brand palette
- **Syntax highlighting**: Complete rewrite of highlight.js themes for both light and dark modes
- **Full app coverage**: Navigation, sidebar, modals, cards, badges, buttons, alerts, connection cards, feedback UI, session management, accordions, evaluate page, admin pages, and all chat components

## 58 files changed, 649 insertions, 703 deletions

## Test plan

- [ ] Visual review of light theme across all pages (projects, sessions, chat, admin, evaluate)
- [ ] Visual review of dark theme across all pages
- [ ] Verify loading dots still display correctly with CSS variable fills
- [ ] Verify agent accordion colors are cohesive and distinguishable
- [ ] Verify code blocks and syntax highlighting are readable in both themes
- [ ] Verify all status badges (success, error, warning, info) render correctly
- [ ] Verify connection cards (GitHub, GitLab, Google, Jira) display properly
- [ ] Verify no regressions in interactive elements (buttons, dropdowns, modals)
- [ ] Run frontend build to confirm no compile errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)