### PR TITLE
fix(manifests): fix RoleBinding subject namespace via Kustomize replacement

### DIFF
--- a/components/manifests/overlays/mpp-openshift/ambient-control-plane-rbac.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-control-plane-rbac.yaml
@@ -1,32 +1,4 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: ambient-control-plane-project-namespaces
-rules:
-  - apiGroups: [""]
-    resources: ["secrets", "serviceaccounts", "services"]
-    verbs: ["get", "list", "watch", "create", "delete", "deletecollection"]
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch", "delete", "deletecollection"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["rolebindings"]
-    verbs: ["get", "list", "watch", "create", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ambient-control-plane-project-namespaces
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: ambient-control-plane-project-namespaces
-subjects:
-  - kind: ServiceAccount
-    name: ambient-control-plane
-    namespace: ambient-code--runtime-int
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ambient-control-plane-tenant-namespaces

--- a/components/manifests/overlays/mpp-openshift/kustomization.yaml
+++ b/components/manifests/overlays/mpp-openshift/kustomization.yaml
@@ -15,6 +15,18 @@ resources:
 - ambient-control-plane-rbac.yaml
 - ambient-tenant-ingress-netpol.yaml
 
+replacements:
+- source:
+    kind: ServiceAccount
+    name: ambient-control-plane
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: RoleBinding
+      name: ambient-control-plane-tenant-namespaces
+    fieldPaths:
+    - subjects.0.namespace
+
 patches:
 - path: ambient-api-server-args-patch.yaml
   target:


### PR DESCRIPTION
## Summary

Follow-up to #1167. The wired-in RBAC had two issues:

1. **Wrong subject namespace**: `subjects[0].namespace` was hardcoded to `ambient-code--runtime-int`, but the CP runs in whatever namespace the overlay deploys to. When deployed to `ambient-code--ambient-s0`, the binding was silently wrong.
2. **Duplicate ClusterRole/ClusterRoleBinding**: The overlay had its own `ClusterRole`/`ClusterRoleBinding` duplicating what `base/rbac/control-plane-clusterrole.yaml` already provides.

## Fix

- Remove the duplicated `ClusterRole`/`ClusterRoleBinding` from `ambient-control-plane-rbac.yaml`
- Keep only the MPP-specific `Role`/`RoleBinding` for `tenantnamespaces.tenant.paas.redhat.com`
- Add a Kustomize `replacement` that sources `subjects[0].namespace` from the `ambient-control-plane` ServiceAccount's `metadata.namespace` — which Kustomize automatically rewrites to match the overlay's `namespace:` field. Any future overlay deploying to a different namespace gets the correct binding automatically, with zero duplication.

## Verification

```
kustomize build components/manifests/overlays/mpp-openshift/
# RoleBinding subjects[0].namespace == ambient-code--runtime-int ✓
```

## Test plan
- [ ] Apply to MPP cluster and confirm no Forbidden errors on `tenantnamespaces` operations
- [ ] CP pod logs show successful project namespace provisioning

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified permissions by removing unused role declarations.
  * Improved namespace configuration synchronization for role bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->