### PR TITLE
fix(frontend): migrate dev Dockerfile from Docker to UBI image

### DIFF
--- a/components/frontend/Dockerfile.dev
+++ b/components/frontend/Dockerfile.dev
@@ -1,6 +1,7 @@
 # Development Dockerfile for Next.js with hot-reloading
-FROM registry.access.redhat.com/ubi9/nodejs-20
+FROM registry.access.redhat.com/ubi9/nodejs-20:1
 
+# Root required for dev: source is volume-mounted and npm ci writes to it
 USER 0
 
 WORKDIR /app


### PR DESCRIPTION
Replace node:20-alpine with registry.access.redhat.com/ubi9/nodejs-20 for consistency with other components. Remove apk install of libc6-compat, python3, make, and g++ as the UBI nodejs-20 s2i builder image already includes them.