### PR TITLE
fix: disable MinIO bucket versioning to prevent unbounded storage growth

### DIFF
--- a/scripts/setup-minio.sh
+++ b/scripts/setup-minio.sh
@@ -59,9 +59,11 @@ fi
 echo "Setting bucket policy..."
 kubectl exec -n "${NAMESPACE}" "${MINIO_POD}" -- mc anonymous set none "local/${BUCKET_NAME}"
 
-# Enable versioning (optional - helps with recovery)
-echo "Enabling versioning..."
-kubectl exec -n "${NAMESPACE}" "${MINIO_POD}" -- mc version enable "local/${BUCKET_NAME}"
+# Versioning is intentionally disabled — the state-sync sidecar overwrites
+# the same objects every 60s, causing massive version accumulation with no
+# practical recovery benefit. Suspend versioning to prevent unbounded growth.
+echo "Suspending versioning..."
+kubectl exec -n "${NAMESPACE}" "${MINIO_POD}" -- mc version suspend "local/${BUCKET_NAME}"
 
 # Show bucket info
 echo ""


### PR DESCRIPTION
## Summary
- Switches MinIO bucket setup from `version enable` to `version suspend` in `scripts/setup-minio.sh`
- The state-sync sidecar overwrites the same objects every 60s, and with versioning enabled every overwrite created a new non-current version that was never cleaned up
- On vteam-uat this accumulated **12.6M versions** consuming **~484 GiB** on a bucket with only 52 GiB of current data (313K objects)

## What was done on vteam-uat
1. Suspended versioning on the `ambient-sessions` bucket
2. Purging all non-current versions (in progress — 12.6M versions to delete)

## Test plan
- [ ] Verify `scripts/setup-minio.sh` runs cleanly on a fresh MinIO instance
- [ ] Confirm sessions still sync/resume correctly without versioning
- [ ] Monitor MinIO disk usage to confirm it stabilizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)