### PR TITLE
Add changelog feature to ACP menu

### DIFF
--- a/components/frontend/src/app/projects/[name]/layout.tsx
+++ b/components/frontend/src/app/projects/[name]/layout.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { RecentUpdatesDialog } from "@/components/recent-updates-dialog";
 import { UserBubble } from "@/components/user-bubble";
 import { cn } from "@/lib/utils";
 import { useLocalStorage } from "@/hooks/use-local-storage";
@@ -114,6 +115,7 @@ export default function ProjectLayout({
 
               {/* Right: nav items */}
               <div className="flex items-center gap-3">
+                <RecentUpdatesDialog />
                 <ThemeToggle />
                 <Button
                   variant="ghost"

--- a/components/frontend/src/components/__tests__/recent-updates-dialog.test.tsx
+++ b/components/frontend/src/components/__tests__/recent-updates-dialog.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RecentUpdatesDialog } from '../recent-updates-dialog';
+import type { GitHubRelease } from '@/services/api/github-releases';
+
+const mockReleases: GitHubRelease[] = [
+  {
+    id: 1,
+    tag_name: 'v1.2.0',
+    name: 'Release 1.2.0',
+    body: '## What\'s New\n\n- Feature A\n- Feature B',
+    html_url: 'https://github.com/ambient-code/platform/releases/tag/v1.2.0',
+    published_at: '2026-03-18T12:00:00Z',
+    prerelease: false,
+    draft: false,
+  },
+  {
+    id: 2,
+    tag_name: 'v1.1.0',
+    name: 'Release 1.1.0',
+    body: 'Bug fixes and improvements',
+    html_url: 'https://github.com/ambient-code/platform/releases/tag/v1.1.0',
+    published_at: '2026-03-10T12:00:00Z',
+    prerelease: false,
+    draft: false,
+  },
+];
+
+const mockRefetch = vi.fn();
+const mockUseGitHubReleases = vi.fn();
+const mockUseLocalStorage = vi.fn();
+
+vi.mock('@/services/queries/use-github-releases', () => ({
+  useGitHubReleases: () => mockUseGitHubReleases(),
+}));
+
+vi.mock('@/hooks/use-local-storage', () => ({
+  useLocalStorage: (...args: unknown[]) => mockUseLocalStorage(...args),
+}));
+
+describe('RecentUpdatesDialog', () => {
+  const mockSetLastSeen = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGitHubReleases.mockReturnValue({
+      data: mockReleases,
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    });
+    mockUseLocalStorage.mockReturnValue([null, mockSetLastSeen, vi.fn()]);
+  });
+
+  it('renders gift icon button', () => {
+    render(<RecentUpdatesDialog />);
+    const button = screen.getByRole('button', { name: /recent updates/i });
+    expect(button).toBeDefined();
+  });
+
+  it('shows red dot when unseen releases exist', () => {
+    render(<RecentUpdatesDialog />);
+    const button = screen.getByRole('button', { name: /recent updates/i });
+    const dot = button.querySelector('.bg-red-500');
+    expect(dot).not.toBeNull();
+  });
+
+  it('hides red dot when all releases are seen', () => {
+    mockUseLocalStorage.mockReturnValue([
+      '2026-03-19T00:00:00Z',
+      mockSetLastSeen,
+      vi.fn(),
+    ]);
+    render(<RecentUpdatesDialog />);
+    const button = screen.getByRole('button', { name: /recent updates/i });
+    const dot = button.querySelector('.bg-red-500');
+    expect(dot).toBeNull();
+  });
+
+  it('opens dialog on click with release content', async () => {
+    render(<RecentUpdatesDialog />);
+    fireEvent.click(screen.getByRole('button', { name: /recent updates/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Recent Updates')).toBeDefined();
+      expect(screen.getByText('Release 1.2.0')).toBeDefined();
+      expect(screen.getByText('v1.2.0')).toBeDefined();
+      expect(screen.getByText('Release 1.1.0')).toBeDefined();
+    });
+  });
+
+  it('marks updates as seen when dialog opens', () => {
+    render(<RecentUpdatesDialog />);
+    fireEvent.click(screen.getByRole('button', { name: /recent updates/i }));
+    expect(mockSetLastSeen).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('shows loading state', () => {
+    mockUseGitHubReleases.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: mockRefetch,
+    });
+    render(<RecentUpdatesDialog />);
+    fireEvent.click(screen.getByRole('button', { name: /recent updates/i }));
+    // Loader2 renders as an SVG with animate-spin
+    const dialog = screen.getByRole('dialog');
+    const spinner = dialog.querySelector('.animate-spin');
+    expect(spinner).not.toBeNull();
+  });
+
+  it('shows error state with retry button', () => {
+    mockUseGitHubReleases.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetch,
+    });
+    render(<RecentUpdatesDialog />);
+    fireEvent.click(screen.getByRole('button', { name: /recent updates/i }));
+    expect(screen.getByText('Failed to load updates.')).toBeDefined();
+    fireEvent.click(screen.getByText('Retry'));
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it('shows empty state', () => {
+    mockUseGitHubReleases.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    });
+    render(<RecentUpdatesDialog />);
+    fireEvent.click(screen.getByRole('button', { name: /recent updates/i }));
+    expect(screen.getByText('No updates available.')).toBeDefined();
+  });
+
+  it('renders markdown in release body', async () => {
+    render(<RecentUpdatesDialog />);
+    fireEvent.click(screen.getByRole('button', { name: /recent updates/i }));
+    await waitFor(() => {
+      // The markdown heading "What's New" should be rendered
+      expect(screen.getByText("What's New")).toBeDefined();
+      expect(screen.getByText('Feature A')).toBeDefined();
+    });
+  });
+});

--- a/components/frontend/src/components/navigation.tsx
+++ b/components/frontend/src/components/navigation.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { UserBubble } from "@/components/user-bubble";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { RecentUpdatesDialog } from "@/components/recent-updates-dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetClose } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
@@ -133,6 +134,7 @@ export function Navigation({ feedbackUrl }: NavigationProps) {
                 Share feedback
               </a>
             )}
+            <RecentUpdatesDialog />
             <ThemeToggle />
             <Button
               variant="ghost"
@@ -157,6 +159,7 @@ export function Navigation({ feedbackUrl }: NavigationProps) {
           </div>
           {/* Mobile: only show theme toggle (user menu items are in the drawer) */}
           <div className="flex md:hidden items-center gap-2">
+            <RecentUpdatesDialog />
             <ThemeToggle />
           </div>
         </div>

--- a/components/frontend/src/components/recent-updates-dialog.tsx
+++ b/components/frontend/src/components/recent-updates-dialog.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Gift, Loader2, ExternalLink } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { useGitHubReleases } from "@/services/queries/use-github-releases";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+import { useState } from "react";
+
+export function RecentUpdatesDialog() {
+  const [open, setOpen] = useState(false);
+  const { data: releases, isLoading, isError, refetch } = useGitHubReleases();
+  const [lastSeen, setLastSeen] = useLocalStorage<string | null>(
+    "acp-last-seen-updates",
+    null
+  );
+
+  const hasUnseen =
+    releases &&
+    releases.length > 0 &&
+    (!lastSeen || new Date(releases[0].published_at) > new Date(lastSeen));
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (isOpen) {
+      setLastSeen(new Date().toISOString());
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9"
+        aria-label="Recent updates"
+        onClick={() => handleOpenChange(true)}
+      >
+        <div className="relative">
+          <Gift className="h-[1.2rem] w-[1.2rem]" />
+          {hasUnseen && (
+            <span className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-red-500" />
+          )}
+        </div>
+      </Button>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Recent Updates</DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto space-y-6 pr-2">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {isError && (
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                Failed to load updates.
+              </p>
+              <Button variant="outline" size="sm" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </div>
+          )}
+          {!isLoading && !isError && releases?.length === 0 && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No updates available.
+            </p>
+          )}
+          {!isLoading &&
+            !isError &&
+            releases?.map((release) => (
+              <div key={release.id} className="space-y-2">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h3 className="font-semibold">
+                    {release.name || release.tag_name}
+                  </h3>
+                  <Badge variant="secondary">{release.tag_name}</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {formatDistanceToNow(new Date(release.published_at), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                </div>
+                {release.body && (
+                  <div className="prose prose-sm dark:prose-invert max-w-none">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {release.body}
+                    </ReactMarkdown>
+                  </div>
+                )}
+                <a
+                  href={release.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  View on GitHub
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+                <hr className="border-border" />
+              </div>
+            ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/frontend/src/services/api/github-releases.ts
+++ b/components/frontend/src/services/api/github-releases.ts
@@ -1,0 +1,31 @@
+/**
+ * GitHub Releases API client
+ * Uses raw fetch since this is a third-party API, not our backend
+ */
+
+export type GitHubRelease = {
+  id: number;
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  html_url: string;
+  published_at: string;
+  prerelease: boolean;
+  draft: boolean;
+};
+
+const GITHUB_RELEASES_URL =
+  "https://api.github.com/repos/ambient-code/platform/releases";
+
+export async function getGitHubReleases(): Promise<GitHubRelease[]> {
+  const response = await fetch(GITHUB_RELEASES_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch releases: ${response.status}`);
+  }
+
+  const releases: GitHubRelease[] = await response.json();
+  return releases.filter((r) => !r.draft && !r.prerelease);
+}

--- a/components/frontend/src/services/queries/use-github-releases.ts
+++ b/components/frontend/src/services/queries/use-github-releases.ts
@@ -1,0 +1,21 @@
+/**
+ * React Query hook for GitHub releases
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { getGitHubReleases } from "../api/github-releases";
+
+export const githubReleasesKeys = {
+  all: ["github-releases"] as const,
+  list: () => [...githubReleasesKeys.all, "list"] as const,
+};
+
+export function useGitHubReleases() {
+  return useQuery({
+    queryKey: githubReleasesKeys.list(),
+    queryFn: getGitHubReleases,
+    staleTime: 15 * 60 * 1000, // 15 minutes — conserve GitHub's 60 req/hr limit
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
As per ticket, changelog button with modal and a gift box icon.

Demo:

<img width="429" height="70" alt="image" src="https://github.com/user-attachments/assets/50a575c8-46b8-44f3-a647-b08a8458f253" />

<img width="827" height="1352" alt="image" src="https://github.com/user-attachments/assets/8a167d24-7144-4696-acf1-cd44f51794e5" />

Changelog comes from Github release changelog - and in future can be reconsidered. 