### PR TITLE
fix(control-plane): use project kube client for namespace provisioner

### DIFF
--- a/components/ambient-control-plane/cmd/ambient-control-plane/main.go
+++ b/components/ambient-control-plane/cmd/ambient-control-plane/main.go
@@ -113,7 +113,11 @@ func runKubeMode(ctx context.Context, cfg *config.ControlPlaneConfig) error {
 		log.Info().Str("token_file", cfg.ProjectKubeTokenFile).Msg("using separate project kube client")
 	}
 
-	provisioner := buildNamespaceProvisioner(cfg, kube)
+	provisionerKube := kube
+	if projectKube != nil {
+		provisionerKube = projectKube
+	}
+	provisioner := buildNamespaceProvisioner(cfg, provisionerKube)
 	tokenProvider := buildTokenProvider(cfg, log.Logger)
 
 	factory := reconciler.NewSDKClientFactory(cfg.APIServerURL, tokenProvider, log.Logger)


### PR DESCRIPTION
## Summary

When `PROJECT_KUBE_TOKEN_FILE` is set, the project kube client carries the TSA identity (`tenantaccess-ambient-control-plane`) which already has `namespace-admin` RoleBindings in `ambient-code--config` — including access to `tenantnamespaces.tenant.paas.redhat.com`. The main in-cluster SA does not.

`buildNamespaceProvisioner` was receiving `kube` (the pod SA identity) unconditionally. The MPP `TenantNamespace` provisioner then failed with:

```
tenantnamespaces.tenant.paas.redhat.com "test" is forbidden:
User "system:serviceaccount:ambient-code--ambient-s0:ambient-control-plane"
cannot get resource "tenantnamespaces" in API group "tenant.paas.redhat.com"
in the namespace "ambient-code--config"
```

## Fix

Three lines: prefer `projectKube` over `kube` when building the provisioner, since that IS the identity with the right permissions already in place.

## Test plan
- [ ] Deploy to MPP cluster with `PROJECT_KUBE_TOKEN_FILE` set — CP logs show successful `TenantNamespace` get/create/delete without Forbidden errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Namespace provisioning now supports project-specific Kubernetes tokens when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->