### PR TITLE
chore: increase MinIO PVC storage to 500Gi

### DIFF
--- a/components/manifests/base/core/minio-deployment.yaml
+++ b/components/manifests/base/core/minio-deployment.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Gi
+      storage: 500Gi
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Summary
- Increase MinIO persistent volume claim from 100Gi to 500Gi to accommodate growing storage needs

## Test plan
- [ ] Verify deployment applies cleanly with updated PVC size
- [ ] Confirm kind/e2e overlays still patch to 1Gi for local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)