### PR TITLE
fix: kind image loading with podman/Vertex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -869,12 +869,11 @@ _kind-load-images: ## Internal: Load images into kind cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Loading images into kind ($(KIND_CLUSTER_NAME))..."
 	@for img in $(BACKEND_IMAGE) $(FRONTEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE) $(PUBLIC_API_IMAGE); do \
 		echo "  Loading $(KIND_IMAGE_PREFIX)$$img..."; \
-		if [ -n "$(KIND_HOST)" ]; then \
+		if [ -n "$(KIND_HOST)" ] || [ "$(CONTAINER_ENGINE)" = "podman" ]; then \
 			$(CONTAINER_ENGINE) save $(KIND_IMAGE_PREFIX)$$img | \
 			$(CONTAINER_ENGINE) exec -i $(KIND_CLUSTER_NAME)-control-plane \
 			ctr --namespace=k8s.io images import -; \
 		else \
-			$(if $(filter podman,$(CONTAINER_ENGINE)),KIND_EXPERIMENTAL_PROVIDER=podman) \
 			kind load docker-image $(KIND_IMAGE_PREFIX)$$img --name $(KIND_CLUSTER_NAME); \
 		fi; \
 	done

--- a/scripts/setup-vertex-kind.sh
+++ b/scripts/setup-vertex-kind.sh
@@ -152,10 +152,12 @@ kubectl patch configmap operator-config -n "$NAMESPACE" --type merge -p "{
 echo "  Done"
 echo ""
 
-# Step 3: Restart operator to pick up changes
-echo "Step 3/3: Restarting operator to apply changes..."
+# Step 3: Restart operator and backend to pick up changes
+echo "Step 3/3: Restarting operator and backend to apply changes..."
 kubectl rollout restart deployment agentic-operator -n "$NAMESPACE"
+kubectl rollout restart deployment backend-api -n "$NAMESPACE"
 kubectl rollout status deployment agentic-operator -n "$NAMESPACE" --timeout=60s
+kubectl rollout status deployment backend-api -n "$NAMESPACE" --timeout=60s
 echo ""
 
 echo "=== Setup Complete ==="


### PR DESCRIPTION
Use podman save | ctr import for loading images into kind when using podman, since kind load docker-image cannot find localhost/-prefixed images. Also restart backend-api after Vertex AI configmap patching so it picks up USE_VERTEX=1.

This was broken for podman setups by 374f50b it seems.