### PR TITLE
fix(manifests): match minio PVC storage to cluster value

### DIFF
--- a/components/manifests/base/core/minio-deployment.yaml
+++ b/components/manifests/base/core/minio-deployment.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 100Gi
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Summary
- Updates minio-data PVC from `50Gi` to `100Gi` to match the current cluster value
- The PVC was manually expanded on the cluster but the manifest was never updated, causing deploy failures (`spec.resources.requests.storage: Forbidden: field can not be less than previous value`)

## Test plan
- [ ] Verify the release deploy workflow passes: the `oc apply -k` step should no longer fail on the minio-data PVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)