### PR TITLE
feat: add stopOnRunFinished + improve activity tracking

### DIFF
--- a/.github/workflows/amber-issue-handler.yml
+++ b/.github/workflows/amber-issue-handler.yml
@@ -95,7 +95,8 @@ jobs:
             [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
           model: claude-opus-4-6
           wait: 'true'
-          timeout: '60'
+          timeout: '0'
+          stop-on-run-finished: 'true'
 
       - name: Post-session labels and comment
         if: steps.existing.outputs.skip != 'true'
@@ -248,7 +249,8 @@ jobs:
             [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
           model: claude-opus-4-6
           wait: 'true'
-          timeout: '60'
+          timeout: '0'
+          stop-on-run-finished: 'true'
 
       # Custom prompt: @amber <instruction> — pass user's text
       - name: Run custom prompt
@@ -271,14 +273,15 @@ jobs:
             [{"url": "https://github.com/${{ github.repository }}", "branch": "main"}]
           model: claude-opus-4-6
           wait: 'true'
-          timeout: '60'
+          timeout: '0'
+          stop-on-run-finished: 'true'
 
       - name: Session summary
         if: always() && steps.context.outputs.is_fork != 'true'
         run: |
-          # Get session name from whichever step ran
-          SESSION_NAME="${{ steps.fix-session.outputs.session-name }}${{ steps.fix-issue-session.outputs.session-name }}${{ steps.custom-session.outputs.session-name }}"
-          SESSION_PHASE="${{ steps.fix-session.outputs.session-phase }}${{ steps.fix-issue-session.outputs.session-phase }}${{ steps.custom-session.outputs.session-phase }}"
+          # Get session name from whichever step ran (only one will have output)
+          SESSION_NAME="${{ steps.fix-session.outputs.session-name || steps.fix-issue-session.outputs.session-name || steps.custom-session.outputs.session-name }}"
+          SESSION_PHASE="${{ steps.fix-session.outputs.session-phase || steps.fix-issue-session.outputs.session-phase || steps.custom-session.outputs.session-phase }}"
 
           echo "### Amber — ${{ steps.context.outputs.type }} #${{ steps.context.outputs.number }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -313,6 +316,8 @@ jobs:
           import os
           import re
           import subprocess
+          import time
+          import uuid
           import requests
           from datetime import datetime, timezone
 
@@ -368,7 +373,6 @@ jobs:
 
           def create_session_api(prompt, session_name="", model="claude-opus-4-6"):
               """Create a new session or send message to existing one."""
-              import time, uuid
 
               if session_name:
                   # Ensure session is running
@@ -401,7 +405,7 @@ jobs:
 
               # Create new session
               url = f"{API_URL.rstrip('/')}/projects/{PROJECT}/agentic-sessions"
-              body = {"initialPrompt": prompt, "inactivityTimeout": 60,
+              body = {"initialPrompt": prompt, "stopOnRunFinished": True,
                       "llmSettings": {"model": model},
                       "repos": [{"url": f"https://github.com/{REPO}", "branch": "main"}]}
               try:

--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -741,6 +741,9 @@ func CreateSession(c *gin.Context) {
 		}
 		spec["inactivityTimeout"] = *req.InactivityTimeout
 	}
+	if req.StopOnRunFinished != nil && *req.StopOnRunFinished {
+		spec["stopOnRunFinished"] = true
+	}
 
 	session := map[string]interface{}{
 		"apiVersion": "vteam.ambient-code/v1alpha1",

--- a/components/backend/types/session.go
+++ b/components/backend/types/session.go
@@ -18,6 +18,7 @@ type AgenticSessionSpec struct {
 	LLMSettings          LLMSettings        `json:"llmSettings"`
 	Timeout              int                `json:"timeout"`
 	InactivityTimeout    *int               `json:"inactivityTimeout,omitempty"`
+	StopOnRunFinished    bool               `json:"stopOnRunFinished,omitempty"`
 	UserContext          *UserContext       `json:"userContext,omitempty"`
 	BotAccount           *BotAccountRef     `json:"botAccount,omitempty"`
 	ResourceOverrides    *ResourceOverrides `json:"resourceOverrides,omitempty"`
@@ -58,6 +59,7 @@ type CreateAgenticSessionRequest struct {
 	LLMSettings          *LLMSettings       `json:"llmSettings,omitempty"`
 	Timeout              *int               `json:"timeout,omitempty"`
 	InactivityTimeout    *int               `json:"inactivityTimeout,omitempty"`
+	StopOnRunFinished    *bool              `json:"stopOnRunFinished,omitempty"`
 	ParentSessionID      string             `json:"parent_session_id,omitempty"`
 	Repos                []SimpleRepo       `json:"repos,omitempty"`
 	ActiveWorkflow       *WorkflowSelection `json:"activeWorkflow,omitempty"`

--- a/components/backend/websocket/agui_proxy.go
+++ b/components/backend/websocket/agui_proxy.go
@@ -36,8 +36,9 @@ import (
 
 const (
 	// activityDebounceInterval is the minimum interval between CR status updates for lastActivityTime.
-	// Inactivity timeout is measured in hours, so minute-level granularity is sufficient.
-	activityDebounceInterval = 60 * time.Second
+	// Must be significantly shorter than the smallest inactivity timeout to prevent
+	// false inactivity detection while the session is actively processing.
+	activityDebounceInterval = 10 * time.Second
 
 	// activityUpdateTimeout bounds how long a single activity status update can take.
 	activityUpdateTimeout = 10 * time.Second
@@ -55,6 +56,11 @@ var activityUpdateSem = make(chan struct{}, 50)
 // lastActivityUpdateTimes tracks the last time we updated lastActivityTime on the CR
 // for each session to avoid excessive API calls. Key: "namespace/sessionName"
 var lastActivityUpdateTimes sync.Map
+
+// stopOnRunFinishedCache tracks which sessions have stopOnRunFinished set.
+// Populated lazily on first RUN_FINISHED event, avoids repeated k8s API calls.
+// Key: sessionName, Value: bool
+var stopOnRunFinishedCache sync.Map
 
 // sessionProjectMap maps sessionName → projectName so that persistStreamedEvent
 // (which only receives sessionID) can look up the project for activity tracking.
@@ -533,10 +539,17 @@ func persistStreamedEvent(sessionID, runID, threadID, jsonData string) {
 	// sessionID-to-project mapping populated by HandleAGUIRunProxy.
 	eventType, _ := event["type"].(string)
 
-	// Update lastActivityTime on CR for activity events (debounced).
-	if isActivityEvent(eventType) {
+	// Update lastActivityTime on CR for any event (debounced).
+	if eventType != "" {
 		if projectName, ok := sessionProjectMap.Load(sessionID); ok {
 			updateLastActivityTime(projectName.(string), sessionID, eventType == types.EventTypeRunStarted)
+		}
+	}
+
+	// Stop session on RUN_FINISHED if stopOnRunFinished is set.
+	if eventType == types.EventTypeRunFinished {
+		if projectName, ok := sessionProjectMap.Load(sessionID); ok {
+			go checkAndStopOnRunFinished(projectName.(string), sessionID)
 		}
 	}
 
@@ -984,17 +997,52 @@ func triggerDisplayNameGenerationIfNeeded(projectName, sessionName string, messa
 	handlers.GenerateDisplayNameAsync(projectName, sessionName, userMessage, sessionCtx)
 }
 
-// isActivityEvent returns true for AG-UI event types that indicate session activity.
-func isActivityEvent(eventType string) bool {
-	switch eventType {
-	case types.EventTypeRunStarted,
-		types.EventTypeTextMessageStart,
-		types.EventTypeTextMessageContent,
-		types.EventTypeToolCallStart:
-		return true
-	default:
-		return false
+// checkAndStopOnRunFinished checks if stopOnRunFinished is set for a session
+// and triggers a stop. Uses an in-memory cache to avoid k8s API calls for
+// sessions that don't have the flag set.
+func checkAndStopOnRunFinished(projectName, sessionName string) {
+	if handlers.DynamicClient == nil {
+		return
 	}
+
+	// Check cache first — skip k8s API call for sessions we've already checked
+	if cached, ok := stopOnRunFinishedCache.Load(sessionName); ok {
+		if !cached.(bool) {
+			return
+		}
+	}
+
+	gvr := types.GetAgenticSessionResource()
+	ctx, cancel := context.WithTimeout(context.Background(), activityUpdateTimeout)
+	defer cancel()
+
+	obj, err := handlers.DynamicClient.Resource(gvr).Namespace(projectName).Get(ctx, sessionName, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("stopOnRunFinished: failed to get session %s/%s: %v", projectName, sessionName, err)
+		return
+	}
+
+	stopOnFinish, _, _ := unstructured.NestedBool(obj.Object, "spec", "stopOnRunFinished")
+	stopOnRunFinishedCache.Store(sessionName, stopOnFinish)
+	if !stopOnFinish {
+		return
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["ambient-code.io/desired-phase"] = "Stopped"
+	annotations["ambient-code.io/stop-reason"] = "run-finished"
+	obj.SetAnnotations(annotations)
+
+	_, err = handlers.DynamicClient.Resource(gvr).Namespace(projectName).Update(ctx, obj, metav1.UpdateOptions{})
+	if err != nil {
+		log.Printf("stopOnRunFinished: failed to update session %s/%s: %v", projectName, sessionName, err)
+		return
+	}
+
+	log.Printf("stopOnRunFinished: session %s/%s set to Stopped after RUN_FINISHED", projectName, sessionName)
 }
 
 // updateLastActivityTime updates the lastActivityTime field on the AgenticSession CR status.

--- a/components/manifests/base/crds/agenticsessions-crd.yaml
+++ b/components/manifests/base/crds/agenticsessions-crd.yaml
@@ -79,6 +79,9 @@ spec:
                 type: integer
                 minimum: 0
                 description: "Seconds of inactivity before auto-stopping a session. 0 disables auto-shutdown. If omitted, falls back to project-level inactivityTimeoutSeconds, then 24h default."
+              stopOnRunFinished:
+                type: boolean
+                description: "When true, automatically stop the session when the agent completes its run (RUN_FINISHED event). Useful for one-shot tasks triggered by automation."
               environmentVariables:
                 type: object
                 additionalProperties:


### PR DESCRIPTION
## Summary

Adds `stopOnRunFinished` CRD field and improves inactivity detection. Builds on #1180.

## Changes

### `stopOnRunFinished` (new CRD field)
- When `true`, the backend auto-stops the session on `RUN_FINISHED` event
- Uses in-memory cache (`sync.Map`) to avoid k8s API call on every `RUN_FINISHED` for sessions without the flag
- Wired through: CRD → backend types → session create handler → AG-UI proxy

### Activity tracking improvements
- All AG-UI events now reset the inactivity timer (was only 4 event types — `RUN_STARTED`, `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TOOL_CALL_START`)
- Prevents false inactivity detection during long tool calls that don't emit those specific events
- Activity debounce reduced from 60s to 10s to support shorter inactivity timeouts

### Amber GHA updates
- Use `stop-on-run-finished: 'true'` with `timeout: '0'` (no inactivity timeout)
- Fix/custom prompt split: `@amber` alone → fix prompt, `@amber <text>` → custom
- Shell injection fix: comment body via env var
- Session summary: use `||` fallback instead of string concatenation

## Test plan

- [ ] Create session with `stopOnRunFinished: true` — verify it stops on `RUN_FINISHED`
- [ ] Create session without the flag — verify no change in behavior
- [ ] Verify activity tracking keeps sessions alive during long tool calls
- [ ] Test `@amber` comment on a PR — verify fix prompt runs
- [ ] Test `@amber do something` on an issue — verify custom prompt runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions can now be configured to automatically stop when agents complete their run.

* **Improvements**
  * Enhanced activity tracking responsiveness with faster status updates.
  * Updated session lifecycle management behavior for improved resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->