### PR TITLE
fix(frontend): update Jira API token helper link

### DIFF
--- a/components/frontend/src/components/jira-connection-card.tsx
+++ b/components/frontend/src/components/jira-connection-card.tsx
@@ -190,7 +190,7 @@ export function JiraConnectionCard({ status, onRefresh }: Props) {
               <p className="text-xs text-muted-foreground mt-1">
                 Create an API token at{' '}
                 <a
-                  href={url ? `${url}/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens` : 'https://id.atlassian.com/manage-profile/security/api-tokens'}
+                  href="https://id.atlassian.com/manage-profile/security/api-tokens"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline"


### PR DESCRIPTION
## Summary
- Updates the Jira integration helper link to always point to the Atlassian Cloud API token management page (`https://id.atlassian.com/manage-profile/security/api-tokens`)
- Removes the conditional that built a Jira Server/DC PAT URL when a custom URL was provided, since we're on Jira Cloud

## Test plan
- [ ] Open the Jira integration/connection card in the UI
- [ ] Verify the "Jira Settings" helper link navigates to `https://id.atlassian.com/manage-profile/security/api-tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)