### PR TITLE
fix(manifests): use Always imagePullPolicy for ambient-api-server

### DIFF
--- a/components/manifests/base/core/ambient-api-server-service.yml
+++ b/components/manifests/base/core/ambient-api-server-service.yml
@@ -35,7 +35,7 @@ spec:
       initContainers:
         - name: migration
           image: quay.io/ambient_code/vteam_api_server:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - /usr/local/bin/ambient-api-server
             - migrate
@@ -58,7 +58,7 @@ spec:
       containers:
         - name: api-server
           image: quay.io/ambient_code/vteam_api_server:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - /usr/local/bin/ambient-api-server
             - serve


### PR DESCRIPTION
## Summary

- Change `imagePullPolicy` from `IfNotPresent` to `Always` for both the `migration` init container and `api-server` container in the `ambient-api-server` Deployment, matching the convention used by all other base Deployments.

Fixes #1030

## Test plan

- [ ] Verify the manifest renders correctly with `kustomize build components/manifests/base`
- [ ] Confirm a rollout restart pulls the latest image on a node with a cached copy