### PR TITLE
fix: use valid model ID for default LLM settings

### DIFF
--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -608,7 +608,7 @@ func CreateSession(c *gin.Context) {
 
 	// Set defaults for LLM settings if not provided
 	llmSettings := types.LLMSettings{
-		Model:       "sonnet",
+		Model:       "claude-sonnet-4-5",
 		Temperature: 0.7,
 		MaxTokens:   4000,
 	}


### PR DESCRIPTION
## Summary

- Default model was `"sonnet"` which isn't a valid model manifest ID
- Changed to `"claude-sonnet-4-5"` which matches the manifest
- Fixes 400 errors when creating sessions without an explicit model (e.g. CI workflows via `ambient-action`)

## Test plan

- [ ] Create a session without specifying a model — should default to `claude-sonnet-4-5`
- [ ] Verify PR fixer CI workflow can create sessions successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)