### PR TITLE
feat(runner): enable Gmail tools in Google Workspace MCP

### DIFF
--- a/components/runners/ambient-runner/.mcp.json
+++ b/components/runners/ambient-runner/.mcp.json
@@ -28,7 +28,8 @@
       "args": [
         "workspace-mcp@1.6.1",
         "--tools",
-        "drive"
+        "drive",
+        "gmail"
       ],
       "env": {
         "GOOGLE_MCP_CREDENTIALS_DIR": "${GOOGLE_MCP_CREDENTIALS_DIR}",


### PR DESCRIPTION
## Summary
- Adds `gmail` to the `--tools` flag for the `workspace-mcp` server in `.mcp.json`
- Enables Gmail tools (search, read, send, draft) alongside the existing Drive tools

## Test plan
- [ ] Verify runner starts with both `drive` and `gmail` tools registered
- [ ] Test Gmail send functionality with valid Google OAuth credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)