### PR TITLE
fix(frontend): fix duplicated path segments in workspace file viewer

### DIFF
--- a/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/workspace/[...path]/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/workspace/[...path]/route.ts
@@ -7,8 +7,8 @@ export async function GET(
 ) {
   const { name, sessionName, path } = await params
   const headers = await buildForwardHeadersAsync(request)
-  const rel = path.join('/')
-  const resp = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/workspace/${encodeURIComponent(rel)}`, { headers })
+  const rel = path.map(s => encodeURIComponent(s)).join('/')
+  const resp = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/workspace/${rel}`, { headers })
   const contentType = resp.headers.get('content-type') || 'application/octet-stream'
   const buf = await resp.arrayBuffer()
   return new Response(buf, { status: resp.status, headers: { 'Content-Type': contentType } })
@@ -21,10 +21,10 @@ export async function PUT(
 ) {
   const { name, sessionName, path } = await params
   const headers = await buildForwardHeadersAsync(request)
-  const rel = path.join('/')
+  const rel = path.map(s => encodeURIComponent(s)).join('/')
   const contentType = request.headers.get('content-type') || 'text/plain; charset=utf-8'
   const textBody = await request.text()
-  const resp = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/workspace/${encodeURIComponent(rel)}`, {
+  const resp = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/workspace/${rel}`, {
     method: 'PUT',
     headers: { ...headers, 'Content-Type': contentType },
     body: textBody,
@@ -39,8 +39,8 @@ export async function DELETE(
 ) {
   const { name, sessionName, path } = await params
   const headers = await buildForwardHeadersAsync(request)
-  const rel = path.join('/')
-  const resp = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/workspace/${encodeURIComponent(rel)}`, {
+  const rel = path.map(s => encodeURIComponent(s)).join('/')
+  const resp = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/workspace/${rel}`, {
     method: 'DELETE',
     headers,
   })

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/explorer/files-tab.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/explorer/files-tab.tsx
@@ -76,8 +76,8 @@ export function FilesTab({
   const handleSelect = (node: FileTreeNode) => {
     if (node.type === "file" && onFileOpen) {
       const fullPath = currentSubPath
-        ? `${selectedDirectory.path}/${currentSubPath}/${node.path}`
-        : `${selectedDirectory.path}/${node.path}`;
+        ? `${selectedDirectory.path}/${currentSubPath}/${node.name}`
+        : `${selectedDirectory.path}/${node.name}`;
       onFileOpen(fullPath);
     } else {
       onFileOrFolderSelect(node);

--- a/components/frontend/src/services/api/workspace.ts
+++ b/components/frontend/src/services/api/workspace.ts
@@ -41,8 +41,9 @@ export async function readWorkspaceFile(
   sessionName: string,
   path: string
 ): Promise<string> {
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/');
   const response = await apiClient.getRaw(
-    `/projects/${projectName}/agentic-sessions/${sessionName}/workspace/${encodeURIComponent(path)}`
+    `/projects/${projectName}/agentic-sessions/${sessionName}/workspace/${encodedPath}`
   );
   if (!response.ok) {
     throw new Error('Failed to read workspace file');
@@ -59,8 +60,9 @@ export async function writeWorkspaceFile(
   path: string,
   content: string
 ): Promise<void> {
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/');
   await apiClient.putText(
-    `/projects/${projectName}/agentic-sessions/${sessionName}/workspace/${encodeURIComponent(path)}`,
+    `/projects/${projectName}/agentic-sessions/${sessionName}/workspace/${encodedPath}`,
     content
   );
 }


### PR DESCRIPTION
## Summary
- Fix path duplication bug in explorer file tab where `node.path` (full API path like `/file-uploads/Ambient data model.md`) was used instead of `node.name`, causing URLs like `/workspace/file-uploads/file-uploads/file.md` and `/workspace/repos/odh-dashboard/repos/odh-dashboard/.dockerignore`
- Fix URL encoding in workspace API client and Next.js route handler to encode each path segment individually instead of the entire path (which encoded slashes as `%2F`)

Affects: file-uploads, repos, workflows, and shared artifacts directories.

## Test plan
- [ ] Open a session with file uploads → click a file in the explorer → verify it loads without 404
- [ ] Open a session with repos → click a file in the explorer → verify it loads without 404
- [ ] Navigate into subdirectories and open files → verify correct path construction
- [ ] Download a file from the explorer → verify download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)