### PR TITLE
fix(manifests): remove hardcoded preprod hostname from mpp-openshift route

### DIFF
--- a/components/manifests/overlays/mpp-openshift/ambient-api-server-route.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-api-server-route.yaml
@@ -7,7 +7,6 @@ metadata:
     component: api
     shard: internal
 spec:
-  host: ambient-api-server-ambient-code--runtime-int.internal-router-shard.mpp-w2-preprod.cfln.p1.openshiftapps.com
   to:
     kind: Service
     name: ambient-api-server


### PR DESCRIPTION
## Summary

- Removes the hardcoded `spec.host` field from `components/manifests/overlays/mpp-openshift/ambient-api-server-route.yaml`
- The hardcoded value (`ambient-api-server-ambient-code--runtime-int.internal-router-shard.mpp-w2-preprod.cfln.p1.openshiftapps.com`) pointed at the preprod cluster ingress, causing the route to advertise the wrong hostname when deployed to other environments (e.g., dev)
- OpenShift's router will now auto-assign the correct hostname based on the cluster's router configuration

## Test plan
- [ ] Verify route hostname auto-assigns correctly after applying to dev cluster
- [ ] Confirm `oc get route ambient-api-server -n ambient-code--ambient-s0` shows the correct dev hostname

Jira: [RHOAIENG-56570](https://redhat.atlassian.net/browse/RHOAIENG-56570)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ambient API server route configuration to use dynamic host assignment instead of a fixed hostname. API functionality and security settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->