### PR TITLE
fix: enable CodeRabbit reviews on alpha branch PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -110,7 +110,8 @@ reviews:
       - "dependabot[bot]"
       - "renovate[bot]"
     base_branches:
-      - ".*"
+      - "main"
+      - "alpha"
 
   # ---------------------------------------------------------------------------
   # Finishing touches


### PR DESCRIPTION
<!-- acp:session_id=triage-gh-1134-coderabbit-alpha source=#1134 last_action=2026-04-02T19:59:00Z retry_count=0 -->

## Summary

Fixes #1134

CodeRabbit was not triggering on PRs targeting the `alpha` branch because the `base_branches` configuration in `.coderabbit.yaml` used a regex pattern `".*"` which doesn't work as expected.

CodeRabbit's `base_branches` field expects **glob patterns**, not regex. The pattern `".*"` as a glob would only match branches starting with a literal dot (like `.github`), not all branches.

## Changes

- Updated `.coderabbit.yaml` to explicitly list `"main"` and `"alpha"` in the `base_branches` configuration
- This ensures CodeRabbit will now trigger reviews on PRs targeting either branch

## Test Plan

- Create a PR targeting the `alpha` branch and verify CodeRabbit triggers a review
- Verify existing PRs targeting `main` continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation configuration to specify target branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->