### PR TITLE
fix(backend): resolve issue with concurrent agent-session creation

### DIFF
--- a/components/backend/handlers/oauth.go
+++ b/components/backend/handlers/oauth.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -440,7 +441,7 @@ func exchangeOAuthCode(ctx context.Context, provider *OAuthProvider, code string
 func storeOAuthCallback(ctx context.Context, state string, data *OAuthCallbackData) error {
 	if state == "" {
 		// Generate a default key if no state provided
-		state = fmt.Sprintf("callback_%d", time.Now().Unix())
+		state = fmt.Sprintf("callback_%s", uuid.New().String())
 	}
 
 	const secretName = "oauth-callbacks"

--- a/components/backend/handlers/permissions.go
+++ b/components/backend/handlers/permissions.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	authnv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -389,8 +390,8 @@ func CreateProjectKey(c *gin.Context) {
 	}
 
 	// Create a dedicated ServiceAccount per key
-	ts := time.Now().Unix()
-	saName := fmt.Sprintf("ambient-key-%s-%d", sanitizeName(req.Name), ts)
+	uid := uuid.New().String()[:8]
+	saName := fmt.Sprintf("ambient-key-%s-%s", sanitizeName(req.Name), uid)
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      saName,
@@ -412,7 +413,7 @@ func CreateProjectKey(c *gin.Context) {
 	}
 
 	// Bind the SA to the selected role via RoleBinding
-	rbName := fmt.Sprintf("ambient-key-%s-%s-%d", role, sanitizeName(req.Name), ts)
+	rbName := fmt.Sprintf("ambient-key-%s-%s-%s", role, sanitizeName(req.Name), uid)
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      rbName,

--- a/components/backend/handlers/scheduled_sessions.go
+++ b/components/backend/handlers/scheduled_sessions.go
@@ -13,6 +13,7 @@ import (
 	"ambient-code-backend/types"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	authzv1 "k8s.io/api/authorization/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -141,8 +142,7 @@ func CreateScheduledSession(c *gin.Context) {
 		}
 	}
 
-	timestamp := time.Now().Unix()
-	name := fmt.Sprintf("schedule-%d", timestamp)
+	name := fmt.Sprintf("schedule-%s", uuid.New().String())
 
 	// Inject display name into session template so the trigger can use it for naming
 	if req.DisplayName != "" && req.SessionTemplate.DisplayName == "" {
@@ -431,7 +431,7 @@ func TriggerScheduledSession(c *gin.Context) {
 		return
 	}
 
-	jobName := fmt.Sprintf("%s-manual-%d", name, time.Now().Unix())
+	jobName := fmt.Sprintf("%s-manual-%s", name, uuid.New().String()[:8])
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,

--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -24,6 +24,7 @@ import (
 	"ambient-code-backend/types"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	authnv1 "k8s.io/api/authentication/v1"
 	authzv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -695,10 +696,9 @@ func CreateSession(c *gin.Context) {
 		timeout = *req.Timeout
 	}
 
-	// Generate unique name (timestamp-based)
+	// Generate unique name (UUID-based)
 	// Note: Runner will create branch as "ambient/{session-name}"
-	timestamp := time.Now().Unix()
-	name := fmt.Sprintf("session-%d", timestamp)
+	name := fmt.Sprintf("session-%s", uuid.New().String())
 
 	// Create the custom resource
 	// Metadata

--- a/components/backend/handlers/sessions_test.go
+++ b/components/backend/handlers/sessions_test.go
@@ -328,13 +328,8 @@ var _ = Describe("Sessions Handler", Label(test_constants.LabelUnit, test_consta
 
 				sessionNames := make([]string, 0)
 
-				// Create multiple sessions with delays to ensure unique timestamps
+				// Create multiple sessions concurrently - UUID-based names ensure uniqueness
 				for i := 0; i < 3; i++ {
-					// Add a delay to ensure unique timestamps (Unix() has 1-second precision)
-					if i > 0 {
-						time.Sleep(1001 * time.Millisecond) // Slightly over 1 second to ensure different Unix timestamps
-					}
-
 					context := httpUtils.CreateTestGinContext("POST", "/api/projects/"+testNamespace+"/agentic-sessions", sessionRequest)
 					httpUtils.SetAuthHeader(testToken)
 					httpUtils.SetProjectContext(testNamespace)


### PR DESCRIPTION
## Summary 
Replaces all timestamp-based (time.Now().Unix()) resource name generation with UUID-based naming (github.com/google/uuid) to eliminate conflicts under concurrent requests.                                        
                                                                                                                    
### Problem
The POST `/api/projects/{PROJECT_NAME}/agentic-sessions` endpoint used `time.Now().Unix()` (1-second precision) to generate session names like session-1711234567. Concurrent requests within the same second produced identical names, causing K8s resource creation conflicts. 

Reported Bug: https://github.com/ambient-code/platform/issues/976

### Fix

Use uuid.New().String() to guarantee uniqueness regardless of request timing. The same pattern was applied to all other timestamp-based name generators in the backend:

<img width="1489" height="504" alt="image" src="https://github.com/user-attachments/assets/86098226-fc0f-45c7-af1c-f172249a3c96" />


### Test results

After applying the fix, now the concurrent API requests are passing successfully:

```
[2026-03-23 08:33:38,147] session-create-dc0e746f-master-ssp2h/INFO/locust.main: Shutting down (exit code 0)
Type     Name                                                                          # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     POST /agentic-sessions                                                           886     0(0.00%) |     23      18      60     23 |    4.92        0.00
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated                                                                       886     0(0.00%) |     23      18      60     23 |    4.92        0.00

Response time percentiles (approximated)
Type     Name                                                                                  50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
POST     POST /agentic-sessions                                                                 23     24     25     25     27     29     36     47     61     61     61    886
--------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
         Aggregated                                                                             23     24     25     25     27     29     36     47     61     61     61    886
```

