### PR TITLE
fix: add OC_USER and OC_EMAIL to dev-env .env.local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,6 +670,8 @@ dev-env: check-kubectl check-local-context ## Generate components/frontend/.env.
 		echo "BACKEND_URL=$$BACKEND_URL"; \
 		echo "ENABLE_OC_WHOAMI=0"; \
 		if [ -n "$$TOKEN" ]; then echo "OC_TOKEN=$$TOKEN"; else echo "OC_TOKEN="; fi; \
+		echo "OC_USER=system:serviceaccount:$(NAMESPACE):test-user"; \
+		echo "OC_EMAIL=test-user@vteam.local"; \
 	} > "$$ENV_FILE.tmp"; \
 	if [ -f "$$ENV_FILE" ] && cmp -s "$$ENV_FILE.tmp" "$$ENV_FILE"; then \
 		rm -f "$$ENV_FILE.tmp"; \


### PR DESCRIPTION
## Summary
- `make dev-env` now includes `OC_USER` and `OC_EMAIL` in the generated `.env.local`
- Fixes 401 errors when creating workspaces from the local frontend dev server (`make dev COMPONENT=frontend`)
- Aligns local dev setup with the kind overlay (`frontend-test-patch.yaml`) which already sets these vars

## Root cause
The frontend proxy (`buildForwardHeaders` in `auth.ts`) uses `OC_USER` to set the `X-Forwarded-User` header. Without it, the backend's `forwardedIdentityMiddleware` cannot populate `userID` in the Gin context, and `CreateProject` fails with "no user subject found in token".

## Test plan
- [ ] Run `make kind-up LOCAL_IMAGES=true`
- [ ] Run `make dev-env` and verify `components/frontend/.env.local` contains `OC_USER` and `OC_EMAIL`
- [ ] Run `make dev COMPONENT=frontend`
- [ ] Create a new workspace from `localhost:3000` — should succeed (previously returned 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)