### PR TITLE
fix(control-plane): wire ProxyFromEnvironment into default HTTP transport

### DIFF
--- a/components/ambient-control-plane/cmd/ambient-control-plane/main.go
+++ b/components/ambient-control-plane/cmd/ambient-control-plane/main.go
@@ -5,10 +5,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/ambient-code/platform/components/ambient-control-plane/internal/auth"
 	"github.com/ambient-code/platform/components/ambient-control-plane/internal/config"
@@ -216,6 +218,13 @@ func loadServiceCAPool() *x509.CertPool {
 
 func installServiceCAIntoDefaultTransport(pool *x509.CertPool) {
 	http.DefaultTransport = &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			RootCAs:    pool,


### PR DESCRIPTION
## Summary

- `installServiceCAIntoDefaultTransport` replaced `http.DefaultTransport` with a bare `&http.Transport{TLSClientConfig: ...}` — no `Proxy` field set
- Go's `net/http` silently ignores `HTTPS_PROXY`/`HTTP_PROXY` env vars when the transport's `Proxy` field is `nil`, causing all outbound connections to go direct
- This caused the OIDC token fetch to `sso.redhat.com` to time out after ~9 minutes (raw TCP connect timeout) despite proxy env vars being present on the pod

## Root cause

```go
// Before — Proxy field absent → env vars silently ignored
http.DefaultTransport = &http.Transport{
    TLSClientConfig: &tls.Config{...},
}

// After — proxy wired + standard DefaultTransport fields restored
http.DefaultTransport = &http.Transport{
    Proxy:                 http.ProxyFromEnvironment,
    DialContext:           (&net.Dialer{Timeout: 30*time.Second, KeepAlive: 30*time.Second}).DialContext,
    ForceAttemptHTTP2:     true,
    MaxIdleConns:          100,
    IdleConnTimeout:       90 * time.Second,
    TLSHandshakeTimeout:   10 * time.Second,
    ExpectContinueTimeout: 1 * time.Second,
    TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool},
}
```

The dialer/timeout fields were also zeroed out by the bare struct initializer, which degraded connection pooling and timeout behavior for all HTTP calls.

## Test plan
- [ ] Deploy updated control-plane image to MPP dev cluster
- [ ] Confirm OIDC token fetch succeeds (no 9-minute timeout in logs)
- [ ] Verify `component: oidc-token-provider` log shows "OIDC token acquired" within seconds

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced connection management and timeout configuration to improve control plane reliability and stability. Updates include optimized connection pooling, improved proxy handling, and refined timeout settings for more robust performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->