### PR TITLE
fix(frontend): thread branch and autoPush through new session repo flow

### DIFF
--- a/components/frontend/src/app/projects/[name]/new/page.tsx
+++ b/components/frontend/src/app/projects/[name]/new/page.tsx
@@ -24,7 +24,7 @@ export default function NewSessionPage() {
       runner: string;
       model: string;
       workflow?: string;
-      repos?: Array<{ url: string }>;
+      repos?: Array<{ url: string; branch?: string; autoPush?: boolean }>;
     }) => {
       const workflowConfig = config.workflow === "custom" && customWorkflow
         ? { gitUrl: customWorkflow.gitUrl, branch: customWorkflow.branch, path: customWorkflow.path }
@@ -50,7 +50,11 @@ export default function NewSessionPage() {
               : {}),
             ...(config.repos && config.repos.length > 0
               ? {
-                  repos: config.repos.map((r) => ({ url: r.url })),
+                  repos: config.repos.map((r) => ({
+                    url: r.url,
+                    ...(r.branch ? { branch: r.branch } : {}),
+                    ...(r.autoPush !== undefined ? { autoPush: r.autoPush } : {}),
+                  })),
                 }
               : {}),
           },

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/new-session-view.test.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/new-session-view.test.tsx
@@ -42,9 +42,14 @@ vi.mock('../workflow-selector', () => ({
 
 vi.mock('../modals/add-context-modal', () => ({
   AddContextModal: ({ onAddRepository }: { open: boolean; onAddRepository: (url: string, branch: string, autoPush?: boolean) => Promise<void> }) => (
-    <span data-testid="add-repo-btn" role="none" onClick={() => onAddRepository('https://github.com/org/platform.git', '')}>
-      Add repo
-    </span>
+    <>
+      <span data-testid="add-repo-btn" role="none" onClick={() => onAddRepository('https://github.com/org/platform.git', '')}>
+        Add repo
+      </span>
+      <span data-testid="add-repo-with-branch-btn" role="none" onClick={() => onAddRepository('https://github.com/org/other.git', 'develop', true)}>
+        Add repo with branch
+      </span>
+    </>
   ),
 }));
 
@@ -111,6 +116,43 @@ describe('NewSessionView', () => {
     fireEvent.change(textarea, { target: { value: 'some text' } });
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
     expect(defaultProps.onCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('includes branch and autoPush in onCreateSession when repo is added with branch', () => {
+    render(<NewSessionView {...defaultProps} />);
+
+    // Add a repo with branch via the mock AddContextModal
+    fireEvent.click(screen.getByTestId('add-repo-with-branch-btn'));
+
+    // Type a prompt and submit
+    const textarea = screen.getByPlaceholderText("Describe what you'd like to work on...");
+    fireEvent.change(textarea, { target: { value: 'Fix a bug' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+
+    expect(defaultProps.onCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'Fix a bug',
+        repos: [
+          { url: 'https://github.com/org/other.git', branch: 'develop', autoPush: true },
+        ],
+      })
+    );
+  });
+
+  it('omits branch from repos when no branch is specified', () => {
+    render(<NewSessionView {...defaultProps} />);
+
+    // Add a repo without branch
+    fireEvent.click(screen.getByTestId('add-repo-btn'));
+
+    const textarea = screen.getByPlaceholderText("Describe what you'd like to work on...");
+    fireEvent.change(textarea, { target: { value: 'Fix a bug' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+
+    const call = defaultProps.onCreateSession.mock.calls[0][0];
+    expect(call.repos).toHaveLength(1);
+    expect(call.repos[0].url).toBe('https://github.com/org/platform.git');
+    expect(call.repos[0].branch).toBeUndefined();
   });
 
   it('removes a pending repo badge when the X button is clicked', () => {

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/new-session-view.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/new-session-view.tsx
@@ -28,6 +28,8 @@ import type { WorkflowConfig } from "../lib/types";
 type PendingRepo = {
   url: string;
   name: string;
+  branch?: string;
+  autoPush?: boolean;
 };
 
 type NewSessionViewProps = {
@@ -37,7 +39,7 @@ type NewSessionViewProps = {
     runner: string;
     model: string;
     workflow?: string;
-    repos?: Array<{ url: string }>;
+    repos?: Array<{ url: string; branch?: string; autoPush?: boolean }>;
   }) => void;
   ootbWorkflows: WorkflowConfig[];
   onLoadCustomWorkflow?: () => void;
@@ -109,10 +111,10 @@ export function NewSessionView({
     el.style.height = `${el.scrollHeight}px`;
   }, [prompt]);
 
-  const addPendingRepo = (url: string) => {
+  const addPendingRepo = (url: string, branch?: string, autoPush?: boolean) => {
     if (pendingRepos.some((r) => r.url === url)) return;
     const name = url.replace(/\/+$/, "").split("/").pop()?.replace(/\.git$/, "") || url;
-    setPendingRepos((prev) => [...prev, { url, name }]);
+    setPendingRepos((prev) => [...prev, { url, name, branch: branch || undefined, autoPush }]);
   };
 
   const removePendingRepo = (url: string) => {
@@ -131,7 +133,7 @@ export function NewSessionView({
       runner: selectedRunner,
       model: selectedModel,
       workflow: hasWorkflow ? selectedWorkflow : undefined,
-      repos: pendingRepos.length > 0 ? pendingRepos.map((r) => ({ url: r.url })) : undefined,
+      repos: pendingRepos.length > 0 ? pendingRepos.map((r) => ({ url: r.url, branch: r.branch, autoPush: r.autoPush })) : undefined,
     });
   }, [prompt, selectedRunner, selectedModel, selectedWorkflow, pendingRepos, onCreateSession]);
 
@@ -259,8 +261,8 @@ export function NewSessionView({
       <AddContextModal
         open={contextModalOpen}
         onOpenChange={setContextModalOpen}
-        onAddRepository={async (url) => {
-          addPendingRepo(url);
+        onAddRepository={async (url, branch, autoPush) => {
+          addPendingRepo(url, branch, autoPush);
           setContextModalOpen(false);
         }}
       />


### PR DESCRIPTION
## Summary

- Fix branch name and autoPush being silently dropped when adding a context repo in the new session creation UI
- Thread `branch` and `autoPush` parameters from `AddContextModal` through `NewSessionView` to the create session API call
- Add 2 regression tests verifying branch/autoPush are forwarded correctly

## Root Cause

The `NewSessionView` component's `onAddRepository` callback only captured the `url` parameter, ignoring `branch` and `autoPush`. The `PendingRepo` type and the `onCreateSession` callback type both lacked these fields, so the data was lost at every layer of the pipeline. This was introduced in PR #939 when the new session UI was created.

## Changes

| File | Change |
|------|--------|
| `components/frontend/.../new-session-view.tsx` | Added `branch?`/`autoPush?` to `PendingRepo` type; updated `addPendingRepo`, `handleSubmit`, and `onAddRepository` callback to thread these values |
| `components/frontend/.../new/page.tsx` | Updated config type and repo mapping to forward `branch`/`autoPush` to the API |
| `components/frontend/.../__tests__/new-session-view.test.tsx` | Added 2 regression tests: branch+autoPush forwarded correctly, and empty branch becomes undefined |

## Test plan

- [x] Regression test: repo added with branch "develop" and autoPush=true flows through to `onCreateSession`
- [x] Regression test: repo added without branch results in `branch: undefined` (not empty string)
- [x] Full frontend test suite passes (615 tests, 0 failures)
- [x] Next.js build passes with 0 errors
- [ ] Manual: Create a new session, add a repo with a specific branch, verify the session uses that branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced repository configuration during session creation with optional branch specification and auto-push toggle.

* **Tests**
  * Added test coverage for new repository configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->