### PR TITLE
fix(ci): add ambient-api-server to deploy-to-openshift workflow

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -208,7 +208,7 @@ jobs:
   deploy-to-openshift:
     runs-on: ubuntu-latest
     needs: [detect-changes, build-and-push, update-rbac-and-crd]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.operator == 'true' || needs.detect-changes.outputs.claude-runner == 'true' || needs.detect-changes.outputs.state-sync == 'true' || needs.detect-changes.outputs.public-api == 'true')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.operator == 'true' || needs.detect-changes.outputs.claude-runner == 'true' || needs.detect-changes.outputs.state-sync == 'true' || needs.detect-changes.outputs.public-api == 'true' || needs.detect-changes.outputs.ambient-api-server == 'true')
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -267,6 +267,12 @@ jobs:
             echo "public_api_tag=stage" >> $GITHUB_OUTPUT
           fi
 
+          if [ "${{ needs.detect-changes.outputs.ambient-api-server }}" == "true" ]; then
+            echo "api_server_tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "api_server_tag=stage" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update kustomization with image tags
         working-directory: components/manifests/overlays/production
         run: |
@@ -276,6 +282,7 @@ jobs:
           kustomize edit set image quay.io/ambient_code/vteam_claude_runner:latest=quay.io/ambient_code/vteam_claude_runner:${{ steps.image-tags.outputs.runner_tag }}
           kustomize edit set image quay.io/ambient_code/vteam_state_sync:latest=quay.io/ambient_code/vteam_state_sync:${{ steps.image-tags.outputs.state_sync_tag }}
           kustomize edit set image quay.io/ambient_code/vteam_public_api:latest=quay.io/ambient_code/vteam_public_api:${{ steps.image-tags.outputs.public_api_tag }}
+          kustomize edit set image quay.io/ambient_code/vteam_api_server:latest=quay.io/ambient_code/vteam_api_server:${{ steps.image-tags.outputs.api_server_tag }}
 
       - name: Validate kustomization
         working-directory: components/manifests/overlays/production
@@ -356,6 +363,7 @@ jobs:
           kustomize edit set image quay.io/ambient_code/vteam_claude_runner:latest=quay.io/ambient_code/vteam_claude_runner:stage
           kustomize edit set image quay.io/ambient_code/vteam_state_sync:latest=quay.io/ambient_code/vteam_state_sync:stage
           kustomize edit set image quay.io/ambient_code/vteam_public_api:latest=quay.io/ambient_code/vteam_public_api:stage
+          kustomize edit set image quay.io/ambient_code/vteam_api_server:latest=quay.io/ambient_code/vteam_api_server:stage
 
       - name: Validate kustomization
         working-directory: components/manifests/overlays/production

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: true
       components:
-        description: 'Components to build (comma-separated: frontend,backend,operator,claude-runner,state-sync) - leave empty for all'
+        description: 'Components to build (comma-separated: frontend,backend,operator,claude-runner,state-sync,public-api,ambient-api-server) - leave empty for all'
         required: false
         type: string
         default: ''
@@ -176,6 +176,14 @@ jobs:
             context: ./components/runners/state-sync
             image: quay.io/ambient_code/vteam_state_sync
             dockerfile: ./components/runners/state-sync/Dockerfile
+          - name: public-api
+            context: ./components/public-api
+            image: quay.io/ambient_code/vteam_public_api
+            dockerfile: ./components/public-api/Dockerfile
+          - name: ambient-api-server
+            context: ./components/ambient-api-server
+            image: quay.io/ambient_code/vteam_api_server
+            dockerfile: ./components/ambient-api-server/Dockerfile
     steps:
       - name: Checkout code from the tag generated above
         uses: actions/checkout@v6
@@ -253,6 +261,8 @@ jobs:
           kustomize edit set image quay.io/ambient_code/vteam_operator:latest=quay.io/ambient_code/vteam_operator:${RELEASE_TAG}
           kustomize edit set image quay.io/ambient_code/vteam_claude_runner:latest=quay.io/ambient_code/vteam_claude_runner:${RELEASE_TAG}
           kustomize edit set image quay.io/ambient_code/vteam_state_sync:latest=quay.io/ambient_code/vteam_state_sync:${RELEASE_TAG}
+          kustomize edit set image quay.io/ambient_code/vteam_public_api:latest=quay.io/ambient_code/vteam_public_api:${RELEASE_TAG}
+          kustomize edit set image quay.io/ambient_code/vteam_api_server:latest=quay.io/ambient_code/vteam_api_server:${RELEASE_TAG}
 
       - name: Validate kustomization
         working-directory: components/manifests/overlays/production


### PR DESCRIPTION
## Summary

- The `deploy-to-openshift` and `deploy-with-dispatch` jobs were missing `ambient-api-server` from the change detection gate, image tag resolution, and kustomize image pinning
- Changes to the api-server component would build but never deploy to OpenShift

## Test plan

- [ ] Verify workflow syntax is valid (GitHub Actions lint)
- [ ] Trigger a workflow_dispatch to confirm api-server image is included in deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)