### PR TITLE
mergify: automate queueing

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,17 +1,11 @@
 queue_rules:
   - name: default
+    autoqueue: true
     merge_method: squash
     queue_conditions:
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
       - check-success=End-to-End Tests
       - check-success=amber-review
       - check-success=validate-manifests
       - check-success=test-local-dev-simulation
-
-pull_request_rules:
-  - name: enqueue on approval
-    conditions:
-      - "#approved-reviews-by>=1"
-      - "#changes-requested-reviews-by=0"
-    actions:
-      queue:
-        name: default


### PR DESCRIPTION
From https://docs.mergify.com/merge-queue/rules/#autoqueueing-pull-requests the default value is `false`.

Possibly related: #868