### PR TITLE
feat: add make crc-* targets for OpenShift Local deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1049,7 +1049,7 @@ crc-down: ## Stop CRC deployments (keep cluster running)
 
 crc-clean: ## Full cleanup including CRC cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Cleaning up CRC environment..."
-	@PROJECT_NAME=$(CRC_PROJECT_NAME) bash components/scripts/local-dev/crc-stop.sh --delete-project --stop-cluster
+	@PROJECT_NAME=$(CRC_PROJECT_NAME) STOP_CLUSTER=true DELETE_PROJECT=true bash components/scripts/local-dev/crc-stop.sh
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) CRC environment cleaned up"
 
 crc-status: ## Show CRC cluster and deployment status


### PR DESCRIPTION
<!-- acp:session_id=fix-pr-1174-crc-targets source=#1116 last_action=2026-04-02T20:10:00Z retry_count=1 -->

## Summary

Adds new `make crc-*` targets to provide a clear way to deploy and manage local OpenShift (CRC) environments. This addresses the retirement of `make local-*` targets by providing explicit CRC deployment commands.

## Changes

### New Makefile Targets

- **`make crc-up`**: Start CRC cluster and deploy the platform
  - Configurable via `CRC_CPUS`, `CRC_MEMORY`, `CRC_DISK`, `CRC_PROJECT_NAME`
  - Calls `components/scripts/local-dev/crc-start.sh`
  
- **`make crc-down`**: Stop CRC deployments (keep cluster running)
  - Preserves cluster for faster restarts
  
- **`make crc-clean`**: Full cleanup including CRC cluster
  - Deletes project and stops cluster
  
- **`make crc-status`**: Show CRC cluster and deployment status
  - Reports cluster state and deployment health
  
- **`make crc-test`**: Run CRC environment tests
  - Calls `components/scripts/local-dev/crc-test.sh`
  
- **`make crc-rebuild`**: Rebuild and redeploy all components
  - Rebuilds backend, frontend, and operator via OpenShift BuildConfigs
  - Restarts deployments with new images
  
- **`make crc-logs`**: Show logs from all CRC components (follow mode)
- **`make crc-logs-backend`**: Backend logs only
- **`make crc-logs-frontend`**: Frontend logs only
- **`make crc-logs-operator`**: Operator logs only

### Configuration Variables

```makefile
CRC_CPUS ?= 4              # Number of CPUs for CRC VM
CRC_MEMORY ?= 11264        # Memory in MB (default: 11GB)
CRC_DISK ?= 50             # Disk size in GB
CRC_PROJECT_NAME ?= vteam-dev  # OpenShift project name
```

## Design Decisions

1. **Mirror `kind-*` pattern**: The new targets follow the same naming and structure as existing `kind-*` targets for consistency
2. **Leverage existing scripts**: Reuses battle-tested scripts in `components/scripts/local-dev/`
3. **No breaking changes**: Doesn't modify existing targets or behavior
4. **Clear separation**: Provides explicit CRC targets distinct from deprecated `local-*` targets

## Testing

Verified with:
```bash
make help | grep crc     # Targets show in help
make -n crc-status       # Dry-run executes correctly
```

## Related Issues

- Resolves #1116
- Related to #992, #1080 (retirement of `make local-*` targets)

## Checklist

- [x] Added new CRC targets to Makefile
- [x] Added `.PHONY` declarations
- [x] Added configuration variables
- [x] Targets follow existing patterns (kind-*)
- [x] Help text is clear and informative
- [x] No breaking changes to existing targets

---

**Note**: This PR introduces the Makefile targets only. The underlying CRC scripts (`crc-start.sh`, `crc-stop.sh`, `crc-test.sh`) already exist in `components/scripts/local-dev/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Make commands for managing a local development cluster: start, stop, clean, status, test, rebuild, and component-specific logging
  * Introduced configurable local-cluster resource parameters (CPU, memory, disk) with sensible defaults
  * Improved observability with per-component and aggregated log viewing options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->