### PR TITLE
spec: skills and workflows — discovery, installation, and usage

### DIFF
--- a/specs/skills-and-workflows.md
+++ b/specs/skills-and-workflows.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-A workflow is a prompt plus a list of skill sources. Skills are the atomic reusable unit. ACP automates the cloning and wiring; locally, the same manifest format works with a simple skill or script. The manifest format is the contract — ACP and local tooling are just consumers.
+A workflow is a `CLAUDE.md` prompt plus a list of sources in `ambient.json`. Skills are the atomic reusable unit. ACP automates the cloning and wiring. Locally, a `/load-workflow` skill or manual `--add-dir` does the same thing.
 
 ---
 
@@ -20,38 +20,52 @@ Commands (`.claude/commands/{name}.md`) and agents (`.claude/agents/{name}.md`) 
 
 A workflow is two things:
 
-1. **A prompt** — the directive, methodology, persona instructions. What today lives in `CLAUDE.md` + `.ambient/ambient.json` (system prompt, startup prompt, phase descriptions).
-2. **A list of skill sources** — references to skills, commands, and agents from various Git repos or registries. Not embedded copies — references resolved at load time.
+1. **A prompt** — the directive and methodology, written as `CLAUDE.md` in the workflow directory. This is the only prompt mechanism — no separate `systemPrompt` or `startupPrompt` fields.
+2. **A list of sources** — references in `ambient.json` to skills, commands, agents, and plugins from various Git repos. Not embedded copies — references resolved at load time.
 
 A workflow does not contain skills. It references them. The bug-fix workflow becomes:
 
-```yaml
-name: Bug Fix
-description: Systematic bug resolution with phased approach
-prompt: |
-  You are a systematic bug fixer. Follow these phases:
-  1. Use /assess to understand the issue
-  2. Use /reproduce to create a failing test
-  3. Use /diagnose to find the root cause
-  4. Use /fix to implement the minimal fix
-  5. Use /test to verify the fix
-  6. Use /review to self-review before PR
-sources:
-  - url: https://github.com/ambient-code/skills.git
-    path: bugfix/assess
-  - url: https://github.com/ambient-code/skills.git
-    path: bugfix/reproduce
-  - url: https://github.com/ambient-code/skills.git
-    path: bugfix/diagnose
-  - url: https://github.com/ambient-code/skills.git
-    path: bugfix/fix
-  - url: https://github.com/ambient-code/skills.git
-    path: bugfix/test
-  - url: https://github.com/ambient-code/skills.git
-    path: bugfix/review
-  - url: https://github.com/opendatahub-io/ai-helpers.git
-    path: helpers/skills/jira-activity
+**`CLAUDE.md`**:
+```markdown
+You are a systematic bug fixer. Follow these phases:
+1. Use /assess to understand the issue
+2. Use /reproduce to create a failing test
+3. Use /diagnose to find the root cause
+4. Use /fix to implement the minimal fix
+5. Use /test to verify the fix
+6. Use /review to self-review before PR
 ```
+
+**`ambient.json`**:
+```json
+{
+  "name": "Bug Fix",
+  "description": "Systematic bug resolution with phased approach",
+  "sources": [
+    {"url": "https://github.com/ambient-code/skills.git", "branch": "main", "path": "bugfix/assess"},
+    {"url": "https://github.com/ambient-code/skills.git", "path": "bugfix/reproduce"},
+    {"url": "https://github.com/ambient-code/skills.git", "path": "bugfix/diagnose"},
+    {"url": "https://github.com/ambient-code/skills.git", "path": "bugfix/fix"},
+    {"url": "https://github.com/ambient-code/skills.git", "path": "bugfix/test"},
+    {"url": "https://github.com/ambient-code/skills.git", "path": "bugfix/review"},
+    {"url": "https://github.com/opendatahub-io/ai-helpers.git", "path": "helpers/skills/jira-activity"},
+    "https://github.com/my-org/shared-skills/tree/main/code-review"
+  ],
+  "rubric": {
+    "activationPrompt": "After completing the fix, evaluate your work",
+    "criteria": [
+      {"name": "Root cause identified", "weight": 0.3},
+      {"name": "Tests added", "weight": 0.3},
+      {"name": "Minimal change", "weight": 0.2},
+      {"name": "No regressions", "weight": 0.2}
+    ]
+  }
+}
+```
+
+Sources support two formats:
+- **Structured object**: `{"url": "...", "branch": "...", "path": "..."}` — works with any Git host, branch is explicit
+- **Single URL string**: `"https://github.com/org/repo/tree/main/path"` — auto-parsed, convenient for sharing
 
 Skills are the reusable atoms. Workflows are recipes. The same skill can appear in multiple workflows.
 
@@ -60,24 +74,12 @@ Skills are the reusable atoms. Workflows are recipes. The same skill can appear 
 A persona — prose defining what an agent is responsible for. "Backend Agent", "Security Agent", "PM Agent". An Agent uses workflows and standalone skills to accomplish its goals. An Agent is a session template with a personality:
 
 ```
-Agent = Persona (prompt/directive) + Workflows (skill bundles) + Standalone skills
+Agent = Persona (CLAUDE.md) + Workflows (skill bundles) + Standalone skills
 ```
 
 A "Bug Fix Agent" = bug-fix persona + bug-fix workflow skills + any additional skills. Same skills reusable by different Agents with different motivations.
 
-### Manifest Format
-
-The workflow manifest (`workflow.yaml` or `ambient.json`) is the core deliverable. It defines prompt + skill sources. Multiple consumers read the same format:
-
-- **ACP runner**: clones sources, adds to `add_dirs`, injects prompt
-- **Local script/skill**: clones sources to temp dirs, passes as `--add-dir`
-- **Claude Code plugin**: `SessionStart` hook reads manifest, sets up environment
-
-The format must support:
-- Prompt text (inline or file reference)
-- Skill sources (Git URL + branch + path)
-- Optional: system prompt, startup prompt, rubric
-- Optional: environment variables, MCP server configs
+Multi-agent orchestration (research agent → writer agent → editor agent pipelines) is a separate design problem out of scope for this spec.
 
 ---
 
@@ -87,19 +89,23 @@ The format must support:
 
 A way to browse and find skills, workflows, and plugins from curated sources.
 
+### Source Types
+
+The scanner must support three types of sources:
+
+1. **Claude Code plugins** — directories with `.claude-plugin/plugin.json` containing `skills/`, `commands/`, `agents/`, `hooks/`, `.mcp.json`. This is the primary format to follow and expect. Skills are namespaced as `plugin-name:skill-name`.
+
+2. **Claude Code marketplace catalogs** — `marketplace.json` files listing plugins with their sources. Users could add the same marketplace from local Claude Code via `/plugin marketplace add`.
+
+3. **Standalone repos with `.claude/`** — any Git repo containing `.claude/skills/`, `.claude/commands/`, `.claude/agents/`. Also supports root-level `skills/`, `commands/`, `agents/` (registry layout like ai-helpers).
+
 ### How
 
-A cluster-level ConfigMap (`marketplace-sources`) holds available registry sources. Each source is one of:
+A cluster-level ConfigMap (`marketplace-sources`) holds available registry sources. The Marketplace page in the ACP UI shows:
 
-- A Git repo with a `data.json` catalog (like ai-helpers at `https://opendatahub-io.github.io/ai-helpers/data.json`)
-- A Claude Code `marketplace.json` (native plugin marketplace format)
-- A direct Git repo with skills/commands/agents in `.claude/` or at root level
-
-The Marketplace page in the ACP UI shows:
-
-- Browsable catalogs from each source with search and type filters (skill / command / agent / workflow)
+- Browsable catalogs from each source with search and type filters
 - Compact card tiles with name, description, type badge
-- Detail panel on click with full description, source repo link, allowed tools
+- Detail panel on click with full description, source repo link
 - "Import Custom" to scan any Git URL and discover items
 - Direct one-click install to workspace
 
@@ -109,16 +115,17 @@ When given a Git URL (from marketplace or custom), the backend:
 
 1. Shallow clones the repo
 2. Applies optional path filter (subdirectory)
-3. Scans for items in both patterns:
+3. Checks for `.claude-plugin/plugin.json` (Claude Code plugin format)
+4. Scans for items in both patterns:
    - `.claude/skills/*/SKILL.md`, `.claude/commands/*.md`, `.claude/agents/*.md`
-   - `skills/*/SKILL.md`, `commands/*.md`, `agents/*.md` (registry layout like ai-helpers)
-4. Checks for `.ambient/ambient.json` (indicates this is a workflow)
-5. Checks for `CLAUDE.md` (indicates project instructions)
-6. Returns discovered items with frontmatter metadata
+   - `skills/*/SKILL.md`, `commands/*.md`, `agents/*.md` (registry layout)
+5. Checks for `.ambient/ambient.json` (indicates this is a workflow)
+6. Checks for `CLAUDE.md` (indicates project instructions)
+7. Returns discovered items with frontmatter metadata
 
-### Alignment with Claude Code
+### Format Alignment
 
-Adopting Claude Code's `marketplace.json` format where possible makes ACP skills portable. Users could add the same marketplace from local Claude Code via `/plugin marketplace add`. The catalog format should normalize to the same shape regardless of source type.
+We follow Claude Code's plugin and skill formats as the standard. The [Agent Skills](https://agentskills.io) open standard that Claude Code implements is the closest cross-tool specification. Our catalog format normalizes to the same shape regardless of source type.
 
 ---
 
@@ -128,7 +135,7 @@ Adopting Claude Code's `marketplace.json` format where possible makes ACP skills
 
 Items installed at the workspace level are stored in the ProjectSettings CR (`spec.installedItems`). These represent the workspace's **library** — what's available, not what's auto-loaded into every session.
 
-When creating a session, users select which installed items to include. The workflow they choose may also pull in its own skill dependencies from the manifest.
+When creating a session, users select which installed items to include. The workflow they choose pulls in its own skill dependencies from the `sources` array in `ambient.json`.
 
 ### Session Level
 
@@ -146,21 +153,22 @@ A UI for composing workflows from standalone skills:
 
 - Select skills from the workspace library or browse marketplace
 - Each skill is a reference (source URL + path), not a copy
-- Define the workflow prompt (methodology, phases, instructions)
-- Optionally configure: system prompt, startup prompt, rubric
-- Save as a workflow manifest that can be:
+- Write the workflow prompt as `CLAUDE.md`
+- Configure metadata in `ambient.json` (name, description, rubric)
+- The `sources` array is built from selected skills
+- Save as a workflow that can be:
   - Stored in the workspace
   - Exported as a Git repo
-  - Exported as a Claude Code plugin (`plugin.json`)
+  - Exported as a Claude Code plugin
 
-The key constraint: skills are never copied into the workflow. The manifest holds references. At load time, the runner resolves dependencies and clones each source.
+The key constraint: skills are never copied into the workflow. The `ambient.json` holds source references. At load time, the runner resolves dependencies and clones each source.
 
 ### How Selection Works
 
 The workspace library is not auto-injected. Selection happens at session creation:
 
 1. User picks a workflow (or "General chat" for none)
-2. The workflow manifest declares its skill dependencies — those are auto-loaded
+2. The workflow's `ambient.json` `sources` array declares dependencies — those are auto-loaded
 3. User can optionally add standalone skills from the workspace library
 4. The session CRD stores the workflow reference + any additional skill sources
 
@@ -178,13 +186,17 @@ This means:
 
 When a session starts, sources are loaded in layers:
 
-1. **Workflow sources** — skills referenced in the workflow manifest, cloned and added to `add_dirs`
+1. **Workflow sources** — skills from the workflow's `ambient.json` `sources` array, cloned and added to `add_dirs`
 2. **Additional standalone sources** — extra skills the user selected at session creation
 3. **Live additions** — skills imported during the session via the context panel
 
 All layers produce directories with `.claude/skills/`, `.claude/commands/`, `.claude/agents/` structure. Each directory is passed to the Claude Agent SDK as an `--add-dir`. Claude Code handles discovery from there.
 
-The `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` env var is set so that `CLAUDE.md` files from add-dirs are also loaded (workflow instructions, skill documentation).
+The `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` env var is set so that `CLAUDE.md` files from add-dirs are also loaded.
+
+### Authentication for Sources
+
+Private repos and authenticated services (MCP servers) use the existing workspace credential system. If the workspace has GitHub/GitLab integrations configured, private source repos are cloned using those credentials via the git credential helper. MCP sources that require auth and TLS are handled through workspace integration configuration. No new auth fields in the manifest.
 
 ### Runtime Management
 
@@ -210,9 +222,7 @@ The frontend uses this to populate the Skills toolbar button and `/` autocomplet
 
 ## Local Usage (outside ACP)
 
-The same workflow manifest works locally. Two approaches:
-
-### 1. Manual (no tooling)
+### 1. Manual
 
 ```bash
 git clone --depth 1 https://github.com/ambient-code/skills.git /tmp/skills
@@ -225,7 +235,7 @@ claude \
 
 ### 2. Load-workflow skill
 
-A meta-skill that reads a workflow manifest and sets up the environment:
+A meta-skill that reads a workflow's `ambient.json`, clones each source, and passes them as `--add-dir`:
 
 ```
 ~/.claude/skills/load-workflow/SKILL.md
@@ -237,97 +247,23 @@ Usage:
 ```
 
 The skill instructs Claude to:
-1. Fetch the workflow manifest
-2. Clone each skill source to temp directories
-3. Symlink `.claude/skills/` structures into the project
-4. Apply the workflow prompt
+1. Fetch the workflow's `ambient.json`
+2. Clone each source to temp directories
+3. Symlink `.claude/` structures into the project
+4. The workflow's `CLAUDE.md` is loaded automatically
 
-This makes ACP workflows portable — anyone with Claude Code can use them without ACP. The skill ships as part of ai-helpers or as its own standalone skill.
-
-### 3. Claude Code plugin (future)
-
-A plugin with a `SessionStart` hook that reads workflow manifests:
-
-```json
-{
-  "name": "ambient-workflows",
-  "hooks": {
-    "SessionStart": [{
-      "type": "command",
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/load-workflow.sh"
-    }]
-  }
-}
-```
-
-The hook script reads a `workflow.yaml` from the project root (if present), clones skill sources, and symlinks them into place. Fully automated, no user action needed.
-
----
-
-## Manifest Format (proposed)
-
-```yaml
-# workflow.yaml or ambient.json
-name: Bug Fix
-description: Systematic bug resolution with phased approach
-
-# The prompt/instructions — can be inline or reference a file
-prompt: |
-  You are a systematic bug fixer...
-
-# Optional: injected as system prompt (short, persona-level)
-systemPrompt: You are an expert software engineer focused on fixing bugs systematically.
-
-# Optional: sent as first message when session starts
-startupPrompt: |
-  Welcome! I'm ready to help you fix a bug.
-  Use /assess to get started, or describe the issue directly.
-
-# Skill sources — cloned and added to add_dirs
-sources:
-  - url: https://github.com/ambient-code/skills.git
-    branch: main
-    path: bugfix/assess
-  - url: https://github.com/ambient-code/skills.git
-    path: bugfix/reproduce
-  - url: https://github.com/opendatahub-io/ai-helpers.git
-    path: helpers/skills/jira-activity
-  - url: https://github.com/my-org/internal-skills.git
-    branch: v2
-    path: code-review
-
-# Optional: quality evaluation criteria
-rubric:
-  activationPrompt: After completing the fix, evaluate your work
-  criteria:
-    - name: Root cause identified
-      weight: 0.3
-    - name: Minimal change
-      weight: 0.2
-    - name: Tests added
-      weight: 0.3
-    - name: No regressions
-      weight: 0.2
-```
-
-This format is consumed by:
-- ACP runner (production)
-- `/load-workflow` skill (local)
-- Claude Code plugin hook (automated local)
-- Workflow builder UI (creation/editing)
+This makes ACP workflows portable — anyone with Claude Code can use them without ACP.
 
 ---
 
 ## Open Questions
 
-1. **Manifest format**: YAML vs JSON? Should we extend `ambient.json` or create a new `workflow.yaml`? The existing `ambient.json` has `name`, `description`, `systemPrompt`, `startupPrompt`, `rubric` — we'd add `sources` and `prompt`.
+1. **Skill versioning**: Sources reference branches today. Should we support tags or SHAs for pinning? What happens when a skill source updates — do sessions get the latest on next start?
 
-2. **Skill versioning**: Sources reference branches today. Should we support tags or SHAs for pinning? What happens when a skill source updates — do sessions get the latest on next start?
+2. **Plugin format**: Should workflow export produce a Claude Code plugin (`plugin.json`)? Pros: portable, namespaced, versioned. Cons: plugins cache/copy files which breaks the dynamic reference model.
 
-3. **Plugin format**: Should workflow export produce a Claude Code plugin (`plugin.json`)? Pros: portable, namespaced, versioned. Cons: plugins cache/copy files which breaks the dynamic reference model.
+3. **RHAI alignment**: How does this map to RHAIRFE-1370 (Skills Registry)? Our `sources` format and marketplace could inform the product's in-cluster registry design.
 
-4. **RHAI alignment**: How does this map to RHAIRFE-1370 (Skills Registry)? Our manifest format and marketplace could inform the product's in-cluster registry design.
+4. **Security**: How do we verify skill sources haven't been tampered with? Git commit SHAs provide content-addressable verification. Enterprise customers may need signed manifests.
 
-5. **Security**: How do we verify skill sources haven't been tampered with? Git commit SHAs provide content-addressable verification. Enterprise customers may need signed manifests.
-
-6. **Workspace defaults**: Should some workspace-level items be "always-on" (loaded in every session regardless of workflow)? Example: company-wide coding standards skill. Or should this be handled via org-level Claude Code managed settings?
+5. **Workspace defaults**: Should some workspace-level items be "always-on" (loaded in every session regardless of workflow)? Or should this be handled via org-level Claude Code managed settings?


### PR DESCRIPTION
## Summary

Defines the architecture for how skills, workflows, and agents work in ACP.

**Core insight**: A workflow is just a prompt + a list of skill source references. Skills are the atomic reusable unit. The manifest format is the contract — ACP and local tooling are just consumers.

## Key Decisions

- **Workflows don't contain skills** — they reference them by Git URL + path
- **Skills are always fetched from canonical sources** at load time, not embedded copies
- **Workspace library != auto-inject** — installing to workspace makes items available, not active. Users select what loads per session.
- **Same manifest works everywhere** — ACP runner, local `--add-dir`, a `/load-workflow` meta-skill, or a Claude Code plugin
- **Layered loading** — workflow dependencies + user-selected extras + live imports, all fed into `add_dirs`

## Sections

1. **Core Concepts** — Skill, Workflow, Agent, Manifest Format
2. **Discovery** — Marketplace, scanning, catalog format
3. **Installation & Configuration** — Workspace level, session level, workflow builder, selection model
4. **Usage in Sessions** — Loading order, runtime management, metadata
5. **Local Usage** — Manual, load-workflow skill, Claude Code plugin
6. **Manifest Format** — Proposed YAML schema
7. **Open Questions** — Format, versioning, plugin compat, RHAI alignment, security

## For Review

Looking for feedback on:
- The manifest format (extend ambient.json vs new workflow.yaml?)
- The selection model (workspace library vs auto-inject)
- The Agent concept (persona + workflows + skills)
- RHAI alignment (RHAIRFE-1370)