### PR TITLE
fix(runner): make RunnerContext.get_env() read live from os.environ

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/platform/context.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/context.py
@@ -28,12 +28,18 @@ class RunnerContext:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Merge environment variables (explicit overrides win)."""
+        """Store explicit overrides for precedence in get_env(); keep environment populated for backward compatibility."""
+        self._overrides = dict(self.environment)
         self.environment = {**os.environ, **self.environment}
 
     def get_env(self, key: str, default: Optional[str] = None) -> Optional[str]:
-        """Get an environment variable value."""
-        return self.environment.get(key, default)
+        """Get an environment variable, with explicit overrides winning. Reads live from os.environ for non-overridden keys."""
+        overrides = getattr(self, "_overrides", None)
+        if overrides is None:
+            return self.environment.get(key, default)
+        if key in overrides:
+            return overrides[key]
+        return os.environ.get(key, default)
 
     def set_metadata(self, key: str, value: Any) -> None:
         """Set a metadata value."""

--- a/components/runners/ambient-runner/tests/test_context.py
+++ b/components/runners/ambient-runner/tests/test_context.py
@@ -1,0 +1,40 @@
+"""Tests for RunnerContext."""
+
+import os
+
+import pytest
+
+from ambient_runner.platform.context import RunnerContext
+
+
+class TestRunnerContextGetEnv:
+    """Verify get_env() reads live from os.environ and respects explicit overrides."""
+
+    def test_get_env_sees_os_environ_mutations_after_creation(self):
+        """get_env() must return current os.environ value when key is mutated at runtime."""
+        key = "_RUNNER_CONTEXT_TEST_MUTATION_"
+        try:
+            if key in os.environ:
+                del os.environ[key]
+            ctx = RunnerContext(session_id="s1", workspace_path="/tmp")
+            assert ctx.get_env(key) is None
+            os.environ[key] = "runtime-mutated"
+            assert ctx.get_env(key) == "runtime-mutated"
+        finally:
+            os.environ.pop(key, None)
+
+    def test_explicit_overrides_win_over_os_environ(self):
+        """Explicit overrides passed at construction must take precedence over os.environ."""
+        key = "_RUNNER_CONTEXT_TEST_OVERRIDE_"
+        try:
+            os.environ[key] = "from-os-environ"
+            ctx = RunnerContext(
+                session_id="s1",
+                workspace_path="/tmp",
+                environment={key: "from-constructor"},
+            )
+            assert ctx.get_env(key) == "from-constructor"
+            os.environ[key] = "mutated-after-creation"
+            assert ctx.get_env(key) == "from-constructor"
+        finally:
+            os.environ.pop(key, None)


### PR DESCRIPTION
## Summary

This is a followup PR to ensure that https://github.com/ambient-code/platform/pull/726 data is pushed to Langfuse for product instrumentation 

- **Fix stale environment snapshot in `RunnerContext`**: `get_env()` was reading from a frozen dict captured once at construction. Runtime mutations to `os.environ` (by `POST /workflow`, `POST /repos/add`, auth refresh) were invisible to any code using `context.get_env()`.
- **Root cause**: `__post_init__` merged `os.environ` into `self.environment` and `get_env()` read only from that dict. The context is never recreated — `mark_dirty()` resets the bridge but reuses the same stale context.
- **Fix**: Store explicit constructor overrides in `_overrides`. `get_env()` now checks overrides first, then falls through to live `os.environ`. `self.environment` remains populated for backward compatibility.

## Changes

| File | Change |
|------|--------|
| `ambient_runner/platform/context.py` | Store `_overrides` in `__post_init__`; `get_env()` reads live from `os.environ` with overrides winning |
| `tests/test_context.py` | Regression tests: runtime mutation visibility + override precedence |

## Test plan

- [x] New `test_get_env_sees_os_environ_mutations_after_creation` — creates context, mutates `os.environ` after, asserts `get_env()` returns mutated value
- [x] New `test_explicit_overrides_win_over_os_environ` — constructor overrides take precedence even after `os.environ` mutation
- [x] All 73 existing tests pass without modification (test_context, test_bridge_claude, test_observability)
- [ ] CI green


Made with [Cursor](https://cursor.com)