### PR TITLE
feat(frontend): sidebar session sorting, links, and action menu

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/sessions-sidebar.test.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/sessions-sidebar.test.tsx
@@ -10,10 +10,13 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('next/link', () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  default: ({ children, href, onClick }: { children: React.ReactNode; href: string; onClick?: () => void }) => (
+    <a href={href} onClick={onClick}>{children}</a>
   ),
 }));
+
+const mockMutate = vi.fn();
+const mockMutation = { mutate: mockMutate, isPending: false };
 
 const mockUseSessionsPaginated = vi.fn((): { data: { items: Partial<AgenticSession>[] } | null; isLoading: boolean } => ({
   data: { items: [] },
@@ -21,6 +24,14 @@ const mockUseSessionsPaginated = vi.fn((): { data: { items: Partial<AgenticSessi
 }));
 vi.mock('@/services/queries/use-sessions', () => ({
   useSessionsPaginated: () => mockUseSessionsPaginated(),
+  useStopSession: () => mockMutation,
+  useDeleteSession: () => mockMutation,
+  useContinueSession: () => mockMutation,
+  useUpdateSessionDisplayName: () => mockMutation,
+}));
+
+vi.mock('@/services/queries/use-project-access', () => ({
+  useProjectAccess: () => ({ data: { userRole: 'admin' } }),
 }));
 
 vi.mock('@/services/queries/use-version', () => ({
@@ -128,14 +139,15 @@ describe('SessionsSidebar', () => {
     expect(screen.getByText('Session 2')).toBeDefined();
   });
 
-  it('clicking session navigates to correct URL', () => {
+  it('session items link to correct URL', () => {
     mockUseSessionsPaginated.mockReturnValue({
       data: { items: makeSessions(2) },
       isLoading: false,
     });
     render(<SessionsSidebar {...defaultProps} />);
-    fireEvent.click(screen.getByText('Session 1'));
-    expect(mockPush).toHaveBeenCalledWith(
+    const link = screen.getByText('Session 1').closest('a');
+    expect(link).toBeDefined();
+    expect(link?.getAttribute('href')).toBe(
       '/projects/test-project/sessions/session-1'
     );
   });

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/sessions-sidebar.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/sessions-sidebar.tsx
@@ -18,6 +18,7 @@ import { AgentStatusIndicator, agentStatusLabel } from "@/components/agent-statu
 import { deriveAgentStatusFromPhase } from "@/hooks/use-agent-status";
 import { SessionStatusDot, sessionPhaseLabel } from "@/components/session-status-dot";
 import { EditSessionNameDialog } from "@/components/edit-session-name-dialog";
+import { DestructiveConfirmationDialog } from "@/components/confirmation-dialog";
 import {
   Plus,
   PanelLeftClose,
@@ -102,6 +103,7 @@ export function SessionsSidebar({
   const updateDisplayNameMutation = useUpdateSessionDisplayName();
 
   const [editingSession, setEditingSession] = useState<{ name: string; displayName: string } | null>(null);
+  const [deletingSessionName, setDeletingSessionName] = useState<string | null>(null);
 
   const sessions = useMemo(() => {
     const items = data?.items ?? [];
@@ -177,13 +179,18 @@ export function SessionsSidebar({
   };
 
   const handleDelete = (sessionName: string) => {
-    if (!confirm(`Delete session "${sessionName}"? This action cannot be undone.`)) return;
-    const isCurrentSession = sessionName === currentSessionName;
+    setDeletingSessionName(sessionName);
+  };
+
+  const confirmDelete = () => {
+    if (!deletingSessionName) return;
+    const isCurrentSession = deletingSessionName === currentSessionName;
     deleteMutation.mutate(
-      { projectName, sessionName },
+      { projectName, sessionName: deletingSessionName },
       {
         onSuccess: () => {
           toast.success(`Session deleted`);
+          setDeletingSessionName(null);
           if (isCurrentSession) {
             router.push(`/projects/${projectName}/sessions`);
           }
@@ -441,13 +448,21 @@ export function SessionsSidebar({
           )}
         </div>
       </div>
-      {/* Edit Session Name Dialog */}
       <EditSessionNameDialog
         open={!!editingSession}
         onOpenChange={(open) => !open && setEditingSession(null)}
         currentName={editingSession?.displayName || ""}
         onSave={handleSaveEditName}
         isLoading={updateDisplayNameMutation.isPending}
+      />
+      <DestructiveConfirmationDialog
+        open={!!deletingSessionName}
+        onOpenChange={(open) => !open && setDeletingSessionName(null)}
+        onConfirm={confirmDelete}
+        title="Delete session"
+        description={`Delete session "${deletingSessionName}"? This action cannot be undone.`}
+        confirmText="Delete"
+        loading={deleteMutation.isPending}
       />
     </div>
   );
@@ -532,7 +547,7 @@ function SidebarSessionActions({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="hidden group-hover:flex items-center justify-center h-6 w-6 rounded-sm flex-shrink-0 mr-1 text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 transition-colors"
+          className="opacity-0 group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 flex items-center justify-center h-6 w-6 rounded-sm flex-shrink-0 mr-1 text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 transition-colors"
         >
           <MoreVertical className="h-3.5 w-3.5" />
           <span className="sr-only">Session actions</span>


### PR DESCRIPTION
## Summary
- **Sort by activity**: Sessions in the sidebar are now ordered by `lastActivityTime` (falling back to `creationTimestamp`), so the most recently active session appears first
- **Proper links**: Session items render as `<Link>` elements instead of `div[role=button]`, enabling middle-click to open in a new tab and standard browser link behavior
- **Hover action menu**: A 3-dot menu appears on hover with context-aware actions: Rename, Stop (for running sessions), Continue (for stopped/completed sessions), and Delete (admin only)

## Test plan
- [ ] Verify sidebar sessions are ordered by most recent activity
- [ ] Middle-click a session item — should open in new tab
- [ ] Hover over a session to see the 3-dot menu
- [ ] Test Rename action opens the edit name dialog
- [ ] Test Stop action on a running session
- [ ] Test Continue action on a stopped/completed session
- [ ] Test Delete action (admin only) with confirmation dialog
- [ ] Verify non-admin users don't see Delete option
- [ ] Verify view-only users don't see any action menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)