### PR TITLE
fix: check out PR feature branch in pr-fixer workflow

### DIFF
--- a/.github/workflows/pr-fixer.yml
+++ b/.github/workflows/pr-fixer.yml
@@ -67,6 +67,15 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get PR branch
+        if: steps.fork_check.outputs.skip != 'true'
+        id: pr_branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH=$(gh pr view ${{ steps.pr.outputs.number }} --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
       - name: Fix PR
         if: steps.fork_check.outputs.skip != 'true'
         id: session
@@ -81,7 +90,7 @@ jobs:
             comments (fix valid issues, respond to invalid ones), run lints
             and tests, and push the fixes.
           repos: >-
-            [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
+            [{"url": "https://github.com/${{ github.repository }}", "branch": "${{ steps.pr_branch.outputs.branch }}"}]
           workflow: >-
             {"gitUrl": "https://github.com/ambient-code/workflows", "branch": "main", "path": "internal-workflows/pr-fixer"}
           model: claude-sonnet-4-5
@@ -177,6 +186,15 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get PR branch
+        if: steps.churn_check.outputs.skip != 'true'
+        id: pr_branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH=$(gh pr view ${{ matrix.pr_number }} --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
       - name: Fix PR #${{ matrix.pr_number }}
         if: steps.churn_check.outputs.skip != 'true'
         id: session
@@ -191,7 +209,7 @@ jobs:
             comments (fix valid issues, respond to invalid ones), run lints
             and tests, and push the fixes.
           repos: >-
-            [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
+            [{"url": "https://github.com/${{ github.repository }}", "branch": "${{ steps.pr_branch.outputs.branch }}"}]
           workflow: >-
             {"gitUrl": "https://github.com/ambient-code/workflows", "branch": "main", "path": "internal-workflows/pr-fixer"}
           model: claude-sonnet-4-5


### PR DESCRIPTION
## Summary

- PR fixer sessions now resolve the PR's head branch via `gh pr view` and pass it in the `repos` config
- The runner clones the feature branch directly instead of starting on `main`
- Applied to both single-fix and batch-fix jobs

## Test plan

- [ ] Trigger pr-fixer on an open PR — session should clone the PR's branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)