### PR TITLE
ci(mergify): require 2 approvals for large PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,15 @@
 queue_rules:
+  - name: large-pr
+    autoqueue: true
+    merge_method: squash
+    queue_conditions:
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - check-success=End-to-End Tests
+      - commented-reviews-by=coderabbitai[bot]
+      - check-success=validate-manifests
+      - check-success=test-local-dev-simulation
+
   - name: default
     autoqueue: true
     merge_method: squash
@@ -9,3 +20,23 @@ queue_rules:
       - commented-reviews-by=coderabbitai[bot]
       - check-success=validate-manifests
       - check-success=test-local-dev-simulation
+
+pull_request_rules:
+  - name: queue large PRs
+    conditions:
+      - or:
+        - "#files>10"
+        - "#added-lines>500"
+        - "#deleted-lines>500"
+    actions:
+      queue:
+        name: large-pr
+
+  - name: queue normal PRs
+    conditions:
+      - "#files<=10"
+      - "#added-lines<=500"
+      - "#deleted-lines<=500"
+    actions:
+      queue:
+        name: default


### PR DESCRIPTION
Add a separate queue rule for PRs that exceed size thresholds, requiring two approvals instead of one. A PR is considered large if it modifies more than 10 files or adds/deletes more than 500 lines. Normal PRs continue to require only 1 approval.

The thresholds I chose (500 lines, 10 files) are pretty arbitrary and up for discussion.