### PR TITLE
feat(operator): add LimitRange defaults for Cluster Autoscaler bin-packing

### DIFF
--- a/components/manifests/base/core/kustomization.yaml
+++ b/components/manifests/base/core/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ambient-api-server-service.yml
 - unleash-deployment.yaml
 - agent-registry-configmap.yaml
+- limitrange.yaml
 
 configMapGenerator:
 - name: ambient-models

--- a/components/manifests/base/core/limitrange.yaml
+++ b/components/manifests/base/core/limitrange.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: ambient-default-limits
+  labels:
+    ambient-code.io/managed: "true"
+    app.kubernetes.io/managed-by: ambient-code
+spec:
+  limits:
+  - type: Container
+    defaultRequest:
+      cpu: 250m
+      memory: 256Mi
+    default:
+      cpu: "2"
+      memory: 4Gi

--- a/components/manifests/base/crds/projectsettings-crd.yaml
+++ b/components/manifests/base/crds/projectsettings-crd.yaml
@@ -77,6 +77,11 @@ spec:
               scheduledSessionRBACReady:
                 type: boolean
                 description: "Whether RBAC for scheduled session triggers is provisioned"
+              limitRangeReady:
+                type: boolean
+                description: "Whether the default LimitRange for CA bin-packing is provisioned"
+    subresources:
+      status: {}
     additionalPrinterColumns:
     - name: Age
       type: date

--- a/components/manifests/base/rbac/operator-clusterrole.yaml
+++ b/components/manifests/base/rbac/operator-clusterrole.yaml
@@ -60,6 +60,10 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["rolebindings"]
   verbs: ["get", "create", "delete"]
+# LimitRanges (create per-project resource defaults for CA bin-packing)
+- apiGroups: [""]
+  resources: ["limitranges"]
+  verbs: ["get", "create"]
 # ConfigMaps (agent registry for runner type resolution)
 - apiGroups: [""]
   resources: ["configmaps"]

--- a/components/operator/internal/handlers/projectsettings.go
+++ b/components/operator/internal/handlers/projectsettings.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/watch"
@@ -149,18 +150,81 @@ func reconcileProjectSettings(obj *unstructured.Unstructured) error {
 		triggerRBACReady = false
 	}
 
+	// Ensure LimitRange for resource defaults (CA bin-packing safety net)
+	limitRangeReady := true
+	if err := ensureLimitRange(namespace, obj); err != nil {
+		log.Printf("Error ensuring LimitRange in namespace %s: %v", namespace, err)
+		limitRangeReady = false
+	}
+
 	// Update status with reconciliation results
 	statusUpdate := map[string]interface{}{
 		"groupBindingsCreated":      groupBindingsCreated,
 		"scheduledSessionRBACReady": triggerRBACReady,
+		"limitRangeReady":           limitRangeReady,
 	}
 
 	if statusErr := updateProjectSettingsStatus(namespace, name, statusUpdate); statusErr != nil {
 		log.Printf("Failed to update ProjectSettings status in namespace %s: %v", namespace, statusErr)
 	}
 
+	// LimitRange failure is non-fatal: sessions can still run without it.
+	// RBAC failure IS fatal: sessions cannot be created without trigger permissions.
 	if !triggerRBACReady {
 		return fmt.Errorf("failed to ensure session trigger RBAC in namespace %s", namespace)
+	}
+
+	return nil
+}
+
+func buildOwnerRef(owner *unstructured.Unstructured) v1.OwnerReference {
+	isController := true
+	return v1.OwnerReference{
+		APIVersion: owner.GetAPIVersion(),
+		Kind:       owner.GetKind(),
+		Name:       owner.GetName(),
+		UID:        owner.GetUID(),
+		Controller: &isController,
+	}
+}
+
+func ensureLimitRange(namespace string, owner *unstructured.Unstructured) error {
+	const lrName = "ambient-default-limits"
+
+	managedLabels := map[string]string{
+		"ambient-code.io/managed": "true",
+	}
+
+	lr := &corev1.LimitRange{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            lrName,
+			Namespace:       namespace,
+			Labels:          managedLabels,
+			OwnerReferences: []v1.OwnerReference{buildOwnerRef(owner)},
+		},
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypeContainer,
+					DefaultRequest: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Default: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := config.K8sClient.CoreV1().LimitRanges(namespace).Create(context.TODO(), lr, v1.CreateOptions{}); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create LimitRange %s: %v", lrName, err)
+		}
+	} else {
+		log.Printf("Created LimitRange %s in namespace %s", lrName, namespace)
 	}
 
 	return nil
@@ -236,14 +300,7 @@ func ensureSessionTriggerRBAC(namespace string, owner *unstructured.Unstructured
 		"ambient-code.io/managed": "true",
 	}
 
-	isController := true
-	ownerRef := v1.OwnerReference{
-		APIVersion: owner.GetAPIVersion(),
-		Kind:       owner.GetKind(),
-		Name:       owner.GetName(),
-		UID:        owner.GetUID(),
-		Controller: &isController,
-	}
+	ownerRef := buildOwnerRef(owner)
 
 	// Create ServiceAccount (idempotent — ignore AlreadyExists)
 	sa := &corev1.ServiceAccount{

--- a/components/operator/internal/handlers/projectsettings_test.go
+++ b/components/operator/internal/handlers/projectsettings_test.go
@@ -34,6 +34,120 @@ func testProjectSettingsOwner(namespace string) *unstructured.Unstructured {
 	}
 }
 
+func TestEnsureLimitRange_CreatesLimitRange(t *testing.T) {
+	setupProjectSettingsTestClient()
+
+	namespace := "test-namespace"
+
+	err := ensureLimitRange(namespace, testProjectSettingsOwner(namespace))
+	if err != nil {
+		t.Fatalf("ensureLimitRange() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+
+	lr, err := config.K8sClient.CoreV1().LimitRanges(namespace).Get(ctx, "ambient-default-limits", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get LimitRange: %v", err)
+	}
+	if lr.Name != "ambient-default-limits" {
+		t.Errorf("LimitRange name = %q, want %q", lr.Name, "ambient-default-limits")
+	}
+	if lr.Labels["ambient-code.io/managed"] != "true" {
+		t.Errorf("LimitRange missing managed label")
+	}
+
+	// Verify correct values
+	if len(lr.Spec.Limits) != 1 {
+		t.Fatalf("Expected 1 limit item, got %d", len(lr.Spec.Limits))
+	}
+	item := lr.Spec.Limits[0]
+	if item.Type != corev1.LimitTypeContainer {
+		t.Errorf("Limit type = %q, want %q", item.Type, corev1.LimitTypeContainer)
+	}
+
+	// Check defaultRequest
+	cpuReq := item.DefaultRequest[corev1.ResourceCPU]
+	if cpuReq.String() != "250m" {
+		t.Errorf("DefaultRequest CPU = %q, want %q", cpuReq.String(), "250m")
+	}
+	memReq := item.DefaultRequest[corev1.ResourceMemory]
+	if memReq.String() != "256Mi" {
+		t.Errorf("DefaultRequest Memory = %q, want %q", memReq.String(), "256Mi")
+	}
+
+	// Check default (limits)
+	cpuLim := item.Default[corev1.ResourceCPU]
+	if cpuLim.String() != "2" {
+		t.Errorf("Default CPU = %q, want %q", cpuLim.String(), "2")
+	}
+	memLim := item.Default[corev1.ResourceMemory]
+	if memLim.String() != "4Gi" {
+		t.Errorf("Default Memory = %q, want %q", memLim.String(), "4Gi")
+	}
+
+	// Verify owner reference
+	if len(lr.OwnerReferences) != 1 {
+		t.Fatalf("Expected 1 owner reference, got %d", len(lr.OwnerReferences))
+	}
+	if lr.OwnerReferences[0].Kind != "ProjectSettings" {
+		t.Errorf("OwnerReference Kind = %q, want %q", lr.OwnerReferences[0].Kind, "ProjectSettings")
+	}
+}
+
+func TestEnsureLimitRange_Idempotent(t *testing.T) {
+	setupProjectSettingsTestClient()
+
+	namespace := "test-namespace"
+	owner := testProjectSettingsOwner(namespace)
+
+	// First call
+	err := ensureLimitRange(namespace, owner)
+	if err != nil {
+		t.Fatalf("First ensureLimitRange() returned error: %v", err)
+	}
+
+	// Second call — should not error
+	err = ensureLimitRange(namespace, owner)
+	if err != nil {
+		t.Fatalf("Second ensureLimitRange() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Verify LimitRange still exists
+	_, err = config.K8sClient.CoreV1().LimitRanges(namespace).Get(ctx, "ambient-default-limits", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("LimitRange should still exist: %v", err)
+	}
+}
+
+func TestEnsureLimitRange_MultipleNamespaces(t *testing.T) {
+	setupProjectSettingsTestClient()
+
+	namespaces := []string{"project-alpha", "project-beta"}
+
+	for _, ns := range namespaces {
+		err := ensureLimitRange(ns, testProjectSettingsOwner(ns))
+		if err != nil {
+			t.Fatalf("ensureLimitRange(%q) returned error: %v", ns, err)
+		}
+	}
+
+	ctx := context.Background()
+
+	for _, ns := range namespaces {
+		lr, err := config.K8sClient.CoreV1().LimitRanges(ns).Get(ctx, "ambient-default-limits", metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("LimitRange should exist in namespace %q: %v", ns, err)
+			continue
+		}
+		if len(lr.Spec.Limits) != 1 {
+			t.Errorf("Namespace %q: expected 1 limit item, got %d", ns, len(lr.Spec.Limits))
+		}
+	}
+}
+
 func TestEnsureSessionTriggerRBAC_CreatesAllResources(t *testing.T) {
 	setupProjectSettingsTestClient()
 


### PR DESCRIPTION
Add LimitRange objects with defaultRequest values to both the platform namespace (static YAML manifest) and project namespaces (dynamically created by the operator during ProjectSettings reconciliation). This ensures containers without explicit resource requests receive a non-zero scheduling footprint, which is critical for Cluster Autoscaler bin-packing accuracy on ROSA.

Changes:
- Static LimitRange manifest for the platform namespace (250m CPU, 256Mi memory defaultRequest; 2 CPU, 4Gi memory default limit)
- ensureLimitRange() in ProjectSettings reconciler for dynamic per-project namespace creation with OwnerReference lifecycle
- Extracted buildOwnerRef() helper to reduce duplication between ensureLimitRange() and ensureSessionTriggerRBAC()
- RBAC: granted operator limitranges get/create permissions
- Three unit tests: creation, idempotency, multi-namespace isolation