### PR TITLE
fix(frontend): handle simple question format in AskUserQuestion HITL UI

### DIFF
--- a/components/frontend/src/components/session/ask-user-question.tsx
+++ b/components/frontend/src/components/session/ask-user-question.tsx
@@ -31,6 +31,13 @@ function parseQuestions(input: Record<string, unknown>): AskUserQuestionItem[] {
   if (isAskUserQuestionInput(input)) {
     return input.questions;
   }
+  // Handle simple { question: "..." } format (e.g. from Claude Code AskUserQuestion tool)
+  if (typeof input.question === 'string' && input.question.trim()) {
+    return [{
+      question: input.question,
+      options: [],
+    }];
+  }
   return [];
 }
 
@@ -136,6 +143,31 @@ export const AskUserQuestionMessage: React.FC<AskUserQuestionMessageProps> = ({
 
   const renderQuestionOptions = (q: AskUserQuestionItem) => {
     const isOther = usingOther[q.question];
+
+    // Free-form text input when no predefined options (e.g. simple question string)
+    if (!q.options || q.options.length === 0) {
+      return (
+        <div className="space-y-1">
+          <Input
+            autoFocus={!disabled}
+            placeholder="Type your answer..."
+            value={(selections[q.question] as string) || ""}
+            onChange={(e) => {
+              if (disabled) return;
+              setSelections((prev) => ({ ...prev, [q.question]: e.target.value }));
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey && allQuestionsAnswered) {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
+            disabled={disabled}
+            className="h-8 text-sm"
+          />
+        </div>
+      );
+    }
 
     if (q.multiSelect) {
       return (


### PR DESCRIPTION
## Summary

- Fixes bug where the HITL (Human-in-the-Loop) user input UI never appeared when the agent called `AskUserQuestion`
- The component only handled structured `{ questions: [...] }` input, but Claude Code sends a simple `{ question: "..." }` string format — causing `parseQuestions` to return `[]` and the component to render nothing
- Adds fallback parsing for the simple format and a free-form text input when no predefined options exist

## Test plan

- [ ] Trigger an `AskUserQuestion` tool call in a session (e.g. ask the agent something that requires clarification)
- [ ] Verify the HITL question UI renders with a text input field
- [ ] Verify submitting an answer works and the form disables after submission
- [ ] Verify the structured `{ questions: [...] }` format still works (radio buttons, checkboxes)
- [ ] `npx vitest run` — all 471 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)