### PR TITLE
fix: use root path for runner AG-UI endpoint in trigger

### DIFF
--- a/components/operator/internal/trigger/trigger.go
+++ b/components/operator/internal/trigger/trigger.go
@@ -143,9 +143,9 @@ func tryReuseLastSession(dynamicClient dynamic.Interface, namespace, scheduledSe
 	}
 }
 
-// sendFollowUpPrompt sends a prompt to a running session via the runner's AG-UI /run endpoint.
+// sendFollowUpPrompt sends a prompt to a running session via the runner's AG-UI endpoint.
 func sendFollowUpPrompt(namespace, sessionName, prompt string) error {
-	runnerURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:%d/run", sessionName, namespace, handlers.DefaultRunnerPort)
+	runnerURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:%d/", sessionName, namespace, handlers.DefaultRunnerPort)
 
 	input := map[string]interface{}{
 		"threadId": sessionName,


### PR DESCRIPTION
## Summary
The trigger was posting follow-up prompts to `/run` but the runner's AG-UI endpoint is at `/` (root). This caused 404 errors when trying to reuse a running session.

## Test plan
- [ ] Trigger a scheduled session with reuse enabled while the session is running — verify the follow-up prompt is sent successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal request routing for improved endpoint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->