### PR TITLE
fix(backend): use Secret-based token for non-expiring access keys

### DIFF
--- a/components/backend/handlers/permissions.go
+++ b/components/backend/handlers/permissions.go
@@ -434,10 +434,18 @@ func CreateProjectKey(c *gin.Context) {
 		return
 	}
 
-	// Issue a one-time JWT token for this ServiceAccount (no audience; used as API key)
-	tokenSpec := authnv1.TokenRequestSpec{}
-	if req.ExpirationSeconds != nil && *req.ExpirationSeconds > 0 {
-		tokenSpec.ExpirationSeconds = req.ExpirationSeconds
+	// Issue a token for this ServiceAccount via the TokenRequest API.
+	// When no expiration is requested, use a 10-year lifetime instead of
+	// omitting ExpirationSeconds (which defaults to 1h). We avoid creating
+	// a kubernetes.io/service-account-token Secret because it persists the
+	// token in the cluster where any principal with Secrets access can read it.
+	var nonExpiringSeconds int64 = 315360000 // 10 years
+	expirationSeconds := &nonExpiringSeconds
+	if req.ExpirationSeconds != nil {
+		expirationSeconds = req.ExpirationSeconds
+	}
+	tokenSpec := authnv1.TokenRequestSpec{
+		ExpirationSeconds: expirationSeconds,
 	}
 	tr := &authnv1.TokenRequest{Spec: tokenSpec}
 	tok, err := k8sClient.CoreV1().ServiceAccounts(projectName).CreateToken(context.TODO(), saName, tr, v1.CreateOptions{})


### PR DESCRIPTION
## Summary

- **Bug**: Selecting "No expiration" when creating an access key via the UI produced a token that expired after 1 hour
- **Root cause**: The Kubernetes TokenRequest API defaults to 1h expiration when `ExpirationSeconds` is omitted from the `TokenRequestSpec`
- **Fix**: Always pass an explicit `ExpirationSeconds` to the TokenRequest API — 10 years for "no expiration" keys, user-specified value for timed keys. This avoids the 1h default while keeping the implementation simple (no Secret creation, no polling loop, no orphaned-resource risk)

## What changed

`components/backend/handlers/permissions.go` — `CreateProjectKey` function:

- Removed the empty `TokenRequestSpec{}` that relied on the K8s default (1h)
- Added an explicit `ExpirationSeconds` of 315360000 (10 years) when the user selects "No expiration"
- Single TokenRequest code path for both timed and non-expiring keys

## Test plan

- [x] `go vet ./...` — clean
- [x] `gofmt` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all passing (pre-existing `TestGetRunnerTypes_ReturnsProvider` failure is unrelated)
- [x] `npm run build` (frontend) — 0 errors
- [x] Deployed to lab OKD cluster and validated via API:
  - No-expiration token: JWT `exp` set ~10 years in the future
  - Timed token (1 day): JWT `exp` set ~86400s from `iat`
  - Both tokens authenticate successfully against the backend