### PR TITLE
feat(frontend): HPA for Frontend

### DIFF
--- a/components/manifests/base/core/frontend-deployment.yaml
+++ b/components/manifests/base/core/frontend-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: frontend
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: frontend

--- a/components/manifests/overlays/production/frontend-deployment-patch.yaml
+++ b/components/manifests/overlays/production/frontend-deployment-patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: frontend
-spec:
-  replicas: null

--- a/components/manifests/overlays/production/kustomization.yaml
+++ b/components/manifests/overlays/production/kustomization.yaml
@@ -49,12 +49,6 @@ patches:
     kind: Service
     name: ambient-api-server
     version: v1
-- path: frontend-deployment-patch.yaml
-  target:
-    group: apps
-    kind: Deployment
-    name: frontend
-    version: v1
 
 # Production images
 images:


### PR DESCRIPTION
**Description:** 

Add HPA for frontend deployment

- frontend-hpa.yaml: HPA that scales the frontend deployment between 2–10 pods based on CPU         
  utilization (70% threshold) of the frontend container only, with conservative scale-down behavior

- kustomization.yaml: one line added to include frontend-hpa.yaml as a resource in the production   
  overlay     