### PR TITLE
fix(frontend): resolve agent response buffering due to stale EventSou…

### DIFF
--- a/components/frontend/src/hooks/use-agui-stream.ts
+++ b/components/frontend/src/hooks/use-agui-stream.ts
@@ -185,7 +185,7 @@ export function useAGUIStream(options: UseAGUIStreamOptions): UseAGUIStreamRetur
         }, delay)
       }
     },
-    [projectName, sessionName, processEvent, onConnected, onError, onDisconnected],
+    [projectName, sessionName, onConnected, onError, onDisconnected],
   )
 
   // Disconnect from the event stream


### PR DESCRIPTION
…rce closure

Fixes intermittent message buffering where agent responses don't display until the user sends another message. The EventSource onmessage handler was capturing a stale processEvent closure, causing events to be processed with outdated setState callbacks when component callbacks changed (e.g., during agent team operations). Use a ref to ensure the handler always calls the latest processEvent, guaranteeing immediate UI updates.