### PR TITLE
fix(manifests): add minio resource limits for e2e and kind overlays

### DIFF
--- a/components/manifests/overlays/e2e/kustomization.yaml
+++ b/components/manifests/overlays/e2e/kustomization.yaml
@@ -31,6 +31,12 @@ patches:
   target:
     kind: PersistentVolumeClaim
     name: minio-data
+- path: minio-resources-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: minio
 - path: frontend-test-patch.yaml
   target:
     kind: Deployment

--- a/components/manifests/overlays/e2e/minio-pvc-patch.yaml
+++ b/components/manifests/overlays/e2e/minio-pvc-patch.yaml
@@ -5,3 +5,6 @@ metadata:
   name: minio-data
 spec:
   storageClassName: standard  # kind default storage class
+  resources:
+    requests:
+      storage: 1Gi

--- a/components/manifests/overlays/e2e/minio-resources-patch.yaml
+++ b/components/manifests/overlays/e2e/minio-resources-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  template:
+    spec:
+      containers:
+      - name: minio
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/components/manifests/overlays/kind/kustomization.yaml
+++ b/components/manifests/overlays/kind/kustomization.yaml
@@ -52,6 +52,12 @@ patches:
   target:
     kind: PersistentVolumeClaim
     name: minio-data
+- path: minio-resources-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: minio
 - path: frontend-test-patch.yaml
   target:
     kind: Deployment

--- a/components/manifests/overlays/kind/minio-pvc-patch.yaml
+++ b/components/manifests/overlays/kind/minio-pvc-patch.yaml
@@ -5,3 +5,6 @@ metadata:
   name: minio-data
 spec:
   storageClassName: standard  # kind default storage class
+  resources:
+    requests:
+      storage: 1Gi

--- a/components/manifests/overlays/kind/minio-resources-patch.yaml
+++ b/components/manifests/overlays/kind/minio-resources-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  template:
+    spec:
+      containers:
+      - name: minio
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi


### PR DESCRIPTION
## Summary
- The base minio deployment was scaled to 3 CPU / 6Gi memory (limits: 6 CPU / 12Gi) in #1008 for UAT, but the e2e and kind overlays had no resource override
- **E2E tests**: minio pod stays `Pending` on CI Kind clusters because the node can't satisfy the resource requests, timing out after 5 minutes
- **test-local-dev**: minio consumes 3000m CPU leaving insufficient CPU for backend-api, frontend, operator, postgresql, and unleash pods (`FailedScheduling: Insufficient cpu`)
- Adds `minio-resources-patch.yaml` to both overlays (250m/256Mi requests, 500m/512Mi limits)
- Reduces minio PVC from 100Gi to 1Gi for local/CI environments

## Test plan
- [ ] E2E CI pipeline passes with minio pod scheduling successfully
- [ ] test-local-dev-simulation CI job passes with all pods scheduling
- [ ] `kubectl kustomize components/manifests/overlays/e2e` renders correctly
- [ ] `kubectl kustomize components/manifests/overlays/kind` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)