### PR TITLE
Reduce Google Workspace MCP OAuth scopes using granular permissions

### DIFF
--- a/components/runners/ambient-runner/.mcp.json
+++ b/components/runners/ambient-runner/.mcp.json
@@ -27,9 +27,9 @@
       "command": "uvx",
       "args": [
         "workspace-mcp@1.14.2",
-        "--tools",
-        "drive",
-        "gmail"
+        "--permissions",
+        "gmail:send",
+        "drive:full"
       ],
       "env": {
         "GOOGLE_MCP_CREDENTIALS_DIR": "${GOOGLE_MCP_CREDENTIALS_DIR}",


### PR DESCRIPTION
## Summary

Reduces Google Workspace MCP OAuth scope requests by switching from `--tools` to `--permissions` flag for granular control.

## Changes

**Configuration file:** `components/runners/ambient-runner/.mcp.json`

**Before:**
```json
"args": [
  "workspace-mcp@1.14.2",
  "--tools",
  "drive",
  "gmail"
]
```

**After:**
```json
"args": [
  "workspace-mcp@1.14.2",
  "--permissions",
  "gmail:send",
  "drive:full"
]
```

## Impact

### OAuth Scopes Removed ✅
- `gmail.modify` - Delete/trash emails
- `gmail.settings.basic` - Modify Gmail settings

### OAuth Scopes Kept
- **Gmail:** `send` level (includes: send, readonly, labels, compose - cumulative)
- **Drive:** `full` access (unchanged)

## Security Benefits

1. **Least privilege principle** - Only requests necessary permissions
2. **Reduced attack surface** - Removes ability to delete emails or modify settings
3. **Better user trust** - Clearer permission requests in OAuth consent screen

## Testing

After deployment:
1. Users will need to re-authenticate with Google Workspace
2. Verify OAuth consent screen only shows expected scopes
3. Test Gmail send functionality works
4. Test Drive operations work

## References

- [workspace-mcp granular permissions docs](https://github.com/taylorwilsdon/google_workspace_mcp#granular-permissions)
- Gmail permission levels are cumulative: `readonly` < `organize` < `drafts` < `send` < `full`

## Breaking Changes

None - existing functionality is preserved, just with reduced permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authorization configuration for the google-workspace integration, modifying how permissions are explicitly granted for email and storage access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->