### PR TITLE
fix(control-plane): drop -z- from MPP namespace prefix

### DIFF
--- a/components/ambient-control-plane/internal/kubeclient/namespace_provisioner.go
+++ b/components/ambient-control-plane/internal/kubeclient/namespace_provisioner.go
@@ -97,7 +97,7 @@ func NewMPPNamespaceProvisioner(kube *KubeClient, configNamespace string, logger
 	}
 }
 
-const mppNamespacePrefix = "ambient-code--z-"
+const mppNamespacePrefix = "ambient-code--"
 
 func (p *MPPNamespaceProvisioner) instanceID(namespaceName string) string {
 	if len(namespaceName) > len(mppNamespacePrefix) && namespaceName[:len(mppNamespacePrefix)] == mppNamespacePrefix {


### PR DESCRIPTION
## Summary

- Fixes hardcoded `ambient-code--z-` prefix in `MPPNamespaceProvisioner` — the tenant-operator materializes `TenantNamespace` CRs as `ambient-code--<id>`, not `ambient-code--z-<id>`
- With the wrong prefix, `ProvisionNamespace` would create the `TenantNamespace` CR correctly but then poll for `ambient-code--z-<id>` which never appeared, timing out after 60s every time

## Test plan
- [ ] Create a session on MPP cluster — namespace provisioned as `ambient-code--<project-id>` and becomes active without timeout

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated namespace naming conventions in the control plane provisioning system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->