### PR TITLE
fix(runner): improve ACP MCP tools

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/backend_tools.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/backend_tools.py
@@ -58,31 +58,78 @@ def create_backend_mcp_tools(
     @sdk_tool_decorator(
         "acp_list_sessions",
         (
-            "List all active agentic sessions in the current project. "
-            "Retrieves running and pending sessions. By default excludes "
-            "completed/stopped sessions."
+            "List agentic sessions in the current project with filtering and pagination. "
+            "By default returns only active sessions (Running, Pending). "
+            "Use 'phase' to filter by specific status, or 'include_completed' to see all. "
+            "Use 'search' to filter by name or display name."
         ),
         {
             "type": "object",
             "properties": {
                 "include_completed": {
                     "type": "boolean",
-                    "description": "Whether to include stopped/completed sessions",
-                }
+                    "description": "Include stopped/completed/failed sessions (default: false)",
+                },
+                "phase": {
+                    "type": "string",
+                    "description": "Filter by phase: Running, Pending, Creating, Stopping, Stopped, Failed, Completed",
+                    "enum": [
+                        "Pending",
+                        "Creating",
+                        "Running",
+                        "Stopping",
+                        "Stopped",
+                        "Completed",
+                        "Failed",
+                    ],
+                },
+                "search": {
+                    "type": "string",
+                    "description": "Search by session name or display name (case-insensitive)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max sessions to return (default 20, max 100)",
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Offset for pagination",
+                },
             },
             "required": [],
         },
     )
     async def acp_list_sessions(args: dict) -> dict:
-        """List all active agentic sessions."""
+        """List agentic sessions with filtering."""
         try:
-            include_completed = args.get("include_completed", False)
-            sessions = api_client.list_sessions(include_completed=include_completed)
+            result = api_client.list_sessions(
+                include_completed=args.get("include_completed", False),
+                search=args.get("search"),
+                limit=args.get("limit"),
+                offset=args.get("offset"),
+                phase=args.get("phase"),
+            )
+            sessions = result["items"]
+            # Return a summary for each session
+            summaries = []
+            for s in sessions:
+                status = s.get("status", {})
+                metadata = s.get("metadata", {})
+                summary = {
+                    "name": metadata.get("name", s.get("name", "")),
+                    "displayName": s.get("spec", {}).get("displayName", ""),
+                    "phase": status.get("phase", "Unknown"),
+                    "agentStatus": status.get("agentStatus"),
+                    "createdAt": metadata.get("creationTimestamp", ""),
+                }
+                summaries.append(summary)
             return _tool_response(
                 {
                     "success": True,
-                    "sessions": sessions,
-                    "count": len(sessions),
+                    "sessions": summaries,
+                    "count": len(summaries),
+                    "totalCount": result.get("totalCount", len(summaries)),
+                    "hasMore": result.get("hasMore", False),
                 }
             )
         except Exception as e:
@@ -126,7 +173,8 @@ def create_backend_mcp_tools(
         "acp_create_session",
         (
             "Create a new agentic session in the current project. "
-            "Creates and starts a new Claude session with the specified configuration."
+            "Creates and starts a new Claude session with the specified configuration. "
+            "Optionally attach a workflow to define the session's behavior."
         ),
         {
             "type": "object",
@@ -151,6 +199,18 @@ def create_backend_mcp_tools(
                     "type": "string",
                     "description": "LLM model override (e.g., claude-sonnet-4-5)",
                 },
+                "workflow_git_url": {
+                    "type": "string",
+                    "description": "Git URL of the workflow repository to use",
+                },
+                "workflow_branch": {
+                    "type": "string",
+                    "description": "Branch of the workflow repo (default: main)",
+                },
+                "workflow_path": {
+                    "type": "string",
+                    "description": "Path within the workflow repo (for multi-workflow repos)",
+                },
             },
             "required": ["session_name"],
         },
@@ -172,12 +232,23 @@ def create_backend_mcp_tools(
                 except json.JSONDecodeError as e:
                     return _tool_error(ValueError(f"Invalid repos JSON: {e}"))
 
+            # Build workflow config if provided
+            workflow = None
+            workflow_git_url = args.get("workflow_git_url")
+            if workflow_git_url:
+                workflow = {"gitUrl": workflow_git_url}
+                if args.get("workflow_branch"):
+                    workflow["branch"] = args["workflow_branch"]
+                if args.get("workflow_path"):
+                    workflow["path"] = args["workflow_path"]
+
             session = api_client.create_session(
                 session_name=session_name,
                 initial_prompt=initial_prompt,
                 display_name=display_name,
                 repos=repos_list,
                 model=model,
+                workflow=workflow,
             )
             return _tool_response(
                 {
@@ -280,7 +351,169 @@ def create_backend_mcp_tools(
 
     tools.append(acp_send_message)
 
-    # Tool 6: Get API Reference
+    # Tool 6: Get Session Status and Recent Messages
+    @sdk_tool_decorator(
+        "acp_get_session_status",
+        (
+            "Get the current status and recent messages of an agentic session. "
+            "Returns the session phase (Running, Pending, Stopped, etc.), "
+            "agent status (working, idle, waiting_input), and the most recent "
+            "text messages from the conversation."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "session_name": {
+                    "type": "string",
+                    "description": "Name of the session to check",
+                },
+                "max_messages": {
+                    "type": "integer",
+                    "description": "Max number of recent text messages to return (default 5, max 50)",
+                },
+            },
+            "required": ["session_name"],
+        },
+    )
+    async def acp_get_session_status(args: dict) -> dict:
+        """Get session status and recent messages."""
+        try:
+            session_name = args["session_name"]
+            max_messages = min(args.get("max_messages", 5), 50)
+
+            # Get session details for phase and agentStatus
+            session = api_client.get_session(session_name)
+            status = session.get("status", {})
+            spec = session.get("spec", {})
+
+            result = {
+                "success": True,
+                "name": session_name,
+                "displayName": spec.get("displayName", ""),
+                "phase": status.get("phase", "Unknown"),
+                "agentStatus": status.get("agentStatus"),
+                "startTime": status.get("startTime"),
+                "lastActivityTime": status.get("lastActivityTime"),
+            }
+
+            # Try to get recent events for message content
+            try:
+                # Fetch a reasonable number of events (not all text events are messages,
+                # so fetch more than max_messages to account for non-text events)
+                events = api_client.get_session_events(
+                    session_name=session_name, limit=max_messages * 10
+                )
+                # Extract text messages from AG-UI events
+                messages = []
+                for event in events:
+                    event_type = event.get("type", "")
+                    if event_type == "TEXT_MESSAGE_CONTENT" and event.get("text"):
+                        messages.append(
+                            {
+                                "role": event.get("role", "assistant"),
+                                "text": event["text"][:500],
+                            }
+                        )
+                # Return only the last N messages
+                result["recentMessages"] = messages[-max_messages:]
+                result["totalMessages"] = len(messages)
+            except Exception as events_err:
+                logger.debug(f"Could not fetch events for {session_name}: {events_err}")
+                result["recentMessages"] = []
+                result["totalMessages"] = 0
+
+            return _tool_response(result)
+        except Exception as e:
+            logger.error(f"Error getting session status: {e}", exc_info=True)
+            return _tool_error(e)
+
+    tools.append(acp_get_session_status)
+
+    # Tool 7: Restart Session
+    @sdk_tool_decorator(
+        "acp_restart_session",
+        (
+            "Restart an agentic session by stopping it and starting it again. "
+            "Useful for recovering from failures or stuck sessions."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "session_name": {
+                    "type": "string",
+                    "description": "Name of the session to restart",
+                }
+            },
+            "required": ["session_name"],
+        },
+    )
+    async def acp_restart_session(args: dict) -> dict:
+        """Restart an agentic session (stop + start)."""
+        try:
+            session_name = args["session_name"]
+            # Stop the session first
+            try:
+                api_client.stop_session(session_name)
+            except Exception:
+                pass  # Session may already be stopped
+            # Start it again
+            api_client.start_session(session_name)
+            return _tool_response(
+                {
+                    "success": True,
+                    "message": f"Session '{session_name}' restarted successfully",
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error restarting session: {e}", exc_info=True)
+            return _tool_error(e)
+
+    tools.append(acp_restart_session)
+
+    # Tool 8: List Available Workflows
+    @sdk_tool_decorator(
+        "acp_list_workflows",
+        (
+            "List available out-of-the-box workflows that can be used when creating sessions. "
+            "Returns workflow id, name, description, and git configuration needed "
+            "for the acp_create_session workflow parameters."
+        ),
+        {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    )
+    async def acp_list_workflows(args: dict) -> dict:
+        """List available workflows."""
+        try:
+            workflows = api_client.list_workflows()
+            summaries = []
+            for w in workflows:
+                summaries.append(
+                    {
+                        "id": w.get("id", ""),
+                        "name": w.get("name", ""),
+                        "description": w.get("description", ""),
+                        "gitUrl": w.get("gitUrl", ""),
+                        "branch": w.get("branch", "main"),
+                        "path": w.get("path", ""),
+                    }
+                )
+            return _tool_response(
+                {
+                    "success": True,
+                    "workflows": summaries,
+                    "count": len(summaries),
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error listing workflows: {e}", exc_info=True)
+            return _tool_error(e)
+
+    tools.append(acp_list_workflows)
+
+    # Tool 9: Get API Reference
     @sdk_tool_decorator(
         "acp_get_api_reference",
         (

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
@@ -112,7 +112,8 @@ def build_mcp_servers(
         logger.info(
             f"Added backend API MCP tools ({len(backend_tools)}): "
             "acp_list_sessions, acp_get_session, acp_create_session, "
-            "acp_stop_session, acp_send_message, acp_get_api_reference"
+            "acp_stop_session, acp_send_message, acp_get_session_status, "
+            "acp_restart_session, acp_list_workflows, acp_get_api_reference"
         )
 
     return mcp_servers

--- a/components/runners/ambient-runner/ambient_runner/tools/backend_api.py
+++ b/components/runners/ambient-runner/ambient_runner/tools/backend_api.py
@@ -11,6 +11,7 @@ import urllib.request
 import uuid
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
 
@@ -91,24 +92,64 @@ class BackendAPIClient:
             logger.error(f"URL error from {url}: {e.reason}")
             raise
 
-    def list_sessions(self, include_completed: bool = False) -> List[Dict[str, Any]]:
-        """List all sessions in the project.
+    def list_sessions(
+        self,
+        include_completed: bool = False,
+        search: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        phase: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List sessions in the project with filtering and pagination.
 
         Args:
-            include_completed: Whether to include completed sessions
+            include_completed: Whether to include stopped/completed sessions
+            search: Search term to filter by name or displayName
+            limit: Max number of sessions to return (default 20, max 100)
+            offset: Offset for pagination
+            phase: Filter by phase (Running, Pending, Stopped, Failed, Completed)
 
         Returns:
-            List of session objects
+            Dict with 'items', 'totalCount', 'hasMore', 'nextOffset' keys
         """
         path = f"/projects/{self.project_name}/agentic-sessions"
+
+        query_params: Dict[str, Any] = {}
+        if search:
+            query_params["search"] = search
+        if limit is not None:
+            query_params["limit"] = limit
+        if offset is not None:
+            query_params["offset"] = offset
+        if query_params:
+            path = f"{path}?{urlencode(query_params)}"
+
         response = self._make_request("GET", path)
 
-        sessions = response.get("sessions", [])
-        if not include_completed:
-            # Filter out completed sessions (phase == "Stopped")
-            sessions = [s for s in sessions if s.get("phase") != "Stopped"]
+        items = response.get("items", [])
 
-        return sessions
+        # Client-side phase filtering (backend doesn't support phase query param)
+        if phase:
+            phase_lower = phase.lower()
+            items = [
+                s
+                for s in items
+                if s.get("status", {}).get("phase", "").lower() == phase_lower
+            ]
+        elif not include_completed:
+            items = [
+                s
+                for s in items
+                if s.get("status", {}).get("phase", "").lower()
+                not in ("stopped", "completed", "failed")
+            ]
+
+        return {
+            "items": items,
+            "totalCount": len(items),
+            "hasMore": response.get("hasMore", False),
+            "nextOffset": response.get("nextOffset"),
+        }
 
     def get_session(self, session_name: str) -> Dict[str, Any]:
         """Get details of a specific session.
@@ -129,6 +170,7 @@ class BackendAPIClient:
         display_name: Optional[str] = None,
         repos: Optional[List[Dict[str, str]]] = None,
         model: Optional[str] = None,
+        workflow: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Create a new agentic session.
 
@@ -141,6 +183,7 @@ class BackendAPIClient:
             display_name: Optional human-readable display name
             repos: Optional list of repository configurations [{"url": "...", "branch": "..."}]
             model: Optional LLM model override (e.g., "claude-sonnet-4-5")
+            workflow: Optional workflow config {"gitUrl": "...", "branch": "...", "path": "..."}
 
         Returns:
             Created session object
@@ -164,6 +207,8 @@ class BackendAPIClient:
             payload["repos"] = repos
         if model:
             payload["llmSettings"] = {"model": model}
+        if workflow:
+            payload["activeWorkflow"] = workflow
 
         return self._make_request("POST", path, data=payload)
 
@@ -205,6 +250,29 @@ class BackendAPIClient:
             payload["threadId"] = thread_id
 
         return self._make_request("POST", path, data=payload)
+
+    def start_session(self, session_name: str) -> Dict[str, Any]:
+        """Start a stopped session.
+
+        Args:
+            session_name: Name of the session to start
+
+        Returns:
+            Response from the backend
+        """
+        path = f"/projects/{self.project_name}/agentic-sessions/{session_name}/start"
+        return self._make_request("POST", path)
+
+    def list_workflows(self) -> List[Dict[str, Any]]:
+        """List available out-of-the-box workflows.
+
+        Returns:
+            List of workflow objects with id, name, description, gitUrl, branch, path
+        """
+        path = "/workflows/ootb"
+        query = f"?project={self.project_name}" if self.project_name else ""
+        response = self._make_request("GET", f"{path}{query}")
+        return response.get("workflows", [])
 
     def get_session_events(
         self,

--- a/components/runners/ambient-runner/tests/test_backend_tools.py
+++ b/components/runners/ambient-runner/tests/test_backend_tools.py
@@ -63,54 +63,125 @@ class TestBackendAPIClient:
 
     @patch("urllib.request.urlopen")
     def test_list_sessions(self, mock_urlopen, monkeypatch):
-        """Test listing sessions."""
+        """Test listing sessions returns paginated response with items key."""
         monkeypatch.setenv("BACKEND_API_URL", "http://backend:8080/api")
         monkeypatch.setenv("PROJECT_NAME", "test-project")
 
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps(
             {
-                "sessions": [
-                    {"name": "session-1", "phase": "Running"},
-                    {"name": "session-2", "phase": "Stopped"},
-                ]
+                "items": [
+                    {
+                        "metadata": {"name": "session-1"},
+                        "status": {"phase": "Running"},
+                    },
+                    {
+                        "metadata": {"name": "session-2"},
+                        "status": {"phase": "Stopped"},
+                    },
+                ],
+                "totalCount": 2,
+                "hasMore": False,
             }
         ).encode("utf-8")
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
         client = BackendAPIClient()
-        sessions = client.list_sessions(include_completed=True)
+        result = client.list_sessions(include_completed=True)
 
-        assert len(sessions) == 2
-        assert sessions[0]["name"] == "session-1"
-        assert sessions[1]["name"] == "session-2"
+        assert len(result["items"]) == 2
+        assert result["items"][0]["metadata"]["name"] == "session-1"
+        assert result["totalCount"] == 2
 
     @patch("urllib.request.urlopen")
     def test_list_sessions_filters_completed(self, mock_urlopen, monkeypatch):
-        """Test that list_sessions filters out stopped sessions by default."""
+        """Test that list_sessions filters out stopped/completed/failed sessions by default."""
         monkeypatch.setenv("BACKEND_API_URL", "http://backend:8080/api")
         monkeypatch.setenv("PROJECT_NAME", "test-project")
 
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps(
             {
-                "sessions": [
-                    {"name": "session-1", "phase": "Running"},
-                    {"name": "session-2", "phase": "Stopped"},
-                    {"name": "session-3", "phase": "Pending"},
-                ]
+                "items": [
+                    {
+                        "metadata": {"name": "session-1"},
+                        "status": {"phase": "Running"},
+                    },
+                    {
+                        "metadata": {"name": "session-2"},
+                        "status": {"phase": "Stopped"},
+                    },
+                    {
+                        "metadata": {"name": "session-3"},
+                        "status": {"phase": "Pending"},
+                    },
+                ],
+                "totalCount": 3,
+                "hasMore": False,
             }
         ).encode("utf-8")
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
         client = BackendAPIClient()
-        sessions = client.list_sessions(include_completed=False)
+        result = client.list_sessions(include_completed=False)
 
-        assert len(sessions) == 2
-        assert sessions[0]["name"] == "session-1"
-        assert sessions[1]["name"] == "session-3"
+        assert len(result["items"]) == 2
+        assert result["items"][0]["metadata"]["name"] == "session-1"
+        assert result["items"][1]["metadata"]["name"] == "session-3"
+
+    @patch("urllib.request.urlopen")
+    def test_list_sessions_filter_by_phase(self, mock_urlopen, monkeypatch):
+        """Test filtering sessions by specific phase."""
+        monkeypatch.setenv("BACKEND_API_URL", "http://backend:8080/api")
+        monkeypatch.setenv("PROJECT_NAME", "test-project")
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(
+            {
+                "items": [
+                    {
+                        "metadata": {"name": "session-1"},
+                        "status": {"phase": "Running"},
+                    },
+                    {
+                        "metadata": {"name": "session-2"},
+                        "status": {"phase": "Stopped"},
+                    },
+                ],
+                "totalCount": 2,
+                "hasMore": False,
+            }
+        ).encode("utf-8")
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+        client = BackendAPIClient()
+        result = client.list_sessions(phase="Running")
+
+        assert len(result["items"]) == 1
+        assert result["items"][0]["metadata"]["name"] == "session-1"
+
+    @patch("urllib.request.urlopen")
+    def test_list_sessions_with_search(self, mock_urlopen, monkeypatch):
+        """Test that search param is passed as query parameter."""
+        monkeypatch.setenv("BACKEND_API_URL", "http://backend:8080/api")
+        monkeypatch.setenv("PROJECT_NAME", "test-project")
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(
+            {"items": [], "totalCount": 0, "hasMore": False}
+        ).encode("utf-8")
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+        client = BackendAPIClient()
+        client.list_sessions(search="my-task")
+
+        call_args = mock_urlopen.call_args
+        request = call_args[0][0]
+        assert "search=my-task" in request.full_url
 
     @patch("urllib.request.urlopen")
     def test_get_session(self, mock_urlopen, monkeypatch):
@@ -161,7 +232,7 @@ class TestBackendAPIClient:
 
     @patch("urllib.request.urlopen")
     def test_create_session_with_all_params(self, mock_urlopen, monkeypatch):
-        """Test creating a session with all params."""
+        """Test creating a session with all params including workflow."""
         monkeypatch.setenv("BACKEND_API_URL", "http://backend:8080/api")
         monkeypatch.setenv("PROJECT_NAME", "test-project")
 
@@ -174,12 +245,18 @@ class TestBackendAPIClient:
 
         client = BackendAPIClient()
         repos = [{"url": "https://github.com/test/repo", "branch": "main"}]
+        workflow = {
+            "gitUrl": "https://github.com/org/workflows",
+            "branch": "main",
+            "path": "workflows/bugfix",
+        }
         session = client.create_session(
             session_name="new-session",
             initial_prompt="Test prompt",
             display_name="Test Session",
             repos=repos,
             model="claude-sonnet-4-5",
+            workflow=workflow,
         )
 
         assert session["name"] == "new-session"
@@ -193,6 +270,7 @@ class TestBackendAPIClient:
         assert payload["displayName"] == "Test Session"
         assert payload["repos"] == repos
         assert payload["llmSettings"]["model"] == "claude-sonnet-4-5"
+        assert payload["activeWorkflow"] == workflow
 
     @patch("urllib.request.urlopen")
     def test_stop_session(self, mock_urlopen, monkeypatch):
@@ -302,7 +380,9 @@ class TestBackendAPIClient:
         monkeypatch.setenv("BOT_TOKEN", "secret-token")
 
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps({"sessions": []}).encode("utf-8")
+        mock_response.read.return_value = json.dumps(
+            {"items": [], "totalCount": 0, "hasMore": False}
+        ).encode("utf-8")
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
@@ -322,7 +402,9 @@ class TestBackendAPIClient:
         monkeypatch.delenv("BOT_TOKEN", raising=False)
 
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps({"sessions": []}).encode("utf-8")
+        mock_response.read.return_value = json.dumps(
+            {"items": [], "totalCount": 0, "hasMore": False}
+        ).encode("utf-8")
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
@@ -362,9 +444,7 @@ class TestBackendMCPTools:
         tools = create_backend_mcp_tools(sdk_tool_decorator=mock_tool, client=client)
 
         assert isinstance(tools, list)
-        assert (
-            len(tools) == 6
-        )  # 6 tools: list, get, create, stop, send_message, get_api_reference
+        assert len(tools) == 9
 
         # Verify tool names
         tool_names = [t._tool_name for t in tools]
@@ -373,6 +453,9 @@ class TestBackendMCPTools:
         assert "acp_create_session" in tool_names
         assert "acp_stop_session" in tool_names
         assert "acp_send_message" in tool_names
+        assert "acp_get_session_status" in tool_names
+        assert "acp_restart_session" in tool_names
+        assert "acp_list_workflows" in tool_names
         assert "acp_get_api_reference" in tool_names
 
     def test_create_backend_tools_returns_empty_when_no_env(self, monkeypatch):
@@ -408,7 +491,20 @@ class TestBackendMCPTools:
 
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps(
-            {"sessions": [{"name": "session-1"}]}
+            {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "session-1",
+                            "creationTimestamp": "2026-01-01T00:00:00Z",
+                        },
+                        "spec": {"displayName": "Test Session"},
+                        "status": {"phase": "Running", "agentStatus": "working"},
+                    }
+                ],
+                "totalCount": 1,
+                "hasMore": False,
+            }
         ).encode("utf-8")
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
@@ -441,6 +537,8 @@ class TestBackendMCPTools:
         assert result_data["success"] is True
         assert result_data["count"] == 1
         assert result_data["sessions"][0]["name"] == "session-1"
+        assert result_data["sessions"][0]["phase"] == "Running"
+        assert result_data["sessions"][0]["agentStatus"] == "working"
 
     @pytest.mark.asyncio
     async def test_api_reference_tool(self, monkeypatch):


### PR DESCRIPTION
## Summary

- **Fix `list_sessions` returning empty array**: Backend returns `{"items": [...]}` but client was reading `response.get("sessions", [])`. Fixed key + added `search`, `limit`, `offset`, `phase` filtering and pagination support.
- **Add workflow support to `create_session`**: Exposes `activeWorkflow` field (`workflow_git_url`, `workflow_branch`, `workflow_path`) so sessions can be created with a workflow attached.
- **New `acp_get_session_status` tool**: Returns session phase, `agentStatus` (working/idle/waiting_input), timestamps, and recent text messages from the conversation.
- **New `acp_restart_session` tool**: Stop + start for recovering stuck/failed sessions.
- **New `acp_list_workflows` tool**: Discover available out-of-the-box workflows (for use with `create_session`).
- **Quality fixes**: proper URL encoding via `urlencode`, accurate `totalCount` after filtering, added missing CRD phases (Creating, Stopping) to filter enum.

## Test plan

- [x] All 22 existing + new tests pass (`pytest tests/test_backend_tools.py`)
- [x] ruff format + ruff check pass
- [ ] Manual verification on dev cluster: list_sessions returns sessions, create with workflow, get_session_status shows messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)