### PR TITLE
fix: eliminate broken pipe warnings in benchmark harness

### DIFF
--- a/scripts/benchmarks/component-bench.sh
+++ b/scripts/benchmarks/component-bench.sh
@@ -434,13 +434,15 @@ bench_scenarios_for_mode() {
 
 bench_has_scenario() {
   local wanted=$1
+  local scenarios
+  scenarios=$(bench_scenarios_for_mode)
   local scenario
 
   while IFS= read -r scenario; do
     if [[ "$scenario" == "$wanted" ]]; then
       return 0
     fi
-  done < <(bench_scenarios_for_mode)
+  done <<< "$scenarios"
 
   return 1
 }


### PR DESCRIPTION
## Why

The first CI run of the benchmark harness ([run 23769619685](https://github.com/ambient-code/platform/actions/runs/23769619685)) produced repeated `echo: write error: Broken pipe` warnings on stderr. While harmless, they clutter CI logs and could mask real errors.

## Summary

- `bench_has_scenario` used process substitution (`< <(bench_scenarios_for_mode)`) with an early `return 0` on match. When mode is `both`, the function emits two lines (`cold`, `warm`). If the first line matches, the reader closes the pipe before the second `echo` completes, triggering SIGPIPE.
- Fix: capture the output in a variable first (`scenarios=$(bench_scenarios_for_mode)`), then iterate via here-string (`<<< "$scenarios"`). Both `echo` calls complete before iteration begins.

## Test plan

- [x] `shellcheck` clean (same pre-existing false positives only)
- [x] `bash tests/bench-test.sh` passes 8/8
- [ ] CI run produces no broken pipe warnings


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release includes internal refactoring improvements to development tooling and does not contain any changes visible to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->