### PR TITLE
fix(frontend): fix new session textarea overflow in Firefox

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/new-session-view.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/new-session-view.tsx
@@ -161,7 +161,7 @@ export function NewSessionView({
             onChange={(e) => setPrompt(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Describe what you'd like to work on..."
-            className="min-h-[100px] resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 pb-12"
+            className="min-h-[100px] resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 pb-12 overflow-y-auto"
           />
           <div className="absolute bottom-0 left-0 right-0 flex items-center justify-between px-2 py-2">
             <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Adds `overflow-y: auto` to the new session textarea to prevent text from visually overflowing into the bottom toolbar in Firefox
- Firefox versions lacking `field-sizing: content` support keep the textarea at fixed `min-h-[100px]`, leaving only ~52px of usable space after the `pb-12` toolbar padding — long text overflows instead of scrolling

## Test plan
- [ ] Open the new session view in Firefox
- [ ] Type or paste long multi-line text into the textarea
- [ ] Verify text scrolls within the textarea instead of overflowing into the toolbar
- [ ] Verify Chrome/Safari behavior is unchanged (textarea still auto-grows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)