### PR TITLE
fix(runner): allow short-form .svc DNS in credential fetch allowlist

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/platform/auth.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/auth.py
@@ -122,6 +122,7 @@ async def _fetch_credential(context: RunnerContext, credential_type: str) -> dic
     parsed = urlparse(base)
     if parsed.hostname and not (
         parsed.hostname.endswith(".svc.cluster.local")
+        or parsed.hostname.endswith(".svc")
         or parsed.hostname == "localhost"
         or parsed.hostname == "127.0.0.1"
     ):


### PR DESCRIPTION
# Human Edit 

The MPP service is `ambient-api-server.ambient-code--ambient-s0.svc`, so the change to the runner makes sense.

## Summary

- The runner's cluster-local security check for `BACKEND_API_URL` only allowed `.svc.cluster.local` hostnames
- OSD deployments set `AMBIENT_API_SERVER_URL` (and thus `BACKEND_API_URL`) using short-form DNS: `ambient-api-server.ambient-code--<ns>.svc:8000`
- Short-form `.svc` DNS resolves only within the cluster — equivalent to `.svc.cluster.local` for security purposes
- All credential fetches were silently rejected with `Refusing to send credentials to external host`

## Test plan

- [ ] Deploy new runner image to OSD `ambient-s0`
- [ ] Start agent session in `credential-test` project
- [ ] Verify runner logs show `Fetching fresh github credentials from: http://ambient-api-server.ambient-code--ambient-s0.svc:8000/api/ambient/v1/credentials/{id}/token`
- [ ] Verify `Successfully fetched github credentials from backend`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Kubernetes service DNS names ending in `.svc` were incorrectly treated as external hosts, preventing credential transmission. These hostnames are now properly recognized as internal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->