### PR TITLE
fix: correct backend deployment name in CI workflows

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Pin OPERATOR_IMAGE on backend for scheduled session triggers
         run: |
-          oc set env deployment/agentic-backend -n ambient-code -c agentic-backend \
+          oc set env deployment/backend-api -n ambient-code -c backend-api \
             OPERATOR_IMAGE="quay.io/ambient_code/vteam_operator:${{ github.sha }}"
 
       - name: Update agent registry ConfigMap with pinned image tags
@@ -352,7 +352,7 @@ jobs:
 
       - name: Pin OPERATOR_IMAGE on backend for scheduled session triggers
         run: |
-          oc set env deployment/agentic-backend -n ambient-code -c agentic-backend \
+          oc set env deployment/backend-api -n ambient-code -c backend-api \
             OPERATOR_IMAGE="quay.io/ambient_code/vteam_operator:${{ github.sha }}"
 
       - name: Update agent registry ConfigMap with pinned image tags

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -462,7 +462,7 @@ jobs:
           RELEASE_TAG="${{ needs.release.outputs.new_tag }}"
           BUILT="${{ steps.built.outputs.names }}"
           if echo ",$BUILT," | grep -q ",operator,"; then
-            oc set env deployment/agentic-backend -n ambient-code -c agentic-backend \
+            oc set env deployment/backend-api -n ambient-code -c backend-api \
               OPERATOR_IMAGE="quay.io/ambient_code/vteam_operator:${RELEASE_TAG}"
           fi
 


### PR DESCRIPTION
## Summary
The OPERATOR_IMAGE pinning step used `agentic-backend` but the actual deployment is named `backend-api`. Fixed in all 3 deploy paths (main push, dispatch, release).

## Test plan
- [ ] CI deploy succeeds without "deployment not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration in build and release workflows to target the appropriate service container during environment variable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->