### PR TITLE
fix(runner): propagate userId to all Langfuse traces across async requests

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/observability.py
+++ b/components/runners/ambient-runner/ambient_runner/observability.py
@@ -462,6 +462,8 @@ class ObservabilityManager:
             )
 
         except Exception as e:
+            self._current_turn_generation = None
+            self._current_turn_ctx = None
             self._exit_turn_propagate_ctx()
             logging.error(f"Langfuse: Failed to start turn: {e}", exc_info=True)
 
@@ -1141,8 +1143,16 @@ class ObservabilityManager:
                     logging.warning(f"Failed to close tool span {tool_id}: {e}")
             self._tool_spans.clear()
 
-            # Emit session-level summary metrics before closing context
-            self._emit_session_summary()
+            # Emit session-level summary metrics before closing context.
+            # Re-enter propagation so the span gets userId/sessionId/tags
+            # even when finalize() runs in a different async task than initialize().
+            if self._propagate_args:
+                from langfuse import propagate_attributes
+
+                with propagate_attributes(**self._propagate_args):
+                    self._emit_session_summary()
+            else:
+                self._emit_session_summary()
 
             # Exit propagate_attributes context.
             # The context uses OpenTelemetry contextvars internally.  When


### PR DESCRIPTION
## Summary

- ~77% of Langfuse traces had no `userId`, `sessionId`, or `tags`, making usage reports unreliable
- Root cause: `propagate_attributes()` stores values in OTel contextvars, which are per-asyncio-task. The context set during `initialize()` (first HTTP request) was invisible to subsequent requests running in new asyncio tasks
- Fix: save propagation args during `initialize()` and re-enter `propagate_attributes()` at the start of each turn in `start_turn()`. Per-turn context is cleaned up in `end_turn()`, `finalize()`, and error paths

## Test plan

- [x] 474 runner unit tests pass
- [ ] Deploy to dev cluster and verify new traces in Langfuse have `userId` and `sessionId` populated
- [ ] Run `scripts/langfuse-usage-report.py` and confirm "unknown" bucket is significantly reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)