### PR TITLE
fix(backend): fix ExtractServiceAccountFromAuth unit test

### DIFF
--- a/components/backend/handlers/middleware_test.go
+++ b/components/backend/handlers/middleware_test.go
@@ -270,15 +270,9 @@ var _ = Describe("Middleware Handlers", Label(test_constants.LabelUnit, test_con
 		It("Should extract service account from token review", func() {
 			context := httpUtils.CreateTestGinContext("GET", "/api/projects/test-project/sessions", nil)
 
-			_, _, err := httpUtils.SetValidTestToken(
-				k8sUtils,
-				"test-project",
-				[]string{"get", "list"},
-				"agenticsessions",
-				"test-sa",
-				"test-agenticsessions-read-role",
-			)
-			Expect(err).NotTo(HaveOccurred())
+			// ExtractServiceAccountFromAuth reads the X-Remote-User header
+			// (set by OpenShift OAuth proxy) to identify service accounts
+			context.Request.Header.Set("X-Remote-User", "system:serviceaccount:test-project:test-sa")
 
 			namespace, serviceAccount, found := ExtractServiceAccountFromAuth(context)
 			Expect(found).To(BeTrue(), "Should find service account from token")


### PR DESCRIPTION
## Summary
- The `ExtractServiceAccountFromAuth` test was failing because it set an `Authorization` header via `SetValidTestToken`, but the function reads the `X-Remote-User` header (OpenShift OAuth proxy format `system:serviceaccount:<ns>:<name>`)
- Fixed by setting the correct `X-Remote-User` header directly instead of using `SetValidTestToken`

## Test plan
- [x] Verified all 407 backend unit tests pass locally with `go test -v -tags=test ./handlers`
- [x] Confirmed the previously failing test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)