### PR TITLE
fix(e2e): wait for Unleash before running tests

### DIFF
--- a/e2e/scripts/wait-for-ready.sh
+++ b/e2e/scripts/wait-for-ready.sh
@@ -22,6 +22,12 @@ kubectl wait --for=condition=available --timeout=300s \
   deployment/frontend \
   -n ambient-code
 
+# Wait for Unleash (feature flags - frontend retries on connect failure cause re-render loops)
+echo "⏳ Waiting for unleash..."
+kubectl wait --for=condition=available --timeout=300s \
+  deployment/unleash \
+  -n ambient-code 2>/dev/null || echo "⚠️  Unleash not deployed (feature flags disabled)"
+
 # Wait for MinIO (required for session state persistence)
 echo "⏳ Waiting for minio..."
 kubectl wait --for=condition=available --timeout=300s \


### PR DESCRIPTION
## Summary

- E2E tests fail on `main` with `cy.click() failed because the page updated` — the "New Session" button gets detached from the DOM by continuous React re-renders
- Root cause: the frontend retries failed Unleash connections, triggering re-render loops when Unleash is still starting (DB migration, pod restarts)
- Fix: add `kubectl wait` for the Unleash deployment in `wait-for-ready.sh` so all services are stable before tests begin

## Test plan

- [x] Reproduced failure locally on fresh Kind cluster without fix (100% failure rate)
- [x] Verified fix: fresh Kind cluster with Unleash wait → 57/57 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)