### PR TITLE
fix: handle RHOAI operator channel mismatch on deploy

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -212,14 +212,28 @@ jobs:
         run: |
           oc apply -f components/manifests/components/openshift-ai/namespace.yaml
           oc apply -f components/manifests/components/openshift-ai/operatorgroup.yaml
+          # Remove any existing subscription/CSV to ensure clean install on the target channel
+          OLD_CSV=$(oc get subscription rhods-operator -n redhat-ods-operator \
+            -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+          if [ -n "$OLD_CSV" ]; then
+            DESIRED_CHANNEL=$(grep 'channel:' components/manifests/components/openshift-ai/subscription.yaml | awk '{print $2}')
+            CURRENT_CHANNEL=$(oc get subscription rhods-operator -n redhat-ods-operator \
+              -o jsonpath='{.spec.channel}' 2>/dev/null || true)
+            if [ "$CURRENT_CHANNEL" != "$DESIRED_CHANNEL" ]; then
+              echo "Channel mismatch ($CURRENT_CHANNEL → $DESIRED_CHANNEL), removing old operator..."
+              oc delete subscription rhods-operator -n redhat-ods-operator --ignore-not-found
+              oc delete csv "$OLD_CSV" -n redhat-ods-operator --ignore-not-found
+            fi
+          fi
           oc apply -f components/manifests/components/openshift-ai/subscription.yaml
 
       - name: Wait for RHOAI operator to be ready
         run: |
-          echo "Waiting for RHOAI operator CSV to appear..."
+          DESIRED_CHANNEL=$(grep 'channel:' components/manifests/components/openshift-ai/subscription.yaml | awk '{print $2}')
+          echo "Waiting for RHOAI operator CSV on channel $DESIRED_CHANNEL..."
           for i in $(seq 1 60); do
             CSV=$(oc get subscription rhods-operator -n redhat-ods-operator \
-              -o jsonpath='{.status.installedCSV}' 2>/dev/null)
+              -o jsonpath='{.status.currentCSV}' 2>/dev/null)
             if [ -n "$CSV" ]; then
               echo "Found CSV: $CSV"
               break

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -351,14 +351,28 @@ jobs:
         run: |
           oc apply -f components/manifests/components/openshift-ai/namespace.yaml
           oc apply -f components/manifests/components/openshift-ai/operatorgroup.yaml
+          # Remove any existing subscription/CSV to ensure clean install on the target channel
+          OLD_CSV=$(oc get subscription rhods-operator -n redhat-ods-operator \
+            -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+          if [ -n "$OLD_CSV" ]; then
+            DESIRED_CHANNEL=$(grep 'channel:' components/manifests/components/openshift-ai/subscription.yaml | awk '{print $2}')
+            CURRENT_CHANNEL=$(oc get subscription rhods-operator -n redhat-ods-operator \
+              -o jsonpath='{.spec.channel}' 2>/dev/null || true)
+            if [ "$CURRENT_CHANNEL" != "$DESIRED_CHANNEL" ]; then
+              echo "Channel mismatch ($CURRENT_CHANNEL → $DESIRED_CHANNEL), removing old operator..."
+              oc delete subscription rhods-operator -n redhat-ods-operator --ignore-not-found
+              oc delete csv "$OLD_CSV" -n redhat-ods-operator --ignore-not-found
+            fi
+          fi
           oc apply -f components/manifests/components/openshift-ai/subscription.yaml
 
       - name: Wait for RHOAI operator to be ready
         run: |
-          echo "Waiting for RHOAI operator CSV to appear..."
+          DESIRED_CHANNEL=$(grep 'channel:' components/manifests/components/openshift-ai/subscription.yaml | awk '{print $2}')
+          echo "Waiting for RHOAI operator CSV on channel $DESIRED_CHANNEL..."
           for i in $(seq 1 60); do
             CSV=$(oc get subscription rhods-operator -n redhat-ods-operator \
-              -o jsonpath='{.status.installedCSV}' 2>/dev/null)
+              -o jsonpath='{.status.currentCSV}' 2>/dev/null)
             if [ -n "$CSV" ]; then
               echo "Found CSV: $CSV"
               break


### PR DESCRIPTION
## Summary
- Fixes the `deploy-rhoai-mlflow` GHA job still failing after #1188
- Root cause: the target cluster has RHOAI **v2.4.0** installed on a different channel. OLM can't find an upgrade path from 2.x → 3.4.0-ea.1 (beta), so the subscription stays stuck on the old CSV and the v2 `DataScienceCluster` API never appears
- Fix: detect channel mismatch and delete the old subscription/CSV before applying the new one
- Also switches from `installedCSV` to `currentCSV` in the wait loop to avoid reading stale status after deletion

## Test plan
- [ ] Re-run the `deploy-rhoai-mlflow` job — should detect the 2.4.0 → beta mismatch, clean up, and install fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced RHOAI operator deployment workflow with improved channel management and conditional subscription updates for smoother operator version transitions
  * Updated operator readiness verification logic for more reliable deployment checks and faster operator availability confirmation
  * Improved deployment process resilience with better handling of operator updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->