### PR TITLE
fix: increase minio PVC to 2Ti to match UAT

### DIFF
--- a/components/manifests/overlays/production/kustomization.yaml
+++ b/components/manifests/overlays/production/kustomization.yaml
@@ -51,6 +51,11 @@ patches:
     kind: Service
     name: ambient-api-server
     version: v1
+- path: minio-pvc-patch.yaml
+  target:
+    kind: PersistentVolumeClaim
+    name: minio-data
+    version: v1
 
 # Production images
 images:

--- a/components/manifests/overlays/production/minio-pvc-patch.yaml
+++ b/components/manifests/overlays/production/minio-pvc-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+spec:
+  resources:
+    requests:
+      storage: 2Ti


### PR DESCRIPTION
## Summary
- UAT cluster already has a 2TB `minio-data` PVC, but the base manifest specifies `500Gi`
- Kubernetes rejects shrinking a PVC, causing `oc apply` to fail with: `spec.resources.requests.storage: Forbidden: field can not be less than previous value`
- Adds a production overlay patch to set `minio-data` PVC to `2Ti`

Fixes https://github.com/ambient-code/platform/actions/runs/23954839404/job/69871041808

## Test plan
- [ ] Verify `kustomize build components/manifests/overlays/production` renders `minio-data` PVC with `storage: 2Ti`
- [ ] Deploy to UAT succeeds without PVC error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration to allocate 2Ti of storage for MinIO object storage service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->