### PR TITLE
fix(backend): inject userContext into scheduled session templates

### DIFF
--- a/components/backend/handlers/scheduled_sessions.go
+++ b/components/backend/handlers/scheduled_sessions.go
@@ -288,6 +288,27 @@ func UpdateScheduledSession(c *gin.Context) {
 		cj.Annotations[annotationDisplayName] = *req.DisplayName
 	}
 	if req.SessionTemplate != nil {
+		// Inject userContext so updated templates retain credential resolution
+		userID := c.GetString("userID")
+		if req.SessionTemplate.UserContext == nil && userID != "" {
+			displayName := ""
+			if v, ok := c.Get("userName"); ok {
+				if s, ok2 := v.(string); ok2 {
+					displayName = s
+				}
+			}
+			groups := []string{}
+			if v, ok := c.Get("userGroups"); ok {
+				if gg, ok2 := v.([]string); ok2 {
+					groups = gg
+				}
+			}
+			req.SessionTemplate.UserContext = &types.UserContext{
+				UserID:      userID,
+				DisplayName: displayName,
+				Groups:      groups,
+			}
+		}
 		templateJSON, err := json.Marshal(req.SessionTemplate)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to encode session template"})


### PR DESCRIPTION
## Summary
- Scheduled sessions fail GitHub/GitLab authentication because the trigger creates AgenticSession CRs without `spec.userContext`. The runner's `populate_runtime_credentials` needs `userContext.userId` to fetch tokens from the backend API.
- Inject the authenticated caller's identity (`userId`, `displayName`, `groups`) into the session template at schedule creation and update time, mirroring what `CreateAgenticSession` does server-side.

## Root Cause
`CreateScheduledSession` serializes the session template into a `SESSION_TEMPLATE` env var on the CronJob. When the trigger fires, it creates the CR directly via the K8s API — bypassing the backend's `CreateAgenticSession` handler which normally injects `userContext`. The resulting CR has no `spec.userContext.userId`, so the credential endpoint (`GET /credentials/github`) returns an error.

## Changes
- **`CreateScheduledSession`**: Inject `userContext` from the gin context into `req.SessionTemplate` before marshaling, if not already set by the caller.
- **`UpdateScheduledSession`**: Apply the same injection when the session template is updated, preventing credential resolution from breaking after a partial template update.

## Test plan
- [ ] Create a scheduled session via UI, verify `SESSION_TEMPLATE` env var on CronJob contains `userContext`
- [ ] Trigger the schedule, verify the resulting AgenticSession CR has `spec.userContext.userId`
- [ ] Confirm `gh auth status` succeeds inside the runner pod
- [ ] Update a scheduled session's template, verify `userContext` is preserved
- [ ] Verify manually created sessions still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)