### PR TITLE
fix(ci): scope model-discovery PR to only include models.json

### DIFF
--- a/.github/workflows/model-discovery.yml
+++ b/.github/workflows/model-discovery.yml
@@ -44,12 +44,13 @@ jobs:
 
       - name: Check for changes
         id: diff
-        run: git diff --quiet && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+        run: git diff --quiet -- components/manifests/base/models.json && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
+          add-paths: components/manifests/base/models.json
           branch: automated/model-discovery
           commit-message: "chore: update model manifest from Vertex AI discovery"
           title: "chore: update model manifest"


### PR DESCRIPTION
## Summary

- Add `add-paths` to `create-pull-request` so only `models.json` is committed (prevents GCP WIF credentials file from leaking into the PR)
- Scope the diff check to only `models.json` so transient workspace files don't trigger false positives

See #911 for the PR where the credentials file was accidentally included.

## Test plan

- [ ] Trigger model-discovery workflow manually and verify the resulting PR only contains `models.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)