### PR TITLE
feat: allow runner to use Skill and Agent tools

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
@@ -28,6 +28,8 @@ DEFAULT_ALLOWED_TOOLS = [
     "Edit",
     "MultiEdit",
     "WebSearch",
+    "Skill",
+    "Agent",
 ]
 
 


### PR DESCRIPTION
I have ~30 skills as part of a pipeline, and none of them get invoked using the 'Skill' tool. Instead, the runner agent reads and interprets the skill.md markdown. It's a pretty long pipeline and the context gets to be huge if the session does that. I have been unable to override the platform config with settings.json or other mechanisms and I believe it's a platform change that's needed.

This PR adds Skill and Agent to the default allowed tools list so the runner can invoke skills and dispatch agents directly without needing to read and interpret them manually.

It may have been a deliberate design choice to exclude these, if so I'd like to understand more. Thanks! :)