### PR TITLE
fix(frontend): change Jira connection label from Username to Email

### DIFF
--- a/components/frontend/src/components/jira-connection-card.tsx
+++ b/components/frontend/src/components/jira-connection-card.tsx
@@ -152,18 +152,18 @@ export function JiraConnectionCard({ status, onRefresh }: Props) {
               />
             </div>
             <div>
-              <Label htmlFor="jira-username" className="text-sm">Username</Label>
+              <Label htmlFor="jira-email" className="text-sm">Email</Label>
               <Input
-                id="jira-username"
-                type="text"
-                placeholder="rh-dept-kerberos or your-email@redhat.com"
+                id="jira-email"
+                type="email"
+                placeholder="your-email@redhat.com"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
                 disabled={connectMutation.isPending}
                 className="mt-1"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Your Jira login username (e.g., rh-dept-kerberos)
+                Your Jira Cloud login email (e.g., jdoe@redhat.com)
               </p>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- Jira Cloud requires a full email for authentication, but the connection form labeled the field "Username"
- Changed the label to "Email", set input type to `email`, and updated placeholder/helper text accordingly

## Test plan
- [ ] Open the Jira connection card in the frontend
- [ ] Verify the field label reads "Email" instead of "Username"
- [ ] Verify the placeholder shows `your-email@redhat.com`
- [ ] Verify the helper text reads "Your Jira Cloud login email (e.g., jdoe@redhat.com)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)