### PR TITLE
chore(ci): sync alpha branch from main on every push

### DIFF
--- a/.github/workflows/sync-alpha-from-main.yml
+++ b/.github/workflows/sync-alpha-from-main.yml
@@ -99,19 +99,25 @@ jobs:
             git rebase --abort 2>/dev/null || true
 
             echo "Rebase had conflicts — falling back to merge"
-            git merge --no-ff --allow-unrelated-histories origin/main \
-              -m "chore: merge main into alpha (conflict resolution required)
+            MERGE_MSG=$(cat <<'MSG'
+chore: merge main into alpha (conflict resolution required)
 
 Automated merge of origin/main into origin/alpha.
 Rebase encountered conflicts; falling back to merge.
-A human must resolve conflict markers before merging this PR." || {
+A human must resolve conflict markers before merging this PR.
+MSG
+)
+            git merge --no-ff --allow-unrelated-histories origin/main -m "${MERGE_MSG}" || {
               git add -A
-              git commit --no-verify \
-                -m "chore: best-effort merge main into alpha (conflicts present)
+              CONFLICT_MSG=$(cat <<'MSG'
+chore: best-effort merge main into alpha (conflicts present)
 
 Automated merge of origin/main into origin/alpha.
 Both rebase and merge encountered conflicts. Conflict markers
-are present and must be resolved before this PR can be merged."
+are present and must be resolved before this PR can be merged.
+MSG
+)
+              git commit --no-verify -m "${CONFLICT_MSG}"
             }
           }
 

--- a/scripts/rebase-main-to-alpha.sh
+++ b/scripts/rebase-main-to-alpha.sh
@@ -58,7 +58,7 @@ git checkout -b "${WORK_BRANCH}" "${UPSTREAM}/${ALPHA_BRANCH}"
 # Attempt rebase of main onto the work branch (best-effort)
 log "Rebasing ${UPSTREAM}/${MAIN_BRANCH} onto ${WORK_BRANCH} (best-effort)..."
 REBASE_EXIT=0
-git rebase "${UPSTREAM}/${MAIN_BRANCH}" --onto "${WORK_BRANCH}" "${MERGE_BASE}" || REBASE_EXIT=$?
+git rebase --onto "${WORK_BRANCH}" "${MERGE_BASE}" "${UPSTREAM}/${MAIN_BRANCH}" || REBASE_EXIT=$?
 
 if [ "${REBASE_EXIT}" -ne 0 ]; then
   log "Rebase encountered conflicts. Collecting conflict state..."


### PR DESCRIPTION
## Summary

- Adds `scripts/rebase-main-to-alpha.sh` — manual best-effort rebase script
- Adds `.github/workflows/sync-alpha-from-main.yml` — automated trigger on every push to `main`

On each `main` push the workflow:
1. Checks if `alpha` is already up to date (exits early if so)
2. Skips if an open sync PR already exists
3. Creates a timestamped branch off `alpha`, attempts rebase, falls back to merge on conflict
4. Opens a PR against `alpha` for human review and conflict resolution

## Test plan

- [ ] Verify workflow triggers on next push to `main`
- [ ] Verify PR is opened against `alpha`
- [ ] Verify early-exit when alpha is already up to date
- [ ] Verify deduplication — no second PR opened if one already exists

🤖 Generated with [Claude Code](https://claude.ai/code)