### PR TITLE
chore(ci): clarify SDK drift check is for Ambient SDK

### DIFF
--- a/.github/workflows/sdk-drift-check.yml
+++ b/.github/workflows/sdk-drift-check.yml
@@ -1,4 +1,4 @@
-name: SDK Drift Check
+name: Ambient SDK Drift Check
 
 on:
   pull_request:
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   check-drift:
-    name: SDK Generator Drift
+    name: Ambient SDK Generator Drift
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Renames workflow and job from "SDK Drift Check" to "Ambient SDK Drift Check" to distinguish from other SDKs

## Test plan
- [ ] Verify workflow name appears correctly in GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)