### PR TITLE
chore(manifests): scale up frontend replicas and backend/minio resource limits

### DIFF
--- a/components/manifests/base/core/backend-deployment.yaml
+++ b/components/manifests/base/core/backend-deployment.yaml
@@ -210,11 +210,11 @@ spec:
               optional: true
         resources:
           requests:
-            cpu: 100m
-            memory: 256Mi
+            cpu: 200m
+            memory: 512Mi
           limits:
-            cpu: 500m
-            memory: 768Mi
+            cpu: "1"
+            memory: 1536Mi
         livenessProbe:
           httpGet:
             path: /health

--- a/components/manifests/base/core/frontend-deployment.yaml
+++ b/components/manifests/base/core/frontend-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: frontend
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: frontend

--- a/components/manifests/base/core/minio-deployment.yaml
+++ b/components/manifests/base/core/minio-deployment.yaml
@@ -74,11 +74,11 @@ spec:
           failureThreshold: 5
         resources:
           requests:
-            cpu: 2000m
-            memory: 4Gi
+            cpu: 3000m
+            memory: 6Gi
           limits:
-            cpu: 4000m
-            memory: 8Gi
+            cpu: 6000m
+            memory: 12Gi
       volumes:
       - name: data
         persistentVolumeClaim:


### PR DESCRIPTION
## Summary

- Scale frontend from 1 to 2 replicas to handle load (already applied to UAT cluster)
- Increase backend-api resource limits (CPU 500m→1, memory 768Mi→1.5Gi)
- Increase MinIO resource limits (CPU 4→6, memory 8Gi→12Gi)

## Test plan

- [x] Already applied live to UAT cluster, pods running healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)