### PR TITLE
fix(frontend): fetch models from API instead of using hardcoded lists

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/new-session-view.test.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/new-session-view.test.tsx
@@ -23,6 +23,19 @@ vi.mock('@/services/api/runner-types', () => ({
   DEFAULT_RUNNER_TYPE_ID: 'claude-agent-sdk',
 }));
 
+vi.mock('@/services/queries/use-models', () => ({
+  useModels: () => ({
+    data: {
+      models: [
+        { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5', provider: 'anthropic', isDefault: true },
+        { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', provider: 'anthropic', isDefault: false },
+      ],
+      defaultModel: 'claude-sonnet-4-5',
+    },
+    isLoading: false,
+  }),
+}));
+
 vi.mock('../workflow-selector', () => ({
   WorkflowSelector: () => <button data-testid="workflow-selector">No workflow</button>,
 }));

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/runner-model-selector.test.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/runner-model-selector.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { RunnerModelSelector, getDefaultModel, getModelsForRunner } from '../runner-model-selector';
+import { RunnerModelSelector, getDefaultModel } from '../runner-model-selector';
 import type { RunnerType } from '@/services/api/runner-types';
+import type { ListModelsResponse } from '@/types/api';
 
 const mockRunnerTypes: RunnerType[] = [
   {
@@ -22,10 +23,26 @@ const mockRunnerTypes: RunnerType[] = [
   },
 ];
 
+const mockAnthropicModels: ListModelsResponse = {
+  models: [
+    { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', provider: 'anthropic', isDefault: false },
+    { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5', provider: 'anthropic', isDefault: true },
+    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', provider: 'anthropic', isDefault: false },
+    { id: 'claude-opus-4-5', label: 'Claude Opus 4.5', provider: 'anthropic', isDefault: false },
+    { id: 'claude-opus-4-6', label: 'Claude Opus 4.6', provider: 'anthropic', isDefault: false },
+  ],
+  defaultModel: 'claude-sonnet-4-5',
+};
+
 const mockUseRunnerTypes = vi.fn(() => ({ data: mockRunnerTypes }));
+const mockUseModels = vi.fn(() => ({ data: mockAnthropicModels }));
 
 vi.mock('@/services/queries/use-runner-types', () => ({
   useRunnerTypes: () => mockUseRunnerTypes(),
+}));
+
+vi.mock('@/services/queries/use-models', () => ({
+  useModels: () => mockUseModels(),
 }));
 
 describe('RunnerModelSelector', () => {
@@ -39,6 +56,7 @@ describe('RunnerModelSelector', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseRunnerTypes.mockReturnValue({ data: mockRunnerTypes });
+    mockUseModels.mockReturnValue({ data: mockAnthropicModels });
   });
 
   it('renders trigger button with runner and model name', () => {
@@ -65,43 +83,54 @@ describe('RunnerModelSelector', () => {
     render(<RunnerModelSelector {...defaultProps} />);
     expect(screen.getByRole('button')).toBeDefined();
   });
+
+  it('resolves 4.6 model name from API data in trigger button', () => {
+    render(
+      <RunnerModelSelector
+        {...defaultProps}
+        selectedModel="claude-sonnet-4-6"
+      />
+    );
+    const button = screen.getByRole('button');
+    expect(button.textContent).toContain('Claude Sonnet 4.6');
+  });
+
+  it('resolves 4.6 opus model name from API data in trigger button', () => {
+    render(
+      <RunnerModelSelector
+        {...defaultProps}
+        selectedModel="claude-opus-4-6"
+      />
+    );
+    const button = screen.getByRole('button');
+    expect(button.textContent).toContain('Claude Opus 4.6');
+  });
 });
 
 describe('getDefaultModel', () => {
-  it('returns second model for claude-code', () => {
-    expect(getDefaultModel('claude-code')).toBe('claude-sonnet-4-5');
+  it('returns the API default model when provided', () => {
+    const models = [
+      { id: 'model-1', name: 'Model 1' },
+      { id: 'model-2', name: 'Model 2' },
+    ];
+    expect(getDefaultModel(models, 'model-1')).toBe('model-1');
   });
 
-  it('returns second model for gemini-cli', () => {
-    expect(getDefaultModel('gemini-cli')).toBe('gemini-2.5-pro');
+  it('returns second model when no default specified', () => {
+    const models = [
+      { id: 'model-1', name: 'Model 1' },
+      { id: 'model-2', name: 'Model 2' },
+      { id: 'model-3', name: 'Model 3' },
+    ];
+    expect(getDefaultModel(models)).toBe('model-2');
   });
 
   it('falls back to first model when only one exists', () => {
-    // amp has two models, second is gpt-4o
-    expect(getDefaultModel('amp')).toBe('gpt-4o');
+    const models = [{ id: 'model-1', name: 'Model 1' }];
+    expect(getDefaultModel(models)).toBe('model-1');
   });
 
-  it('returns "default" for unknown runner', () => {
-    expect(getDefaultModel('nonexistent')).toBe('default');
-  });
-});
-
-describe('getModelsForRunner', () => {
-  it('returns claude models for claude-code', () => {
-    const models = getModelsForRunner('claude-code');
-    expect(models).toHaveLength(3);
-    expect(models[0].id).toBe('claude-haiku-4-5');
-  });
-
-  it('returns gemini models for gemini-cli', () => {
-    const models = getModelsForRunner('gemini-cli');
-    expect(models).toHaveLength(2);
-    expect(models[0].id).toBe('gemini-2.0-flash');
-  });
-
-  it('returns fallback for unknown runner', () => {
-    const models = getModelsForRunner('unknown');
-    expect(models).toHaveLength(1);
-    expect(models[0].id).toBe('default');
+  it('returns "default" for empty model list', () => {
+    expect(getDefaultModel([])).toBe('default');
   });
 });

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/new-session-view.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/new-session-view.tsx
@@ -21,6 +21,7 @@ import { RunnerModelSelector, getDefaultModel } from "./runner-model-selector";
 import { WorkflowSelector } from "./workflow-selector";
 import { AddContextModal } from "./modals/add-context-modal";
 import { useRunnerTypes } from "@/services/queries/use-runner-types";
+import { useModels } from "@/services/queries/use-models";
 import { DEFAULT_RUNNER_TYPE_ID } from "@/services/api/runner-types";
 import type { WorkflowConfig } from "../lib/types";
 
@@ -54,18 +55,42 @@ export function NewSessionView({
 
   const [prompt, setPrompt] = useState("");
   const [selectedRunner, setSelectedRunner] = useState<string>(DEFAULT_RUNNER_TYPE_ID);
-  const [selectedModel, setSelectedModel] = useState(() =>
-    getDefaultModel(DEFAULT_RUNNER_TYPE_ID)
+  const [selectedModel, setSelectedModel] = useState<string>("");
+
+  const currentRunner = runnerTypes?.find((r) => r.id === selectedRunner);
+  const currentProvider = currentRunner?.provider;
+
+  // Fetch models for the selected runner's provider.
+  // Only enabled once the provider is known to avoid seeding a model from the wrong provider.
+  const { data: modelsData } = useModels(
+    projectName,
+    !!currentProvider,
+    currentProvider
   );
+
+  // Set default model when models load or runner/provider changes.
+  // Only backfill when the current selection is empty or invalid for the active provider.
+  useEffect(() => {
+    if (!modelsData?.models?.length) return;
+
+    setSelectedModel((prev) => {
+      if (prev && modelsData.models.some((m) => m.id === prev)) {
+        return prev;
+      }
+      return getDefaultModel(
+        modelsData.models.map((m) => ({ id: m.id, name: m.label })),
+        modelsData.defaultModel,
+      );
+    });
+  }, [modelsData]);
 
   // Once runner types load, default to the first available if current selection isn't available
   useEffect(() => {
     if (runnerTypes && runnerTypes.length > 0) {
       const isCurrentAvailable = runnerTypes.some((r) => r.id === selectedRunner);
       if (!isCurrentAvailable) {
-        const firstRunner = runnerTypes[0].id;
-        setSelectedRunner(firstRunner);
-        setSelectedModel(getDefaultModel(firstRunner));
+        setSelectedRunner(runnerTypes[0].id);
+        // Model will be set by the modelsData effect above
       }
     }
   }, [runnerTypes, selectedRunner]);

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/runner-model-selector.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/runner-model-selector.tsx
@@ -14,43 +14,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useRunnerTypes } from "@/services/queries/use-runner-types";
+import { useModels } from "@/services/queries/use-models";
 
 type ModelOption = {
   id: string;
   name: string;
 };
 
-const MODELS_BY_RUNNER: Record<string, ModelOption[]> = {
-  "claude-code": [
-    { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
-    { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
-    { id: "claude-opus-4-5", name: "Claude Opus 4.5" },
-  ],
-  "claude-agent-sdk": [
-    { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
-    { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
-    { id: "claude-opus-4-5", name: "Claude Opus 4.5" },
-  ],
-  "gemini-cli": [
-    { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash" },
-    { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
-  ],
-  "openai-codex": [
-    { id: "gpt-4o", name: "GPT-4o" },
-    { id: "gpt-4.1", name: "GPT-4.1" },
-  ],
-  amp: [
-    { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
-    { id: "gpt-4o", name: "GPT-4o" },
-  ],
-};
-
-function getModelsForRunner(runnerId: string): ModelOption[] {
-  return MODELS_BY_RUNNER[runnerId] ?? [{ id: "default", name: "Default" }];
-}
-
-function getDefaultModel(runnerId: string): string {
-  const models = getModelsForRunner(runnerId);
+function getDefaultModel(models: ModelOption[], defaultModelId?: string): string {
+  if (defaultModelId && models.some((m) => m.id === defaultModelId)) {
+    return defaultModelId;
+  }
   return models[1]?.id ?? models[0]?.id ?? "default";
 }
 
@@ -60,6 +34,48 @@ type RunnerModelSelectorProps = {
   selectedModel: string;
   onSelect: (runner: string, model: string) => void;
 };
+
+type RunnerModelsRadioGroupProps = {
+  projectName: string;
+  runner: { id: string; provider: string };
+  selectedRunner: string;
+  selectedModel: string;
+  onSelect: (runner: string, model: string) => void;
+};
+
+function RunnerModelsRadioGroup({
+  projectName,
+  runner,
+  selectedRunner,
+  selectedModel,
+  onSelect,
+}: RunnerModelsRadioGroupProps) {
+  // Fetch models for this specific runner's provider
+  const { data: modelsData } = useModels(projectName, true, runner.provider);
+
+  const models = modelsData?.models.map((m) => ({ id: m.id, name: m.label })) ?? [];
+
+  if (models.length === 0) {
+    return (
+      <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+        No models available
+      </div>
+    );
+  }
+
+  return (
+    <DropdownMenuRadioGroup
+      value={selectedRunner === runner.id ? selectedModel : ""}
+      onValueChange={(modelId) => onSelect(runner.id, modelId)}
+    >
+      {models.map((model) => (
+        <DropdownMenuRadioItem key={model.id} value={model.id}>
+          {model.name}
+        </DropdownMenuRadioItem>
+      ))}
+    </DropdownMenuRadioGroup>
+  );
+}
 
 export function RunnerModelSelector({
   projectName,
@@ -74,7 +90,14 @@ export function RunnerModelSelector({
   const currentRunner = runners.find((r) => r.id === selectedRunner);
   const currentRunnerName = currentRunner?.displayName ?? selectedRunner;
 
-  const models = useMemo(() => getModelsForRunner(selectedRunner), [selectedRunner]);
+  // Fetch models from API filtered by the current runner's provider.
+  // models.json is the single source of truth — no hardcoded fallback lists.
+  const { data: modelsData } = useModels(projectName, true, currentRunner?.provider);
+
+  const models = useMemo(() => {
+    return modelsData?.models.map((m) => ({ id: m.id, name: m.label })) ?? [];
+  }, [modelsData]);
+
   const currentModel = models.find((m) => m.id === selectedModel);
   const currentModelName = currentModel?.name ?? selectedModel;
 
@@ -93,26 +116,20 @@ export function RunnerModelSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" side="top" sideOffset={4}>
-        {runners.map((runner) => {
-          const runnerModels = getModelsForRunner(runner.id);
-          return (
-            <DropdownMenuSub key={runner.id}>
-              <DropdownMenuSubTrigger>{runner.displayName}</DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                <DropdownMenuRadioGroup
-                  value={selectedRunner === runner.id ? selectedModel : ""}
-                  onValueChange={(modelId) => onSelect(runner.id, modelId)}
-                >
-                  {runnerModels.map((model) => (
-                    <DropdownMenuRadioItem key={model.id} value={model.id}>
-                      {model.name}
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          );
-        })}
+        {runners.map((runner) => (
+          <DropdownMenuSub key={runner.id}>
+            <DropdownMenuSubTrigger>{runner.displayName}</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <RunnerModelsRadioGroup
+                projectName={projectName}
+                runner={runner}
+                selectedRunner={selectedRunner}
+                selectedModel={selectedModel}
+                onSelect={onSelect}
+              />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        ))}
         {runners.length === 0 && (
           <div className="px-2 py-4 text-center text-sm text-muted-foreground">
             No runner types available
@@ -123,4 +140,4 @@ export function RunnerModelSelector({
   );
 }
 
-export { getDefaultModel, getModelsForRunner };
+export { getDefaultModel };


### PR DESCRIPTION
## Summary
- Removed hardcoded model lists from `runner-model-selector` component
- Replaced with API calls to `GET /api/projects/:projectName/models?provider=X`
- Updated `new-session-view` to fetch default model from API
- Fixed tests to mock API instead of testing hardcoded data

## Problem
The new session UI (`runner-model-selector.tsx`) was using hardcoded model lists that only included 4.5 models:
```typescript
const MODELS_BY_RUNNER = {
  "claude-code": [
    { id: "claude-haiku-4-5", ... },
    { id: "claude-sonnet-4-5", ... },
    { id: "claude-opus-4-5", ... },  // Only 4.5!
  ],
  ...
};
```

This caused **Claude 4.6 models to be missing** in the new session view, even though:
- The backend API properly returns all models (including 4.6)
- The `models.json` ConfigMap includes 4.6 models
- The older `create-session-dialog` component fetches from API correctly

## Root Cause
Recent UI redesign introduced `runner-model-selector` with hardcoded models instead of fetching from the API. The old `create-session-dialog` was already using the API correctly via `useModels()` hook.

## Solution
Updated `runner-model-selector` to use the same pattern as `create-session-dialog`:
1. Import and call `useModels(projectName, enabled, provider)` hook
2. Fetch models filtered by runner's provider from API
3. Map API response to select options
4. Remove all hardcoded model constants

## Changes
### `runner-model-selector.tsx`
- Added `useModels()` import
- Removed `MODELS_BY_RUNNER` constant (hardcoded)
- Removed `getModelsForRunner()` function
- Updated `getDefaultModel()` to use API models list
- Added `RunnerModelsRadioGroup` component to fetch models per runner
- Updated exports to remove deleted functions

### `new-session-view.tsx`
- Added `useModels()` import
- Fetch models when component mounts
- Use API's `defaultModel` instead of calling `getDefaultModel(runnerId)`
- Update default model when modelsData changes

### Tests
- Updated mocks to provide `useModels` data
- Changed test assertions to match new API-driven behavior
- Removed tests for deleted `getModelsForRunner()` function
- Updated `getDefaultModel` tests for new signature

## Test plan
- [ ] Verify 4.6 models appear in new session view model selector
- [ ] Verify models update when switching runners
- [ ] Verify default model is selected correctly
- [ ] Frontend unit tests pass
- [ ] TypeScript builds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)