### PR TITLE
fix: flaky "element detached from DOM" in sessions test

### DIFF
--- a/e2e/cypress/e2e/sessions.cy.ts
+++ b/e2e/cypress/e2e/sessions.cy.ts
@@ -78,7 +78,13 @@ describe('Ambient Session Management Tests', () => {
     })).then((r) => expect(r.status).to.eq(200))
 
     // Create a session for UI tests
-    cy.get('[data-testid="new-session-btn"]').click()
+    // Re-visit the workspace page so the sessions list fetch fires after the
+    // intercept is registered, avoiding "element detached from DOM" errors
+    // from React re-renders while clicking.
+    cy.intercept('GET', '**/api/projects/*/agentic-sessions*').as('sessionsList')
+    cy.then(() => cy.visit(`/projects/${workspaceSlug}`))
+    cy.wait('@sessionsList', { timeout: 15000 })
+    cy.get('[data-testid="new-session-btn"]').should('be.visible').click()
     cy.get('[data-testid="create-session-submit"]', { timeout: 10000 })
         .should('not.be.disabled').click()
     cy.get('[data-testid="create-session-submit"]', { timeout: 10000 })


### PR DESCRIPTION
Wait for the sessions list API response before clicking the new session button, ensuring React has finished re-rendering with the fetched data.

Example failed test:
https://github.com/ambient-code/platform/actions/runs/23146894542/job/67237433020