### PR TITLE
fix: increase Gemini CLI buffer limit to 10 MB for large MCP tool responses

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/gemini_cli/session.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/gemini_cli/session.py
@@ -152,6 +152,7 @@ class GeminiSessionWorker:
             stderr=asyncio.subprocess.PIPE,
             cwd=self._cwd,
             env=env,
+            limit=10 * 1024 * 1024,  # 10 MB buffer for large MCP tool responses
         )
 
         # Start concurrent stderr streaming

--- a/components/runners/ambient-runner/tests/test_gemini_session.py
+++ b/components/runners/ambient-runner/tests/test_gemini_session.py
@@ -208,6 +208,23 @@ class TestWorkerEnvironment:
             call_kwargs = mock_exec.call_args[1]
             assert call_kwargs["cwd"] == "/my/workspace"
 
+    @pytest.mark.asyncio
+    async def test_buffer_limit_set_for_large_responses(self):
+        """The subprocess should use a 10 MB buffer limit for large MCP tool responses."""
+        worker = GeminiSessionWorker(model="m")
+        proc = _make_mock_process(
+            stdout_lines=[b'{"done":true}\n'],
+            stderr_lines=[],
+        )
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            async for _ in worker.query("test"):
+                pass
+
+            call_kwargs = mock_exec.call_args[1]
+            # Verify 10 MB limit is set to prevent LimitOverrunError on large NDJSON lines
+            assert call_kwargs["limit"] == 10 * 1024 * 1024
+
 
 # ------------------------------------------------------------------
 # GeminiSessionWorker -- stderr streaming


### PR DESCRIPTION
<!-- acp:session_id=triage-gh-1126-gemini-buffer-limit source=#1126 last_action=2026-04-02T19:59:00Z retry_count=0 -->

## Summary

Fixes #1126 — Gemini CLI bridge crashes on large MCP tool responses (>64KB).

The issue occurred when MCP tools (like `mcp_kubernetes_events_list`) returned responses larger than the default `asyncio.StreamReader` buffer limit of 64 KB. The bridge would crash with `Separator is not found` and `chunk exceed the limit` errors.

## Changes

- **`components/runners/ambient-runner/ambient_runner/bridges/gemini_cli/session.py`**: Added `limit=10 * 1024 * 1024` parameter to `asyncio.create_subprocess_exec()` call to increase buffer from 64 KB to 10 MB
- **`components/runners/ambient-runner/tests/test_gemini_session.py`**: Added test to verify the buffer limit is correctly configured

## Root Cause

The `asyncio.create_subprocess_exec()` call used Python's default `StreamReader` buffer limit of 64 KB. When the Gemini CLI outputs NDJSON lines exceeding this limit, `asyncio.StreamReader.readline()` raises `asyncio.LimitOverrunError`.

## Test Plan

- [x] Added unit test `test_buffer_limit_set_for_large_responses` to verify correct configuration
- [ ] CI unit tests pass (runner tests workflow)
- [ ] Manual verification with large MCP tool responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved subprocess buffer management to better handle large responses.

* **Tests**
  * Added test coverage to verify buffer limit configuration for response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->