### PR TITLE
fix: restore OPERATOR_IMAGE valueFrom in backend manifest

### DIFF
--- a/components/manifests/base/core/backend-deployment.yaml
+++ b/components/manifests/base/core/backend-deployment.yaml
@@ -104,7 +104,13 @@ spec:
               name: google-workflow-app-secret
               key: BACKEND_URL
               optional: true
-        # OPERATOR_IMAGE for scheduled session triggers is set by CI via oc set env
+        # Operator image for scheduled session trigger jobs (CI pins via ConfigMap)
+        - name: OPERATOR_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              name: operator-config
+              key: OPERATOR_IMAGE
+              optional: true
         # OOTB Workflows Configuration
         - name: OOTB_WORKFLOWS_REPO
           value: "https://github.com/ambient-code/workflows.git"


### PR DESCRIPTION
## Summary
PR #1159 removed the `OPERATOR_IMAGE` env var from the backend deployment manifest. It should stay — the manifest declares `valueFrom` (ConfigMap ref) and CI writes the SHA tag to the ConfigMap. This keeps the deployment declarative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment configuration to source environment variables from ConfigMap instead of CI-based injection, providing improved flexibility in managing operational settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->