### PR TITLE
feat(mcp): Use Official Jira MCP

### DIFF
--- a/components/runners/ambient-runner/.mcp.json
+++ b/components/runners/ambient-runner/.mcp.json
@@ -12,15 +12,11 @@
       "command": "uvx",
       "args": ["mcp-server-fetch"]
     },
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": ["mcp-atlassian"],
-      "env": {
-        "JIRA_URL": "${JIRA_URL}",
-        "JIRA_USERNAME": "${JIRA_EMAIL}",
-        "JIRA_API_TOKEN": "${JIRA_API_TOKEN}",
-        "JIRA_SSL_VERIFY": "true",
-        "READ_ONLY_MODE": "true"
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp",
+      "headers": {
+        "Authorization": "Basic ${ATLASSIAN_AUTH_HEADER}"
       }
     },
     "google-workspace": {

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
@@ -225,7 +225,10 @@ def check_mcp_authentication(server_name: str) -> tuple[bool | None, str | None]
         except KeyError as e:
             return False, f"Google OAuth credentials corrupted: {str(e)}"
 
-    if server_name in ("mcp-atlassian", "jira"):
+    if server_name in ("atlassian", "mcp-atlassian", "jira"):
+        if os.getenv("ATLASSIAN_AUTH_HEADER", "").strip():
+            return True, "Atlassian credentials configured"
+
         jira_url = os.getenv("JIRA_URL", "").strip()
         jira_token = os.getenv("JIRA_API_TOKEN", "").strip()
         if jira_url and jira_token:

--- a/components/runners/ambient-runner/ambient_runner/platform/auth.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/auth.py
@@ -322,7 +322,7 @@ async def populate_runtime_credentials(context: RunnerContext) -> None:
         except Exception as e:
             logger.warning(f"Failed to write Google credentials: {e}")
 
-    # Jira credentials
+    # Jira / Atlassian credentials
     if isinstance(jira_creds, Exception):
         logger.warning(f"Failed to refresh Jira credentials: {jira_creds}")
     elif jira_creds.get("apiToken"):
@@ -330,6 +330,18 @@ async def populate_runtime_credentials(context: RunnerContext) -> None:
         os.environ["JIRA_API_TOKEN"] = jira_creds.get("apiToken", "")
         os.environ["JIRA_EMAIL"] = jira_creds.get("email", "")
         logger.info("Updated Jira credentials in environment")
+
+        # Build base64 auth header for official Atlassian Remote MCP Server
+        email = jira_creds.get("email", "")
+        api_token = jira_creds["apiToken"]
+        if email and api_token:
+            import base64
+
+            auth_header = base64.b64encode(
+                f"{email}:{api_token}".encode()
+            ).decode()
+            os.environ["ATLASSIAN_AUTH_HEADER"] = auth_header
+            logger.info("Set ATLASSIAN_AUTH_HEADER for Atlassian Remote MCP Server")
 
     # GitLab credentials (with user identity)
     if isinstance(gitlab_creds, Exception):

--- a/components/runners/ambient-runner/ambient_runner/platform/auth.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/auth.py
@@ -342,6 +342,9 @@ async def populate_runtime_credentials(context: RunnerContext) -> None:
             ).decode()
             os.environ["ATLASSIAN_AUTH_HEADER"] = auth_header
             logger.info("Set ATLASSIAN_AUTH_HEADER for Atlassian Remote MCP Server")
+        else:
+            os.environ.pop("ATLASSIAN_AUTH_HEADER", None)
+            logger.info("Cleared ATLASSIAN_AUTH_HEADER: missing email or apiToken")
 
     # GitLab credentials (with user identity)
     if isinstance(gitlab_creds, Exception):

--- a/components/runners/ambient-runner/pyproject.toml
+++ b/components/runners/ambient-runner/pyproject.toml
@@ -26,12 +26,9 @@ claude = [
 observability = [
   "langfuse>=3.0.0",
 ]
-mcp-atlassian = [
-  "mcp-atlassian>=0.11.9",
-]
 # Install everything for the polymorphic runner
 all = [
-  "ambient-runner[claude,observability,mcp-atlassian]",
+  "ambient-runner[claude,observability]",
 ]
 
 [tool.uv]

--- a/components/runners/ambient-runner/tests/test_mcp_auth.py
+++ b/components/runners/ambient-runner/tests/test_mcp_auth.py
@@ -81,7 +81,7 @@ class TestGoogleWorkspaceAuth:
 
 
 class TestJiraAuth:
-    """Test check_mcp_authentication for jira/mcp-atlassian."""
+    """Test check_mcp_authentication for jira/atlassian/mcp-atlassian."""
 
     def test_jira_credentials_present(self, monkeypatch):
         monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
@@ -94,6 +94,7 @@ class TestJiraAuth:
     def test_jira_no_credentials(self, monkeypatch):
         monkeypatch.delenv("JIRA_URL", raising=False)
         monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+        monkeypatch.delenv("ATLASSIAN_AUTH_HEADER", raising=False)
         monkeypatch.delenv("BACKEND_API_URL", raising=False)
 
         is_auth, msg = check_mcp_authentication("jira")
@@ -106,6 +107,26 @@ class TestJiraAuth:
 
         is_auth, msg = check_mcp_authentication("mcp-atlassian")
         assert is_auth is True
+
+    def test_atlassian_auth_header(self, monkeypatch):
+        """Official Atlassian Remote MCP Server uses ATLASSIAN_AUTH_HEADER."""
+        monkeypatch.delenv("JIRA_URL", raising=False)
+        monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+        monkeypatch.setenv("ATLASSIAN_AUTH_HEADER", "dXNlckBleC5jb206dG9rZW4=")
+
+        is_auth, msg = check_mcp_authentication("atlassian")
+        assert is_auth is True
+        assert "atlassian" in msg.lower()
+
+    def test_atlassian_no_credentials(self, monkeypatch):
+        monkeypatch.delenv("JIRA_URL", raising=False)
+        monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+        monkeypatch.delenv("ATLASSIAN_AUTH_HEADER", raising=False)
+        monkeypatch.delenv("BACKEND_API_URL", raising=False)
+
+        is_auth, msg = check_mcp_authentication("atlassian")
+        assert is_auth is False
+        assert "not configured" in msg.lower()
 
 
 class TestUnknownServer:

--- a/components/runners/ambient-runner/tests/test_observability_metrics.py
+++ b/components/runners/ambient-runner/tests/test_observability_metrics.py
@@ -86,18 +86,18 @@ class TestToolClassification:
 
     def test_mcp_jira(self):
         assert (
-            classify_tool("mcp__mcp-atlassian__jira_get_issue") == ToolCallType.MCP_JIRA
+            classify_tool("mcp__atlassian__jira_get_issue") == ToolCallType.MCP_JIRA
         )
 
     def test_mcp_confluence(self):
         assert (
-            classify_tool("mcp__mcp-atlassian__confluence_search")
+            classify_tool("mcp__atlassian__confluence_search")
             == ToolCallType.MCP_CONFLUENCE
         )
 
     def test_mcp_atlassian_generic(self):
         assert (
-            classify_tool("mcp__mcp-atlassian__some_other_tool")
+            classify_tool("mcp__atlassian__some_other_tool")
             == ToolCallType.MCP_ATLASSIAN
         )
 


### PR DESCRIPTION
  - .mcp.json — Replaced the community mcp-atlassian stdio server (spawns a local Python process via uvx) with the official        
  Atlassian Remote MCP Server as an HTTP endpoint (https://mcp.atlassian.com/v1/mcp) with Basic auth header                        
  - auth.py — After fetching Jira creds from the backend, computes a base64 email:apiToken string and sets ATLASSIAN_AUTH_HEADER   
  env var for the HTTP header                                                                                                      
  - mcp.py — Auth check recognizes the new "atlassian" server name and checks ATLASSIAN_AUTH_HEADER first
  - pyproject.toml — Removed mcp-atlassian>=0.11.9 optional dependency                                                             
  - Tests — Updated tool classification tests to use mcp__atlassian__* prefix, added tests for the new auth header check
                                                                                                                                   
This Eliminates local Python process + community dependency, uses first-party Atlassian server with Jira + Confluence + Compass                                                                                             