### PR TITLE
fix: set explicit model in CI workflows

### DIFF
--- a/.github/workflows/feedback-loop.yml
+++ b/.github/workflows/feedback-loop.yml
@@ -166,6 +166,7 @@ jobs:
           repos: ${{ steps.config.outputs.repos }}
           labels: ${{ steps.config.outputs.labels }}
           environment-variables: ${{ steps.config.outputs.environment-variables }}
+          model: claude-sonnet-4-5
 
       - name: Session summary
         if: always()

--- a/.github/workflows/pr-fixer.yml
+++ b/.github/workflows/pr-fixer.yml
@@ -84,6 +84,7 @@ jobs:
             [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
           workflow: >-
             {"gitUrl": "https://github.com/ambient-code/workflows", "branch": "main", "path": "internal-workflows/pr-fixer"}
+          model: claude-sonnet-4-5
           wait: 'true'
           timeout: '25'
 
@@ -193,6 +194,7 @@ jobs:
             [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
           workflow: >-
             {"gitUrl": "https://github.com/ambient-code/workflows", "branch": "main", "path": "internal-workflows/pr-fixer"}
+          model: claude-sonnet-4-5
           wait: 'false'
 
       - name: Session summary

--- a/.github/workflows/pr-merge-review.yml
+++ b/.github/workflows/pr-merge-review.yml
@@ -31,6 +31,7 @@ jobs:
             [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
           workflow: >-
             {"gitUrl": "https://github.com/ambient-code/workflows", "branch": "main", "path": "internal-workflows/pr-overview"}
+          model: claude-sonnet-4-5
           wait: 'true'
           timeout: '10'
 


### PR DESCRIPTION
## Summary

- Added `model: claude-sonnet-4-5` to all `ambient-action` usages in CI workflows
- Affected workflows: `pr-fixer.yml`, `pr-merge-review.yml`, `feedback-loop.yml`
- Prevents 400 errors from the backend rejecting the invalid default model `"sonnet"`

## Test plan

- [ ] PR fixer workflow creates sessions successfully
- [ ] Feedback loop workflow creates sessions successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)