### PR TITLE
fix(control-plane): default BackendURL to AMBIENT_API_SERVER_URL

### DIFF
--- a/components/ambient-control-plane/internal/config/config.go
+++ b/components/ambient-control-plane/internal/config/config.go
@@ -57,7 +57,7 @@ func Load() (*ControlPlaneConfig, error) {
 		Reconcilers:           parseReconcilers(envOrDefault("RECONCILERS", "tally,kube")),
 		RunnerImage:           envOrDefault("RUNNER_IMAGE", "quay.io/ambient_code/vteam_claude_runner:latest"),
 		RunnerGRPCUseTLS:      os.Getenv("AMBIENT_GRPC_USE_TLS") == "true",
-		BackendURL:            envOrDefault("BACKEND_API_URL", "http://backend-service.ambient-code.svc:8080/api"),
+		BackendURL:            envOrDefault("BACKEND_API_URL", envOrDefault("AMBIENT_API_SERVER_URL", "http://localhost:8000")),
 		Namespace:             envOrDefault("NAMESPACE", "ambient-code"),
 		AnthropicAPIKey:       os.Getenv("ANTHROPIC_API_KEY"),
 		VertexEnabled:         os.Getenv("USE_VERTEX") == "1" || os.Getenv("USE_VERTEX") == "true",


### PR DESCRIPTION
## Summary

The `BackendURL` config field defaulted to `http://backend-service.ambient-code.svc:8080/api` — a legacy service that no longer exists. Runner pods need `BACKEND_API_URL` set to call `GET /credentials/{id}/token`. Since `AMBIENT_API_SERVER_URL` is already set in all deployments, default `BackendURL` to it.

Discovered during E2E testing of the credential flow on OSD `ambient-s0`: runner logs showed DNS failures fetching credentials from the old backend URL.

## Test plan

- [ ] Runner pod logs show `Successfully fetched github credentials from backend` instead of DNS failure on `backend-service.ambient-code.svc`
- [ ] Agent can retrieve GitHub token via `/credentials/{id}/token` and use it

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Backend URL configuration now uses environment variable fallback logic (`BACKEND_API_URL` → `AMBIENT_API_SERVER_URL` → default to `http://localhost:8000`), enabling more flexible configuration across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->