### PR TITLE
mergify: remove coderabbit comment requirement

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,6 @@ queue_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - check-success=End-to-End Tests
-      - commented-reviews-by=coderabbitai[bot]
       - check-success=validate-manifests
       - check-success=test-local-dev-simulation
 
@@ -17,7 +16,6 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - check-success=End-to-End Tests
-      - commented-reviews-by=coderabbitai[bot]
       - check-success=validate-manifests
       - check-success=test-local-dev-simulation
 


### PR DESCRIPTION
CodeRabbit does not leave a review if there are no actionable comments.  When Mergify does not see the CodeRabbit review, it will not merge the PR, even if the PR meets all the other criteria (successful human review + passing tests).

The purpose of adding coderabbit to the Mergify criteria is to provide a natural quality governer: to ensure that humans read the reviews. Turns out CodeRabbit is useful enough that we don't need to enforce this with Mergify, and tweaking it further is not worth optimizing.

Fixes: #940 
