### PR TITLE
feat(ci): enhance release changelog with author grouping and first-time contributors

### DIFF
--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -140,7 +140,9 @@ jobs:
                       ['git', 'log', '--all', f'--before={tag_date}', '--format=%an'],
                       capture_output=True, text=True
                   )
-                  prior_authors = set(prior.stdout.strip().split('\n')) if prior.stdout.strip() else set()
+                  prior_authors = set()
+                  if prior.returncode == 0 and prior.stdout.strip():
+                      prior_authors = set(prior.stdout.strip().split('\n'))
                   for author, _ in sorted_authors:
                       if author not in prior_authors:
                           first_timers.append(author)


### PR DESCRIPTION
## Summary

- **Group commits by author** with commit counts (e.g., "Gage Krumbach (18)"), sorted by contribution count
- **Add "First-Time Contributors" section** with 🎉 emoji to celebrate new contributors
- **Use Python** for reliable parsing of commit data with special characters
- **Fix `--before` bug**: resolve tag to ISO date since `git log --before` requires a date, not a ref name — passing a tag name silently returns wrong results, causing incorrect first-timer detection

## Example Output (v0.0.34)

### Before (flat list):
```
- fix(frontend): resolve agent response buffering (#991) (de502766)
- fix(frontend): export chat handles compacted MESSAGES_SNAPSHOT events (#1010) (b204abdf)
- fix(frontend): binary file download corruption (#996) (5b584f82)
...
```

### After (grouped by author):
```
## 🎉 First-Time Contributors

- Derek Higgins
- Pete Savage
- Rahul Shetty

### Gage Krumbach (5)
- fix(runner): improve ACP MCP tools (#1006) (26be0f94)
- chore(manifests): scale up frontend replicas (#1008) (b331da14)
...

### Pete Savage (1)
- fix(frontend): resolve agent response buffering (#991) (de502766)
```

## Bug Fix: `--before` with tag names

`git log --before=v0.0.33` does **not** filter by the tag's date — it resolves differently and returns commits from after the tag. This caused first-timer detection to produce wrong results. Fixed by resolving the tag to its ISO date first:

```python
tag_date = subprocess.run(
    ['git', 'log', '-1', '--format=%ci', latest_tag],
    capture_output=True, text=True
).stdout.strip()
```

## Test Plan

- [x] Verified `--before=<tag>` vs `--before=<date>` returns different results
- [x] Tested changelog generation locally against v0.0.33→v0.0.34 and v0.0.34→v0.0.35
- [x] Confirmed first-time contributor detection works correctly with date-based filtering
- [x] YAML validates (`check-yaml` hook passes)
- [ ] Will validate in next production release

🤖 Generated with [Claude Code](https://claude.com/claude-code)