### PR TITLE
feat: post check runs on PRs with Amber session link

### DIFF
--- a/.github/workflows/amber-issue-handler.yml
+++ b/.github/workflows/amber-issue-handler.yml
@@ -457,9 +457,9 @@ jobs:
                  "-f", f"output[summary]=Session `{session_name}` triggered for PR #{pr_number}"]
               if session_url:
                   args.extend(["-f", f"details_url={session_url}"])
-              result = gh(*args)
-              if not result and "error" in result.lower() if result else False:
-                  print(f"  Warning: failed to create check run for PR #{pr_number}")
+              proc = subprocess.run(["gh"] + list(args), capture_output=True, text=True)
+              if proc.returncode != 0:
+                  print(f"  Warning: failed to create check run for PR #{pr_number}: {proc.stderr or proc.stdout}")
 
           def create_session_api(prompt, session_name="", model="claude-opus-4-6"):
               """Create a new session or send message to existing one."""


### PR DESCRIPTION
<!-- acp:session_id=session-59da355d-1aa3-4de7-84ae-79ee7b5e2a5a source=#1201 last_action=2026-04-06T17:48:08Z retry_count=0 -->
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
<!-- acp:session_id=session-59da355d-1aa3-4de7-84ae-79ee7b5e2a5a source=#1201 last_action=2026-04-06T16:48:46Z retry_count=0 -->
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
<!-- acp:session_id=session-59da355d-1aa3-4de7-84ae-79ee7b5e2a5a source=#1201 last_action=2026-04-06T16:47:48Z retry_count=1 -->
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
<!-- acp:session_id=session-59da355d-1aa3-4de7-84ae-79ee7b5e2a5a source=#1201 last_action=2026-04-06T16:19:50Z retry_count=1 -->
## Summary

When Amber works on a PR, post a GitHub check run so the session shows up in the PR checks tab with a direct link to the session UI.

## Where it posts

- **`handle-comment` on PR**: After any `@ambient-code` comment triggers a fix/custom session
- **`batch-pr-fixer`**: After each PR is processed in the 30 min cron

## What it shows

- **Check name**: "Amber Session"
- **Conclusion**: success (Completed/Running), failure (Error/Failed), neutral (other)
- **Details URL**: Direct link to the session in Ambient UI
- **Summary**: Session name, phase, and prompt type

## Permissions

Added `checks: write` to workflow permissions.

## Test plan

- [ ] Comment `@ambient-code` on a PR — verify check appears in PR checks tab
- [ ] Click "Details" on the check — verify it opens the session URL
- [ ] Batch cron processes a PR — verify check appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts an "Amber Session" status check on pull requests to show session progress and outcome.
  * Sends Slack notifications for circuit-breaker events when a webhook is configured.

* **Behavior Changes**
  * Automated corrections must be explicitly logged for each fix to improve visibility.
  * Retry-count and circuit-breaker handling moved into session/frontmatter logic, triggering human review at the threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->