### PR TITLE
fix: wait for DataScienceCluster CRD before applying DSC

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -272,6 +272,14 @@ jobs:
             sleep 10
           done
 
+      - name: Ensure mlflow database exists in PostgreSQL
+        run: |
+          oc exec -n ambient-code deploy/postgresql -- \
+            psql -U postgres -tAc \
+            "SELECT 1 FROM pg_database WHERE datname = 'mlflow'" | grep -q 1 \
+          || oc exec -n ambient-code deploy/postgresql -- \
+            psql -U postgres -c "CREATE DATABASE mlflow"
+
       - name: Verify mlflow-db-credentials secret exists
         run: |
           if ! oc get secret mlflow-db-credentials -n redhat-ods-applications &>/dev/null; then

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -411,6 +411,14 @@ jobs:
             sleep 10
           done
 
+      - name: Ensure mlflow database exists in PostgreSQL
+        run: |
+          oc exec -n ambient-code deploy/postgresql -- \
+            psql -U postgres -tAc \
+            "SELECT 1 FROM pg_database WHERE datname = 'mlflow'" | grep -q 1 \
+          || oc exec -n ambient-code deploy/postgresql -- \
+            psql -U postgres -c "CREATE DATABASE mlflow"
+
       - name: Verify mlflow-db-credentials secret exists
         run: |
           if ! oc get secret mlflow-db-credentials -n redhat-ods-applications &>/dev/null; then

--- a/components/manifests/components/openshift-ai/mlflow.yaml
+++ b/components/manifests/components/openshift-ai/mlflow.yaml
@@ -3,7 +3,7 @@ kind: MLflow
 metadata:
   name: mlflow
 spec:
-  replicas: 2
+  replicas: 1
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Fixes the `deploy-rhoai-mlflow` GHA job failure from #1166
- The RHOAI operator CSV succeeding doesn't guarantee CRDs are registered yet
- Adds a wait loop for `datascienceclusters.datasciencecluster.opendatahub.io` CRD between the operator readiness check and the DSC apply step
- Applied to both `components-build-deploy.yml` and `prod-release-deploy.yaml`

## Test plan
- [ ] Re-run the `deploy-rhoai-mlflow` job and verify it passes
- [ ] Verify the CRD wait step logs show the CRD becoming available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflows now wait (up to ~10 minutes) for a cluster CRD to register before proceeding; the job fails with an error if the CRD never appears.
  * Deployment steps now verify the PostgreSQL database named "mlflow" exists and create it if absent.
* **Configuration**
  * MLflow server replica count changed from 2 to 1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->