### PR TITLE
feat: add Gmail scopes and bump workspace-mcp to 1.17.1

### DIFF
--- a/components/backend/handlers/oauth.go
+++ b/components/backend/handlers/oauth.go
@@ -71,6 +71,12 @@ func getOAuthProvider(provider string) (*OAuthProvider, error) {
 				"https://www.googleapis.com/auth/drive",
 				"https://www.googleapis.com/auth/drive.readonly",
 				"https://www.googleapis.com/auth/drive.file",
+				// Gmail scopes for gmail:send permission level (cumulative in workspace-mcp)
+				// Includes: readonly, organize (labels+modify), drafts (compose), and send
+				"https://www.googleapis.com/auth/gmail.readonly",
+				"https://www.googleapis.com/auth/gmail.labels",
+				"https://www.googleapis.com/auth/gmail.modify",
+				"https://www.googleapis.com/auth/gmail.compose",
 				"https://www.googleapis.com/auth/gmail.send",
 			},
 		}, nil

--- a/components/runners/ambient-runner/.mcp.json
+++ b/components/runners/ambient-runner/.mcp.json
@@ -26,7 +26,7 @@
     "google-workspace": {
       "command": "uvx",
       "args": [
-        "workspace-mcp@1.14.2",
+        "workspace-mcp@1.17.1",
         "--permissions",
         "gmail:send",
         "drive:full"


### PR DESCRIPTION
## Summary
- Add missing Gmail OAuth scopes (`readonly`, `labels`, `modify`, `compose`) required by workspace-mcp's cumulative `gmail:send` permission level
- Bump `workspace-mcp` from `1.14.2` to `1.17.1`

**Root cause**: The Google OAuth flow only requested `gmail.send`, but workspace-mcp with `--permissions gmail:send` requires the full cumulative scope chain. This caused Google MCP connections to fail silently in sessions.

**Note**: Existing users will need to disconnect and reconnect Google from the Integrations page to pick up the new scopes.

## Test plan
- [ ] Disconnect Google from Integrations page
- [ ] Reconnect — verify OAuth consent screen shows Gmail permissions
- [ ] Create session and confirm Google Workspace MCP connects (both Drive and Gmail tools available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Gmail integration with additional authorization scopes for label management, read-only access, message composition, and modification capabilities.

* **Chores**
  * Updated Google Workspace integration to the latest version for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->