### PR TITLE
fix: route scheduled follow-up prompts through backend AG-UI proxy

### DIFF
--- a/components/manifests/deploy.sh
+++ b/components/manifests/deploy.sh
@@ -356,6 +356,12 @@ fi
 echo -e "${BLUE}Updating operator with custom runner image...${NC}"
 oc patch deployment agentic-operator -n ${NAMESPACE} -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"agentic-operator\",\"env\":[{\"name\":\"AMBIENT_CODE_RUNNER_IMAGE\",\"value\":\"${DEFAULT_RUNNER_IMAGE}\"}]}]}}}}" --type=strategic
 
+# Pin OPERATOR_IMAGE in operator-config so scheduled session triggers use the correct image
+echo -e "${BLUE}Pinning OPERATOR_IMAGE in operator-config configmap...${NC}"
+oc patch configmap operator-config -n ${NAMESPACE} \
+    --type=merge -p "{\"data\":{\"OPERATOR_IMAGE\":\"${DEFAULT_OPERATOR_IMAGE}\"}}" 2>/dev/null || \
+oc create configmap operator-config -n ${NAMESPACE} --from-literal=OPERATOR_IMAGE="${DEFAULT_OPERATOR_IMAGE}" 2>/dev/null || true
+
 # Update agent-registry configmap with custom runner and state-sync images
 echo -e "${BLUE}Updating agent-registry configmap with custom images...${NC}"
 REGISTRY_JSON=$(oc get configmap ambient-agent-registry -n ${NAMESPACE} -o jsonpath='{.data.agent-registry\.json}')

--- a/components/operator/internal/trigger/trigger.go
+++ b/components/operator/internal/trigger/trigger.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 
-	"ambient-code-operator/internal/handlers"
 	"ambient-code-operator/internal/types"
 )
 
@@ -143,9 +142,17 @@ func tryReuseLastSession(dynamicClient dynamic.Interface, namespace, scheduledSe
 	}
 }
 
-// sendFollowUpPrompt sends a prompt to a running session via the runner's AG-UI endpoint.
+// sendFollowUpPrompt sends a prompt to a running session via the backend's AG-UI proxy.
+// This ensures events are persisted and broadcast to the UI.
 func sendFollowUpPrompt(namespace, sessionName, prompt string) error {
-	runnerURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:%d/", sessionName, namespace, handlers.DefaultRunnerPort)
+	backendNS := os.Getenv("BACKEND_NAMESPACE")
+	if backendNS == "" {
+		backendNS = "ambient-code"
+	}
+	backendURL := fmt.Sprintf(
+		"http://backend-service.%s.svc.cluster.local:8080/api/projects/%s/agentic-sessions/%s/agui/run",
+		backendNS, namespace, sessionName,
+	)
 
 	input := map[string]interface{}{
 		"threadId": sessionName,
@@ -164,24 +171,31 @@ func sendFollowUpPrompt(namespace, sessionName, prompt string) error {
 		return fmt.Errorf("failed to marshal run input: %v", err)
 	}
 
-	req, err := http.NewRequest("POST", runnerURL, bytes.NewReader(body))
+	// Read the service account token for backend auth
+	token, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		return fmt.Errorf("failed to read service account token: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", backendURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+string(token))
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to send request to runner: %v", err)
+		return fmt.Errorf("failed to send request to backend: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("runner returned status %d", resp.StatusCode)
+		return fmt.Errorf("backend returned status %d", resp.StatusCode)
 	}
 
-	log.Printf("Successfully sent follow-up prompt to session %s (status %d)", sessionName, resp.StatusCode)
+	log.Printf("Successfully sent follow-up prompt to session %s via backend (status %d)", sessionName, resp.StatusCode)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
When the trigger sent a follow-up prompt to a running session, it posted directly to the runner pod. The runner processed it, but events weren't persisted or broadcast to the UI because the backend's AG-UI proxy was bypassed.

Now the trigger posts to the backend's `/agui/run` endpoint using its service account token. The backend proxy handles event persistence and broadcasting, so the UI sees the response.

## What changed
- `sendFollowUpPrompt` now posts to `backend-service.{ns}.svc.cluster.local:8080/api/projects/{project}/agentic-sessions/{session}/agui/run`
- Uses the pod's mounted service account token for auth
- Removed direct runner endpoint dependency (no more `handlers.DefaultRunnerPort`)

## Test plan
- [ ] Create a scheduled session with reuse enabled
- [ ] Let it create and run a session
- [ ] Trigger again while the session is running
- [ ] Verify the follow-up prompt and response appear in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Follow-up prompts now route through a centralized backend proxy; logs now reference the backend.
  * Service-to-service requests authenticate using the cluster service account and honor a configurable backend namespace.

* **Chores**
  * Added a post-deploy step to persist the operator image in cluster configuration to ensure consistent runtime deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->