### PR TITLE
ci: push PR images to Quay for pre-merge testing

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -200,21 +200,22 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.component.name }}-${{ matrix.arch.suffix }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component.name }}-${{ matrix.arch.suffix }}
 
-      - name: Build ${{ matrix.component.name }} (${{ matrix.arch.suffix }}) for pull request
+      - name: Build and push ${{ matrix.component.name }} (${{ matrix.arch.suffix }}) for pull request
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.component.context }}
           file: ${{ matrix.component.dockerfile }}
           platforms: ${{ matrix.arch.platform }}
-          push: false
+          push: true
           tags: ${{ matrix.component.image }}:pr-${{ github.event.pull_request.number }}-${{ matrix.arch.suffix }}
           build-args: AMBIENT_VERSION=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.component.name }}-${{ matrix.arch.suffix }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component.name }}-${{ matrix.arch.suffix }}
 
   merge-manifests:
     needs: [detect-changes, build]
-    if: github.event_name != 'pull_request' && needs.detect-changes.outputs.has-builds == 'true'
+    if: needs.detect-changes.outputs.has-builds == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -234,7 +235,8 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Create multi-arch manifest for ${{ matrix.component.name }}
+      - name: Create multi-arch manifest for ${{ matrix.component.name }} (push/dispatch)
+        if: github.event_name != 'pull_request'
         # Suffixes (-amd64, -arm64) must match the arch matrix in the build job above.
         # Arch-suffixed tags remain in the registry after merging. Clean these up
         # via Quay tag expiration policies or a periodic job.
@@ -245,6 +247,14 @@ jobs:
             -t ${{ matrix.component.image }}:stage \
             ${{ matrix.component.image }}:${{ github.sha }}-amd64 \
             ${{ matrix.component.image }}:${{ github.sha }}-arm64
+
+      - name: Create multi-arch manifest for ${{ matrix.component.name }} (pull request)
+        if: github.event_name == 'pull_request'
+        run: |
+          docker buildx imagetools create \
+            -t ${{ matrix.component.image }}:pr-${{ github.event.pull_request.number }} \
+            ${{ matrix.component.image }}:pr-${{ github.event.pull_request.number }}-amd64 \
+            ${{ matrix.component.image }}:pr-${{ github.event.pull_request.number }}-arm64
 
   update-rbac-and-crd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Enable `push: true` for PR builds so component images are pushed to Quay with `pr-{number}` tags
- Create multi-arch manifests for PR images (`pr-{number}`) alongside the existing `latest`/`stage`/`{sha}` tags for main
- No changes to deploy jobs — PRs are still not deployed

## Test plan
- [ ] Open a PR that touches a component (e.g. frontend) and verify the image is pushed to Quay as `pr-{number}`
- [ ] Verify main branch builds still tag `latest`, `stage`, and `{sha}` as before
- [ ] Verify deploy jobs do not run for PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)