### PR TITLE
Add Mergify config for automated merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,17 @@
+queue_rules:
+  - name: default
+    merge_method: squash
+    queue_conditions:
+      - check-success=End-to-End Tests
+      - check-success=amber-review
+      - check-success=validate-manifests
+      - check-success=test-local-dev-simulation
+
+pull_request_rules:
+  - name: enqueue on approval
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      queue:
+        name: default


### PR DESCRIPTION
## Summary

- Adds `.mergify.yml` with a merge queue that rebases queued PRs onto `main` and re-runs CI, then squash-merges once all checks pass
- PRs enter the queue once they have at least one approved review and no outstanding change requests, satisfying CODEOWNERS requirements

Fixes #858

## Prerequisites

- [x] The [Mergify GitHub App](https://github.com/apps/mergify) must be installed on the org (Gage completed this today)

## Test plan

- [x] Validate YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.mergify.yml'))"`
- [ ] After merge, confirm Mergify bot activates on the repo
- [ ] Open a test PR to verify queue behavior