### PR TITLE
fix: scheduled sessions fail due to Service name exceeding 63-char K8s limit

### DIFF
--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -1392,9 +1392,13 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 
 	// Create session Service pointing to the runner's FastAPI server
 	// Backend proxies both AG-UI and content requests to this service endpoint
+	svcName := fmt.Sprintf("session-%s", name)
+	if len(svcName) > 63 {
+		return fmt.Errorf("session name %q too long: derived Service name %q is %d chars (max 63)", name, svcName, len(svcName))
+	}
 	aguiSvc := &corev1.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      fmt.Sprintf("session-%s", name),
+			Name:      svcName,
 			Namespace: sessionNamespace,
 			Labels: map[string]string{
 				"app":             "ambient-code",
@@ -1422,7 +1426,7 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 	if _, serr := config.K8sClient.CoreV1().Services(sessionNamespace).Create(context.TODO(), aguiSvc, v1.CreateOptions{}); serr != nil && !errors.IsAlreadyExists(serr) {
 		log.Printf("Failed to create AG-UI service for %s: %v", name, serr)
 	} else {
-		log.Printf("Created AG-UI service session-%s for AgenticSession %s", name, name)
+		log.Printf("Created AG-UI service %s for AgenticSession %s", svcName, name)
 	}
 
 	// Pod created — controller-runtime reconciler will handle monitoring

--- a/components/operator/internal/trigger/trigger.go
+++ b/components/operator/internal/trigger/trigger.go
@@ -45,10 +45,14 @@ func RunSessionTrigger() {
 		log.Fatalf("Failed to parse SESSION_TEMPLATE JSON: %v", err)
 	}
 
-	// Build session name and display name
+	// Build session name and display name.
+	// The most restrictive derived K8s resource name is the Service:
+	//   "session-" (8 chars) + sessionName ≤ 63  →  sessionName ≤ 55
+	// sanitizeName caps at 40 chars, so namePrefix + "-" + timestamp (10)
+	// yields at most 51 chars — well within the 55-char budget.
 	now := time.Now()
 	ts := strconv.FormatInt(now.Unix(), 10)
-	namePrefix := scheduledSessionName
+	namePrefix := sanitizeName(scheduledSessionName)
 	if dn, ok := template["displayName"].(string); ok && dn != "" {
 		namePrefix = sanitizeName(dn)
 		// Set display name with human-readable timestamp, e.g. "Daily Jira Summary (Jan 1, 2026 - 00:00:00)"

--- a/components/operator/internal/trigger/trigger_test.go
+++ b/components/operator/internal/trigger/trigger_test.go
@@ -77,6 +77,22 @@ func TestSanitizeName(t *testing.T) {
 	}
 }
 
+func TestSanitizeName_ScheduledSessionUUID(t *testing.T) {
+	// Scheduled session names contain UUIDs (e.g. "schedule-cb9522da-ce4d-4bc8-8cc8-5647407288f5").
+	// Without sanitization, "session-" + name + "-" + timestamp = 64 chars, exceeding
+	// the 63-char K8s Service name limit.  sanitizeName must cap at 40 chars.
+	input := "schedule-cb9522da-ce4d-4bc8-8cc8-5647407288f5"
+	result := sanitizeName(input)
+	if len(result) > 40 {
+		t.Errorf("sanitizeName(%q) length = %d, want <= 40", input, len(result))
+	}
+	// session-{sanitized}-{10-digit-ts} must fit in 63 chars
+	svcName := "session-" + result + "-1775052000"
+	if len(svcName) > 63 {
+		t.Errorf("derived Service name %q length = %d, exceeds 63-char K8s limit", svcName, len(svcName))
+	}
+}
+
 func TestSanitizeName_TruncationPreservesValidSuffix(t *testing.T) {
 	// Verify that truncation to 40 chars does not leave a trailing hyphen
 	input := "abcdefghijklmnopqrstuvwxyz1234567890abcd!"


### PR DESCRIPTION
## Summary

- Scheduled sessions with empty `displayName` used the raw `scheduledSessionName` (including UUID) as the name prefix, producing a K8s Service name of 64 chars — 1 over the 63-char DNS label limit
- The Service creation silently failed, so the backend could never route back to the runner pod, causing "Runner is not available" errors on every run
- Regular sessions (`session-{uuid}` = 44 chars → Service = 52 chars) are unaffected

## Changes

- **Trigger**: Always run `sanitizeName()` on the name prefix (caps at 40 chars), not just when `displayName` is set
- **Operator**: Early-return error if derived Service name exceeds 63 chars, preventing silent failures
- **Test**: Added test verifying UUID-based scheduled session names produce valid Service names

## Test plan

- [x] `go test ./internal/trigger/ -run TestSanitizeName` — all pass
- [x] `go vet ./internal/handlers/` — clean
- [ ] Deploy and verify scheduled sessions with empty displayName create Services successfully
- [ ] Verify existing scheduled sessions with displayName set continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)