### PR TITLE
feat(frontend): add dynamic page titles for workspace and session pages

### DIFF
--- a/components/frontend/src/app/integrations/page.tsx
+++ b/components/frontend/src/app/integrations/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from 'next'
 import React from 'react'
 import IntegrationsClient from '@/app/integrations/IntegrationsClient'
+
+export const metadata: Metadata = {
+  title: 'Integrations · Ambient Code Platform',
+}
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0

--- a/components/frontend/src/app/projects/[name]/layout.tsx
+++ b/components/frontend/src/app/projects/[name]/layout.tsx
@@ -1,0 +1,7 @@
+export default function WorkspaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/components/frontend/src/app/projects/[name]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/page.tsx
@@ -99,6 +99,12 @@ export default function ProjectDetailsPage() {
   const initialSection = (searchParams.get('section') as Section) || 'sessions';
   const [activeSection, setActiveSection] = useState<Section>(initialSection);
 
+  // Update page title with display name when available
+  useEffect(() => {
+    const title = project?.displayName || projectName;
+    document.title = `${title} · Ambient Code Platform`;
+  }, [project?.displayName, projectName]);
+
   // Update active section when query parameter changes
   useEffect(() => {
     const sectionParam = searchParams.get('section') as Section;

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/layout.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/layout.tsx
@@ -1,0 +1,7 @@
+export default function SessionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -251,6 +251,14 @@ export default function ProjectSessionDetailPage({
     return undefined;
   }, [capabilities?.framework, runnerTypes]);
 
+  // Update page title with display name when available
+  useEffect(() => {
+    const title = session?.spec?.displayName || sessionName;
+    if (title) {
+      document.title = `${title} · Ambient Code Platform`;
+    }
+  }, [session?.spec?.displayName, sessionName]);
+
   // Track the current Langfuse trace ID for feedback association
   const [langfuseTraceId, setLangfuseTraceId] = useState<string | null>(null);
 

--- a/components/frontend/src/app/projects/layout.tsx
+++ b/components/frontend/src/app/projects/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Workspaces · Ambient Code Platform",
+};
+
+export default function WorkspacesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}


### PR DESCRIPTION
Replaces https://github.com/ambient-code/platform/pull/861/