### PR TITLE
fix(operator): increase runner pod memory limit from 4Gi to 8Gi

### DIFF
--- a/components/manifests/base/core/agent-registry-configmap.yaml
+++ b/components/manifests/base/core/agent-registry-configmap.yaml
@@ -20,7 +20,7 @@ data:
           },
           "resources": {
             "requests": {"cpu": "500m", "memory": "512Mi"},
-            "limits": {"cpu": "2", "memory": "4Gi"}
+            "limits": {"cpu": "2", "memory": "8Gi"}
           }
         },
         "sandbox": {

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -802,7 +802,7 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("2000m"),
-			corev1.ResourceMemory: resource.MustParse("4Gi"),
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
 		},
 	}
 	if runtime != nil && runtime.Container.Resources != nil {


### PR DESCRIPTION
## Summary
- Increase runner pod memory limit from 4Gi to 8Gi (8192 MiB) in both the agent-registry ConfigMap and the operator's hardcoded fallback defaults
- Runner pods were hitting OOM kills at the previous 4Gi limit

## Changes
- `components/manifests/base/core/agent-registry-configmap.yaml` — bump `limits.memory` from `4Gi` to `8Gi`
- `components/operator/internal/handlers/sessions.go` — bump default `ResourceMemory` limit from `4Gi` to `8Gi`

## Test plan
- [ ] Deploy to staging and verify new pods get the 8Gi memory limit (`kubectl describe pod`)
- [ ] Confirm existing sessions are unaffected (limit change only applies to newly created pods)


Made with [Cursor](https://cursor.com)