### PR TITLE
fix(e2e): add visibility waits for new-session-btn to fix timing issues

### DIFF
--- a/e2e/cypress/e2e/sessions.cy.ts
+++ b/e2e/cypress/e2e/sessions.cy.ts
@@ -77,7 +77,8 @@ describe('Ambient Session Management Tests', () => {
       body: { data: { ANTHROPIC_API_KEY: apiKey } }
     })).then((r) => expect(r.status).to.eq(200))
 
-    // Create a session for UI tests
+    // Wait for the workspace page to finish loading before creating a session
+    cy.get('[data-testid="new-session-btn"]', { timeout: 20000 }).should('be.visible')
     cy.get('[data-testid="new-session-btn"]').click()
     cy.get('[data-testid="create-session-submit"]', { timeout: 10000 })
         .should('not.be.disabled').click()
@@ -180,7 +181,7 @@ describe('Ambient Session Management Tests', () => {
 
     it('should open create session dialog and interact with form', () => {
       cy.visit(`/projects/${workspaceSlug}`)
-      cy.get('[data-testid="new-session-btn"]', { timeout: 10000 }).click()
+      cy.get('[data-testid="new-session-btn"]', { timeout: 10000 }).should('be.visible').click()
 
       // Create session dialog — covers create-session-dialog.tsx
       cy.get('[data-testid="create-session-submit"]', { timeout: 10000 }).should('exist')
@@ -244,7 +245,7 @@ describe('Ambient Session Management Tests', () => {
 
       // Step 1: Create session
       cy.visit(`/projects/${workspaceSlug}`)
-      cy.get('[data-testid="new-session-btn"]').click()
+      cy.get('[data-testid="new-session-btn"]', { timeout: 10000 }).should('be.visible').click()
       cy.get('[data-testid="create-session-submit"]', { timeout: 10000 })
         .should('not.be.disabled').click()
       cy.url({ timeout: 30000 }).should('match', /\/projects\/.*\/sessions\/[a-z0-9-]+$/)


### PR DESCRIPTION
## Summary

Fixes the E2E test failures across multiple PRs by adding proper visibility checks before clicking the `new-session-btn`.

## Problem

The E2E tests were failing with:
```
AssertionError: Timed out retrying after 10000ms: Expected to find element: `[data-testid="new-session-btn"]`, but never found it.
```

This caused all 58 tests to be skipped in the before() hook, failing the E2E suite on PRs #962, #964, #965, and others.

## Root Cause

The workspace page (`/projects/{slug}`) shows a loading spinner while fetching project data. The test's `cy.request()` API calls complete successfully, but the UI is still rendering. When the test immediately tries to click `new-session-btn`, the page is still showing the loading state, so the button doesn't exist yet.

## Solution

Added `should('be.visible')` checks before clicking the button in three places:
1. `before()` hook (line 80) - with 20s timeout
2. "should open create session dialog" test (line 184)  
3. "Agent Interaction" test (line 248)

This ensures the button is fully rendered and interactive before the test attempts to click it.

## Test Plan

- [x] Local syntax validation (eslint passed)
- [x] Committed and pushed to branch
- [ ] CI E2E tests should now pass (verifying...)
- [ ] Should fix failures on PRs #962, #964, #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)