### PR TITLE
fix(manifests): wire ambient-control-plane-rbac.yaml into mpp-openshift kustomization

### DIFF
--- a/components/manifests/overlays/mpp-openshift/kustomization.yaml
+++ b/components/manifests/overlays/mpp-openshift/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ambient-control-plane.yaml
 - ambient-api-server-route.yaml
 - ambient-control-plane-sa.yaml
+- ambient-control-plane-rbac.yaml
 - ambient-tenant-ingress-netpol.yaml
 
 patches:


### PR DESCRIPTION
## Summary

- `ambient-control-plane-rbac.yaml` already existed in the mpp-openshift overlay with the correct `Role`/`RoleBinding` granting the CP service account `get/list/watch/create/delete` on `tenantnamespaces.tenant.paas.redhat.com` in `ambient-code--config`
- The file was never listed in `kustomization.yaml`, so it was never applied — causing `Forbidden` errors when the `MPPNamespaceProvisioner` tried to manage `TenantNamespace` CRs
- Fix: add `- ambient-control-plane-rbac.yaml` to the `resources:` list

## Root Cause

Error observed after PR #1162 merged:
```
tenantnamespaces.tenant.paas.redhat.com "test" is forbidden:
User "system:serviceaccount:ambient-code--ambient-s0:ambient-control-plane"
cannot get resource "tenantnamespaces" in API group "tenant.paas.redhat.com"
in the namespace "ambient-code--config"
```

## Test plan
- [ ] Apply kustomize overlay to MPP cluster and confirm no Forbidden errors on `tenantnamespaces` operations
- [ ] CP pod logs should show successful project namespace provisioning

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to include additional role-based access control settings for enhanced security management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->