### PR TITLE
fix(frontend): allow spaces in AskUserQuestion Other input

### DIFF
--- a/components/frontend/src/components/session/ask-user-question.tsx
+++ b/components/frontend/src/components/session/ask-user-question.tsx
@@ -271,6 +271,7 @@ export const AskUserQuestionMessage: React.FC<AskUserQuestionMessageProps> = ({
                 value={otherText[q.question] || ""}
                 onChange={(e) => handleOtherTextChange(q.question, e.target.value)}
                 onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
                 disabled={disabled}
                 className="mt-1 h-7 text-sm"
               />


### PR DESCRIPTION
## Summary
- Fixes a bug where spaces could not be typed in the "Other" freeform text input of the AskUserQuestion tool UI
- The parent `<label>` element's `onKeyDown` handler was intercepting Space key presses and calling `preventDefault()`, blocking the character from reaching the input
- Added `onKeyDown={(e) => e.stopPropagation()}` on the input to match the existing `onClick` stopPropagation pattern

## Test plan
- [ ] Open a session with an AskUserQuestion tool call that has predefined options (triggering the "Other" option)
- [ ] Select "Other" and verify spaces can be typed in the text input
- [ ] Verify selecting predefined radio options still works correctly
- [ ] Verify Enter key in the input still submits the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)