### PR TITLE
feat: allow live model switching on running agentic sessions (RHOAIENG-56044)

### DIFF
--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -1215,16 +1215,56 @@ func UpdateSession(c *gin.Context) {
 		return
 	}
 
-	// Prevent spec changes while session is running or being created
+	// Prevent most spec changes while session is running or being created
+	// Exception: llmSettings.model can be updated live (takes effect on next run)
 	if status, ok := item.Object["status"].(map[string]interface{}); ok {
 		if phase, ok := status["phase"].(string); ok {
 			if strings.EqualFold(phase, "Running") || strings.EqualFold(phase, "Creating") {
-				c.JSON(http.StatusConflict, gin.H{
-					"error": "Cannot modify session specification while the session is running",
-					"phase": phase,
-				})
-				return
+				// Check if request is ONLY updating llmSettings (live model switching)
+				isOnlyModelUpdate := req.LLMSettings != nil &&
+					req.InitialPrompt == nil &&
+					req.DisplayName == nil &&
+					req.Timeout == nil
+
+				if !isOnlyModelUpdate {
+					c.JSON(http.StatusConflict, gin.H{
+						"error": "Cannot modify session specification while the session is running (except llmSettings)",
+						"phase": phase,
+					})
+					return
+				}
+				log.Printf("Live model update on Running session %s: %+v", sessionName, req.LLMSettings)
 			}
+		}
+	}
+
+	// Validate model if being updated
+	if req.LLMSettings != nil && req.LLMSettings.Model != "" {
+		// Get runner type from existing session spec to determine provider
+		spec := item.Object["spec"].(map[string]interface{})
+		runnerTypeID := DefaultRunnerType // default
+		if envVars, ok := spec["environmentVariables"].(map[string]interface{}); ok {
+			if rt, ok := envVars["RUNNER_TYPE"].(string); ok && rt != "" {
+				runnerTypeID = rt
+			}
+		}
+
+		// Resolve provider for validation
+		runnerProvider := ""
+		if rt, rtErr := GetRuntime(runnerTypeID); rtErr == nil {
+			runnerProvider = rt.Provider
+		} else {
+			log.Printf("WARNING: could not resolve runner type %q from registry: %v", runnerTypeID, rtErr)
+		}
+
+		// Validate model is available for this runner's provider
+		k8sClt, _ := GetK8sClientsForRequest(c)
+		if !isModelAvailable(c.Request.Context(), k8sClt, req.LLMSettings.Model, runnerProvider, project) {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Model is not available for this runner type",
+				"model": req.LLMSettings.Model,
+			})
+			return
 		}
 	}
 

--- a/components/backend/websocket/agui_proxy.go
+++ b/components/backend/websocket/agui_proxy.go
@@ -367,8 +367,12 @@ func HandleAGUIRunProxy(c *gin.Context) {
 		log.Printf("Run with per-user credentials for %s/%s", projectName, sessionName)
 	}
 
+	// Fetch current model from session spec for live model switching
+	currentModel := getCurrentModel(projectName, sessionName)
+	currentModelVertexID := getCurrentModelVertexID(projectName, sessionName, currentModel)
+
 	// Start background goroutine to proxy runner SSE → persist + broadcast
-	go proxyRunnerStream(runnerURL, bodyBytes, sessionName, runID, threadID, currentUserID, currentUserName, callerToken)
+	go proxyRunnerStream(runnerURL, bodyBytes, sessionName, runID, threadID, currentUserID, currentUserName, callerToken, currentModel, currentModelVertexID)
 
 	// Return metadata immediately — events arrive via GET /agui/events
 	c.JSON(http.StatusOK, gin.H{
@@ -382,13 +386,14 @@ func HandleAGUIRunProxy(c *gin.Context) {
 // a background goroutine so the POST /agui/run handler can return immediately.
 // If userID is provided, forwards user context headers for credential scoping.
 // callerToken is the original user's bearer token for per-user credential requests.
-func proxyRunnerStream(runnerURL string, bodyBytes []byte, sessionName, runID, threadID, userID, userName, callerToken string) {
+// currentModel and currentModelVertexID are forwarded to enable live model switching.
+func proxyRunnerStream(runnerURL string, bodyBytes []byte, sessionName, runID, threadID, userID, userName, callerToken, currentModel, currentModelVertexID string) {
 	logSuffix := ""
 	if userID != "" {
 		logSuffix = fmt.Sprintf(" (user=%s)", userID)
 	}
 	log.Printf("AGUI Proxy: connecting to runner at %s%s", runnerURL, logSuffix)
-	resp, err := connectToRunner(runnerURL, bodyBytes, userID, userName, callerToken)
+	resp, err := connectToRunner(runnerURL, bodyBytes, userID, userName, callerToken, currentModel, currentModelVertexID)
 	if err != nil {
 		log.Printf("AGUI Proxy: runner unavailable for %s: %v", sessionName, err)
 		// Publish error events so GET /agui/events subscribers see the failure
@@ -784,7 +789,7 @@ var runnerHTTPClient = &http.Client{
 // container startup time and K8s Service DNS propagation. Retries on
 // "connection refused", "no such host", and "dial tcp" errors with
 // exponential backoff (500ms initial, 1.5x, capped at 5s, 15 attempts).
-func connectToRunner(runnerURL string, bodyBytes []byte, userID, userName, callerToken string) (*http.Response, error) {
+func connectToRunner(runnerURL string, bodyBytes []byte, userID, userName, callerToken, currentModel, currentModelVertexID string) (*http.Response, error) {
 	maxAttempts := 15
 	retryDelay := 500 * time.Millisecond
 	maxDelay := 5 * time.Second
@@ -808,6 +813,13 @@ func connectToRunner(runnerURL string, bodyBytes []byte, userID, userName, calle
 		// for credential requests with the user's own identity.
 		if callerToken != "" {
 			req.Header.Set("X-Caller-Token", callerToken)
+		}
+		// Forward current model for live model switching
+		if currentModel != "" {
+			req.Header.Set("X-Current-Model", currentModel)
+		}
+		if currentModelVertexID != "" {
+			req.Header.Set("X-Current-Model-Vertex-ID", currentModelVertexID)
 		}
 
 		resp, err := runnerHTTPClient.Do(req)
@@ -1289,4 +1301,53 @@ func HandleTaskList(c *gin.Context) {
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	c.Data(resp.StatusCode, resp.Header.Get("Content-Type"), body)
+}
+
+// ─── Live Model Switching Helpers ────────────────────────────────────
+
+// getCurrentModel fetches the current model from the session spec.
+// Returns empty string if unable to read (runner will fall back to env var).
+func getCurrentModel(projectName, sessionName string) string {
+	if handlers.DynamicClient == nil {
+		return ""
+	}
+
+	gvr := handlers.GetAgenticSessionV1Alpha1Resource()
+	obj, err := handlers.DynamicClient.Resource(gvr).Namespace(projectName).Get(
+		context.Background(), sessionName, metav1.GetOptions{},
+	)
+	if err != nil {
+		return ""
+	}
+
+	model, _, _ := unstructured.NestedString(obj.Object, "spec", "llmSettings", "model")
+	return model
+}
+
+// getCurrentModelVertexID resolves the Vertex AI model ID for the given model.
+// Returns empty string if Vertex ID mapping is not needed or unavailable.
+func getCurrentModelVertexID(projectName, sessionName, model string) string {
+	if model == "" {
+		return ""
+	}
+
+	// Load model manifest from ConfigMap mount
+	manifestPath := handlers.ManifestPath()
+	manifest, err := handlers.LoadManifest(manifestPath)
+	if err != nil {
+		log.Printf("WARNING: failed to load model manifest for Vertex ID resolution: %v", err)
+		return ""
+	}
+
+	// Find model entry and extract Vertex ID
+	for _, entry := range manifest.Models {
+		if entry.ID == model && entry.Available {
+			if entry.VertexID != "" {
+				log.Printf("Resolved Vertex ID for model %q: %s", model, entry.VertexID)
+			}
+			return entry.VertexID
+		}
+	}
+
+	return ""
 }

--- a/components/frontend/src/services/api/sessions.ts
+++ b/components/frontend/src/services/api/sessions.ts
@@ -12,6 +12,7 @@ import type {
   ListAgenticSessionsPaginatedResponse,
   StopAgenticSessionRequest,
   StopAgenticSessionResponse,
+  UpdateAgenticSessionRequest,
   CloneAgenticSessionRequest,
   CloneAgenticSessionResponse,
   PaginationParams,
@@ -186,6 +187,20 @@ export async function getSessionPodEvents(
   sessionName: string
 ): Promise<PodEventsResponse> {
   return apiClient.get(`/projects/${projectName}/agentic-sessions/${sessionName}/pod-events`);
+}
+
+/**
+ * Update session spec (supports live model switching)
+ */
+export async function updateSession(
+  projectName: string,
+  sessionName: string,
+  updates: UpdateAgenticSessionRequest
+): Promise<AgenticSession> {
+  return apiClient.put<AgenticSession, UpdateAgenticSessionRequest>(
+    `/projects/${projectName}/agentic-sessions/${sessionName}`,
+    updates
+  );
 }
 
 /**

--- a/components/frontend/src/types/api/sessions.ts
+++ b/components/frontend/src/types/api/sessions.ts
@@ -180,6 +180,13 @@ export type StopAgenticSessionResponse = {
   message: string;
 };
 
+export type UpdateAgenticSessionRequest = {
+  llmSettings?: Partial<LLMSettings>;
+  displayName?: string;
+  initialPrompt?: string;
+  timeout?: number;
+};
+
 export type CloneAgenticSessionRequest = {
   targetProject: string;
   newSessionName: string;

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
@@ -140,11 +140,28 @@ class ClaudeBridge(PlatformBridge):
         current_user_id: str = "",
         current_user_name: str = "",
         caller_token: str = "",
+        current_model: str = "",
+        current_model_vertex_id: str = "",
     ) -> AsyncIterator[BaseEvent]:
-        """Full run lifecycle: initialize → session worker → tracing."""
+        """Full run lifecycle: initialize → session worker → tracing.
+
+        Live model switching: current_model and current_model_vertex_id from
+        the backend override the env var model for this run.
+        """
         thread_id = input_data.thread_id or (self._context.session_id if self._context else "")
 
         await self._initialize_run(thread_id, current_user_id, current_user_name, caller_token)
+
+        # Live model switching: inject current model into forwarded_props
+        if current_model:
+            if input_data.forwarded_props is None:
+                input_data.forwarded_props = {}
+            input_data.forwarded_props["model"] = current_model
+            logger.info(f"Live model switch: using {current_model}")
+            # Update env var for Vertex AI mapping (used by setup_sdk_authentication)
+            if current_model_vertex_id:
+                os.environ["LLM_MODEL_VERTEX_ID"] = current_model_vertex_id
+                logger.info(f"Vertex ID set: {current_model_vertex_id}")
 
         from ag_ui_claude_sdk.utils import process_messages
 

--- a/components/runners/ambient-runner/ambient_runner/endpoints/run.py
+++ b/components/runners/ambient-runner/ambient_runner/endpoints/run.py
@@ -68,6 +68,9 @@ async def run_agent(input_data: RunnerInput, request: Request):
     # The caller's bearer token — used for credential requests so each user
     # can only access their own credentials (no BOT_TOKEN impersonation).
     caller_token = request.headers.get("x-caller-token", "")
+    # Extract current model for live model switching
+    current_model = request.headers.get("x-current-model", "")
+    current_model_vertex_id = request.headers.get("x-current-model-vertex-id", "")
     if current_user_id:
         from ambient_runner.platform.auth import sanitize_user_context
 
@@ -75,6 +78,8 @@ async def run_agent(input_data: RunnerInput, request: Request):
             current_user_id, current_user_name
         )
         logger.info(f"Run user context: {current_user_id}")
+    if current_model:
+        logger.info(f"Run with live model: {current_model}")
 
     logger.info(
         f"Run: thread_id={run_agent_input.thread_id}, run_id={run_agent_input.run_id}"
@@ -87,6 +92,8 @@ async def run_agent(input_data: RunnerInput, request: Request):
                 current_user_id=current_user_id,
                 current_user_name=current_user_name,
                 caller_token=caller_token,
+                current_model=current_model,
+                current_model_vertex_id=current_model_vertex_id,
             ):
                 try:
                     yield encoder.encode(event)


### PR DESCRIPTION
# Allow Live Model Switching on Running Agentic Sessions

**JIRA:** RHOAIENG-56044
**GitHub Issue:** #1090

## Summary

Enables users to change the LLM model on running agentic sessions without stopping and restarting them. Model changes take effect on the next AG-UI run, preserving conversation history and session state.

## Architecture Overview

### Design Decisions (from user requirements):
- **Apply Timing**: Next run only (no pod restart) - leverages existing `forwarded_props["model"]` mechanism
- **Vertex AI**: Backend resolves Vertex ID from ConfigMap and passes to runner
- **Context Strategy**: No handoff - replay conversation history (optimal for same-family model switches)
- **UI Placement**: API-driven (UI selector deferred to follow-up PR)

### Data Flow

```
User updates model via API
  ↓
Backend validates model (manifest + provider compatibility)
  ↓
Session CR spec.llmSettings.model updated
  ↓
On next /run request:
  Backend reads current model from CR
  Backend resolves Vertex ID (if needed)
  Backend passes X-Current-Model header to runner
  ↓
Runner injects model into forwarded_props
  ↓
Claude SDK uses new model for this run
```

## Changes by Component

### Backend (`components/backend/`)

**handlers/sessions.go:**
- Modified `UpdateSession()` to allow `llmSettings` updates while Running/Creating
- Added model validation using existing `isModelAvailable()` function
- Validates against runner provider to prevent cross-provider mismatches

**websocket/agui_proxy.go:**
- Added `getCurrentModel()` to fetch current model from session CR
- Added `getCurrentModelVertexID()` to resolve Vertex AI model IDs
- Modified `HandleAGUIRunProxy()` to pass model to runner via headers
- Modified `connectToRunner()` to include `X-Current-Model` and `X-Current-Model-Vertex-ID` headers

### Runner (`components/runners/ambient-runner/`)

**ambient_runner/endpoints/run.py:**
- Extract `X-Current-Model` and `X-Current-Model-Vertex-ID` headers
- Pass to `bridge.run()` for per-run model override

**ambient_runner/bridges/claude/bridge.py:**
- Modified `ClaudeBridge.run()` to accept `current_model` and `current_model_vertex_id`
- Inject model into `input_data.forwarded_props["model"]` before SDK invocation
- Set `LLM_MODEL_VERTEX_ID` env var for Vertex AI authentication

### Frontend (`components/frontend/`)

**types/api/sessions.ts:**
- Added `UpdateAgenticSessionRequest` type

**services/api/sessions.ts:**
- Added `updateSession()` function for PATCH endpoint
- Exports `UpdateAgenticSessionRequest` type

## Testing

### Manual Testing Steps

1. Create a running session with model `claude-sonnet-4-5`
2. Update model via API:
   ```bash
   curl -X PUT https://.../api/projects/my-project/agentic-sessions/my-session \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"llmSettings": {"model": "claude-opus-4-6"}}'
   ```
3. Send a new message to the session
4. Verify the next run uses `claude-opus-4-6` (check logs or model badge)

### Validation

- ✅ Backend compiles (`go build ./...`)
- ✅ Model validation rejects unavailable models
- ✅ Model validation rejects cross-provider models (e.g., Gemini model with Claude runner)
- ⏳ Frontend tests (deferred - no UI component added yet)
- ⏳ E2E test (recommended follow-up)

## Limitations & Follow-ups

### Current Limitations

- **No UI model selector**: Users must update via API directly (frontend API is ready)
- **No system message in chat**: Model change not announced in conversation
- **No model history tracking**: Could add `status.modelHistory` for audit trail

### Recommended Follow-ups

1. **UI Implementation** (high priority):
   - Add model selector to session header using existing `RunnerModelSelector` component
   - Display current model badge
   - Add toast notification on model change

2. **Enhanced Context Handoff** (optional):
   - Implement self-summarization strategy for large → small model switches
   - Add mechanical fallback for instant switches

3. **Observability** (nice-to-have):
   - Emit system message event on model change
   - Track model usage per-run in `status.modelHistory`
   - Add model change to session events log

## References

- **JIRA Story**: RHOAIENG-56044
- **GitHub Issue**: #1090 (detailed design discussion)
- **Runner Model Override**: Already supported via `ALLOWED_FORWARDED_PROPS["model"]`
- **Vertex AI Mapping**: Uses existing `models.json` ConfigMap

## How to Test

### Prerequisites
- Running Ambient cluster with session
- Auth token with update permissions

### Test Script

```bash
#!/bin/bash
PROJECT="my-project"
SESSION="my-session"
TOKEN="your-token-here"

# 1. Create session (or use existing)
# 2. Update model
curl -X PUT "https://your-cluster/api/projects/$PROJECT/agentic-sessions/$SESSION" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "llmSettings": {
      "model": "claude-opus-4-6"
    }
  }'

# 3. Verify update
curl "https://your-cluster/api/projects/$PROJECT/agentic-sessions/$SESSION" \
  -H "Authorization: Bearer $TOKEN" | jq '.spec.llmSettings.model'

# 4. Send message and check logs for model usage
```

## Notes

- Model change is **not** retroactive - previous conversation remains in original model's context
- Works best for same-family switches (e.g., Sonnet → Opus)
- For large context → small context switches, consider future self-summarization enhancement
