### PR TITLE
fix(control-plane): refresh runner tokens immediately on startup

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -904,6 +904,7 @@ func (r *SimpleKubeReconciler) refreshRunnerToken(ctx context.Context, namespace
 
 func (r *SimpleKubeReconciler) StartTokenRefreshLoop(ctx context.Context) {
 	go func() {
+		r.refreshAllRunningTokens(ctx)
 		ticker := time.NewTicker(runnerTokenRefreshEvery)
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
## Summary

- The token refresh loop fires every 10 minutes via a ticker
- If the control-plane restarts while sessions are running, the ticker resets and won't fire for another 10 minutes
- OIDC BOT_TOKENs have a ~15 min TTL — a runner pod started near end-of-token-life can expire before the first post-restart tick
- Fix: call `refreshAllRunningTokens` once immediately on goroutine start before entering the ticker loop

## Test plan

- [ ] Restart control-plane while a session is running
- [ ] Verify "runner token refreshed" log appears within seconds of pod start
- [ ] Verify runner does not get UNAUTHENTICATED on gRPC after control-plane restart

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token refresh now triggers immediately upon startup before entering periodic refresh cycles, improving responsiveness.
  * Token refresh scope expanded to include all projects, ensuring tokens are refreshed across the entire system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->