### PR TITLE
fix: migrate Dockerfile from Docker to UBI image

### DIFF
--- a/components/public-api/Dockerfile
+++ b/components/public-api/Dockerfile
@@ -1,10 +1,9 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 
 WORKDIR /app
 
-# Install git for fetching dependencies
-RUN apk add --no-cache git
+USER 0
 
 # Copy go mod files first for caching
 COPY go.mod go.sum* ./
@@ -17,18 +16,16 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o public-api .
 
 # Runtime stage
-FROM alpine:3.19
-
-# Add ca-certificates for HTTPS requests
-RUN apk --no-cache add ca-certificates
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 WORKDIR /app
 
 # Copy binary from builder
 COPY --from=builder /app/public-api .
 
-# Create non-root user
-RUN adduser -D -u 1001 appuser
+# Set executable permissions
+RUN chmod +x ./public-api && chmod 775 /app
+
 USER 1001
 
 # Expose port
@@ -36,7 +33,7 @@ EXPOSE 8081
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8081/health || exit 1
+    CMD curl -sf http://localhost:8081/health || exit 1
 
 # Run the binary
 ENTRYPOINT ["./public-api"]


### PR DESCRIPTION
Replace golang:1.24-alpine and alpine:3.19 with
registry.access.redhat.com/ubi9/go-toolset:1.24 and ubi9/ubi-minimal:latest for consistency with other components.