### PR TITLE
fix: migrate dev Dockerfile from Docker to UBI

### DIFF
--- a/components/backend/Dockerfile.dev
+++ b/components/backend/Dockerfile.dev
@@ -1,10 +1,11 @@
 # Development Dockerfile for Go backend (simplified, no Air)
-FROM golang:1.24-alpine
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24
+
+USER 0
 
 WORKDIR /app
-
-# Install git and build dependencies
-RUN apk add --no-cache git build-base
+RUN chown -R 1001:0 /app
+USER 1001
 
 # Set environment variables
 ENV AGENTS_DIR=/app/agents


### PR DESCRIPTION
Replace golang:1.24-alpine with
registry.access.redhat.com/ubi9/go-toolset:1.24. Remove apk install of git and build-base as go-toolset already includes them.