### PR TITLE
feat(backend): filter disabled workflows from OOTB listing

### DIFF
--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -2028,12 +2028,19 @@ func ListOOTBWorkflows(c *gin.Context) {
 		var ambientConfig struct {
 			Name        string `json:"name"`
 			Description string `json:"description"`
+			Enabled     *bool  `json:"enabled,omitempty"`
 		}
 		if err == nil {
 			// Parse ambient.json if found
 			if parseErr := json.Unmarshal(ambientData, &ambientConfig); parseErr != nil {
 				log.Printf("ListOOTBWorkflows: failed to parse ambient.json for %s: %v", entryName, parseErr)
 			}
+		}
+
+		// Skip workflows explicitly disabled in ambient.json
+		if ambientConfig.Enabled != nil && !*ambientConfig.Enabled {
+			log.Printf("ListOOTBWorkflows: skipping disabled workflow %s", entryName)
+			continue
 		}
 
 		// Use ambient.json values or fallback to directory name


### PR DESCRIPTION
## Summary

- Workflows with `"enabled": false` in their `.ambient/ambient.json` are now completely excluded from the `/api/workflows/ootb` response
- Previously all discovered workflows were returned with `enabled: true` regardless of their config
- Field is optional — omitting it or setting `"enabled": true` preserves current behavior (backward compatible)

## Test plan

- [ ] Deploy backend, verify workflows without `enabled` field still appear
- [ ] Set `"enabled": false` on a workflow's `ambient.json`, verify it no longer appears in API response or UI
- [ ] Set `"enabled": true` explicitly, verify it still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)