### PR TITLE
fix(build): add build-control-plane to build-all RHOAIENG-55811

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ help: ## Display this help message
 
 ##@ Building
 
-build-all: build-frontend build-backend build-operator build-runner build-state-sync build-public-api build-api-server build-mcp ## Build all container images
+build-all: build-frontend build-backend build-operator build-runner build-state-sync build-public-api build-api-server build-control-plane build-mcp ## Build all container images
 
 build-frontend: ## Build frontend image
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Building frontend with $(CONTAINER_ENGINE)..."


### PR DESCRIPTION
## Summary

- `build-control-plane` was defined in the Makefile but missing from the `build-all` target, causing it to be silently skipped during full builds and CI runs
- Adds `build-control-plane` to the `build-all` dependency chain alongside `build-mcp`

## Jira

RHOAIENG-55811

## Test plan

- [ ] `make build-all` completes and includes the control-plane image