### PR TITLE
feat(custom-agents): add filesystem-based loading of Claude subagents from .claude/agents/*.md

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/agents.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/agents.py
@@ -27,7 +27,10 @@ def _parse_agent_file(file_path: Path) -> tuple[dict[str, str], str]:
     try:
         content = file_path.read_text(encoding="utf-8")
     except OSError:
-        return {}, ""
+        logger.warning("Cannot read agent file %s", file_path.name, exc_info=True)
+        raise
+
+    content = content.replace("\r\n", "\n")
 
     if not content.startswith("---\n"):
         return {}, content

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/agents.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/agents.py
@@ -116,11 +116,7 @@ def load_agents_from_directory(agents_dir: str) -> dict[str, AgentDefinition]:
             logger.info("Loaded custom agent '%s' from %s", name, md_file.name)
 
         except Exception:
-            logger.warning(
-                "Failed to load agent from %s", md_file.name, exc_info=True
-            )
+            logger.warning("Failed to load agent from %s", md_file.name, exc_info=True)
 
-    logger.info(
-        "Loaded %d custom agent(s) from %s", len(agents), agents_dir
-    )
+    logger.info("Loaded %d custom agent(s) from %s", len(agents), agents_dir)
     return agents

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/agents.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/agents.py
@@ -1,0 +1,126 @@
+"""Load custom agent definitions from .claude/agents/*.md files.
+
+Scans markdown files with YAML-style frontmatter and converts them to
+``AgentDefinition`` objects that the Claude Agent SDK can dispatch as
+custom subagent types.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from claude_agent_sdk import AgentDefinition
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_agent_file(file_path: Path) -> tuple[dict[str, str], str]:
+    """Parse frontmatter key-value pairs and body from a markdown file.
+
+    Uses the same manual ``key: value`` parsing approach as
+    ``ambient_runner.endpoints.content._parse_frontmatter`` to avoid
+    adding a ``pyyaml`` dependency.
+
+    Returns:
+        A tuple of (frontmatter dict, body text after closing ``---``).
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError:
+        return {}, ""
+
+    if not content.startswith("---\n"):
+        return {}, content
+
+    end_idx = content.find("\n---", 4)
+    if end_idx == -1:
+        return {}, content
+
+    frontmatter_raw = content[4:end_idx]
+    body = content[end_idx + 4 :].strip()  # skip past "\n---"
+
+    metadata: dict[str, str] = {}
+    for line in frontmatter_raw.split("\n"):
+        if not line.strip():
+            continue
+        parts = line.split(":", 1)
+        if len(parts) == 2:
+            key = parts[0].strip()
+            value = parts[1].strip().strip("\"'")
+            metadata[key] = value
+
+    return metadata, body
+
+
+def _parse_string_list(value: Any) -> list[str] | None:
+    """Parse a comma-separated string into a list of stripped strings.
+
+    Returns ``None`` when *value* is falsy so that ``AgentDefinition``
+    falls back to its default (inherit parent tools).
+    """
+    if not value:
+        return None
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if isinstance(value, str):
+        items = [v.strip() for v in value.split(",") if v.strip()]
+        return items if items else None
+    return None
+
+
+def load_agents_from_directory(agents_dir: str) -> dict[str, AgentDefinition]:
+    """Load ``AgentDefinition`` objects from ``.claude/agents/*.md`` files.
+
+    Each markdown file is expected to have YAML-style frontmatter
+    (``---`` delimited) followed by a body that becomes the agent's
+    prompt.  Recognised frontmatter keys:
+
+    * ``name`` – agent name (falls back to the filename stem)
+    * ``description`` – when to use this agent (falls back to
+      ``"Agent: {name}"``)
+    * ``tools`` – comma-separated list of tool names
+    * ``model`` – model alias or full model ID
+    * ``skills`` – comma-separated list of skill names
+
+    Args:
+        agents_dir: Absolute path to the ``.claude/agents`` directory.
+
+    Returns:
+        Mapping of agent name → ``AgentDefinition``.  Empty dict when
+        the directory does not exist or contains no valid agents.
+    """
+    agents: dict[str, AgentDefinition] = {}
+    agents_path = Path(agents_dir)
+
+    if not agents_path.is_dir():
+        logger.debug("No agents directory at %s", agents_dir)
+        return agents
+
+    for md_file in sorted(agents_path.glob("*.md")):
+        try:
+            metadata, body = _parse_agent_file(md_file)
+
+            name = metadata.get("name", md_file.stem)
+            description = metadata.get("description", f"Agent: {name}")
+            tools = _parse_string_list(metadata.get("tools"))
+            skills = _parse_string_list(metadata.get("skills"))
+            model = metadata.get("model")
+
+            agents[name] = AgentDefinition(
+                description=description,
+                prompt=body,
+                tools=tools,
+                model=model,
+                skills=skills,
+            )
+            logger.info("Loaded custom agent '%s' from %s", name, md_file.name)
+
+        except Exception:
+            logger.warning(
+                "Failed to load agent from %s", md_file.name, exc_info=True
+            )
+
+    logger.info(
+        "Loaded %d custom agent(s) from %s", len(agents), agents_dir
+    )
+    return agents

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
@@ -538,6 +538,12 @@ class ClaudeBridge(PlatformBridge):
         if add_dirs:
             os.environ["CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD"] = "1"
 
+        # Custom agents from .claude/agents/*.md
+        from ambient_runner.bridges.claude.agents import load_agents_from_directory
+
+        agents_dir = os.path.join(cwd_path, ".claude", "agents")
+        custom_agents = load_agents_from_directory(agents_dir)
+
         # Observability (shared helper, before MCP so rubric tool can access it)
         self._obs = await setup_bridge_observability(self._context, configured_model)
 
@@ -561,6 +567,7 @@ class ClaudeBridge(PlatformBridge):
         self._configured_model = configured_model
         self._cwd_path = cwd_path
         self._add_dirs = add_dirs
+        self._custom_agents = custom_agents
         self._mcp_servers = mcp_servers
         self._allowed_tools = allowed_tools
         self._system_prompt = system_prompt
@@ -615,6 +622,8 @@ class ClaudeBridge(PlatformBridge):
             options["add_dirs"] = self._add_dirs
         if self._configured_model:
             options["model"] = self._configured_model
+        if self._custom_agents:
+            options["agents"] = self._custom_agents
 
         adapter = ClaudeAgentAdapter(
             name="claude_code_runner",

--- a/components/runners/ambient-runner/tests/test_custom_agents.py
+++ b/components/runners/ambient-runner/tests/test_custom_agents.py
@@ -1,0 +1,287 @@
+"""Unit tests for custom agent loading from .claude/agents/*.md files."""
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ambient_runner.bridges.claude.agents import (
+    _parse_agent_file,
+    _parse_string_list,
+    load_agents_from_directory,
+)
+
+
+# ------------------------------------------------------------------
+# _parse_agent_file
+# ------------------------------------------------------------------
+
+
+class TestParseAgentFile:
+    """Verify frontmatter + body extraction from markdown files."""
+
+    def test_valid_frontmatter_and_body(self, tmp_path: Path):
+        md = tmp_path / "agent.md"
+        md.write_text(
+            textwrap.dedent("""\
+                ---
+                name: test-agent
+                description: A test agent
+                tools: Read, Write, Bash
+                model: sonnet
+                ---
+
+                You are a helpful test agent.
+            """)
+        )
+
+        metadata, body = _parse_agent_file(md)
+
+        assert metadata["name"] == "test-agent"
+        assert metadata["description"] == "A test agent"
+        assert metadata["tools"] == "Read, Write, Bash"
+        assert metadata["model"] == "sonnet"
+        assert body == "You are a helpful test agent."
+
+    def test_no_frontmatter(self, tmp_path: Path):
+        md = tmp_path / "plain.md"
+        md.write_text("Just a plain markdown file.\n")
+
+        metadata, body = _parse_agent_file(md)
+
+        assert metadata == {}
+        assert body == "Just a plain markdown file."
+
+    def test_empty_file(self, tmp_path: Path):
+        md = tmp_path / "empty.md"
+        md.write_text("")
+
+        metadata, body = _parse_agent_file(md)
+
+        assert metadata == {}
+        assert body == ""
+
+    def test_frontmatter_only_no_body(self, tmp_path: Path):
+        md = tmp_path / "no-body.md"
+        md.write_text("---\nname: solo\n---\n")
+
+        metadata, body = _parse_agent_file(md)
+
+        assert metadata["name"] == "solo"
+        assert body == ""
+
+    def test_missing_file(self, tmp_path: Path):
+        md = tmp_path / "nonexistent.md"
+
+        metadata, body = _parse_agent_file(md)
+
+        assert metadata == {}
+        assert body == ""
+
+    def test_quoted_values_stripped(self, tmp_path: Path):
+        md = tmp_path / "quoted.md"
+        md.write_text('---\nname: "my-agent"\ndescription: \'does things\'\n---\nBody.\n')
+
+        metadata, body = _parse_agent_file(md)
+
+        assert metadata["name"] == "my-agent"
+        assert metadata["description"] == "does things"
+
+    def test_multiline_body(self, tmp_path: Path):
+        md = tmp_path / "multi.md"
+        md.write_text("---\nname: multi\n---\nLine one.\n\nLine two.\n")
+
+        metadata, body = _parse_agent_file(md)
+
+        assert metadata["name"] == "multi"
+        assert "Line one." in body
+        assert "Line two." in body
+
+
+# ------------------------------------------------------------------
+# _parse_string_list
+# ------------------------------------------------------------------
+
+
+class TestParseStringList:
+    """Verify comma-separated string → list conversion."""
+
+    def test_comma_separated(self):
+        assert _parse_string_list("Read, Write, Bash") == ["Read", "Write", "Bash"]
+
+    def test_single_item(self):
+        assert _parse_string_list("Read") == ["Read"]
+
+    def test_none_returns_none(self):
+        assert _parse_string_list(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_string_list("") is None
+
+    def test_list_passthrough(self):
+        assert _parse_string_list(["Read", "Write"]) == ["Read", "Write"]
+
+    def test_whitespace_trimmed(self):
+        assert _parse_string_list("  Read ,  Write  ") == ["Read", "Write"]
+
+    def test_empty_items_filtered(self):
+        assert _parse_string_list("Read,,Write,") == ["Read", "Write"]
+
+
+# ------------------------------------------------------------------
+# load_agents_from_directory
+# ------------------------------------------------------------------
+
+
+class TestLoadAgentsFromDirectory:
+    """Verify end-to-end agent loading from a directory of .md files."""
+
+    def _write_agent(self, agents_dir: Path, filename: str, content: str) -> None:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / filename).write_text(textwrap.dedent(content))
+
+    @patch("ambient_runner.bridges.claude.agents.AgentDefinition")
+    def test_loads_multiple_agents(self, mock_agent_def, tmp_path: Path):
+        agents_dir = tmp_path / "agents"
+        self._write_agent(
+            agents_dir,
+            "researcher.md",
+            """\
+            ---
+            name: researcher
+            description: Research agent for web lookups
+            tools: Read, WebSearch, WebFetch
+            model: sonnet
+            ---
+
+            You are a research assistant.
+            """,
+        )
+        self._write_agent(
+            agents_dir,
+            "writer.md",
+            """\
+            ---
+            name: docs-writer
+            description: Technical documentation writer
+            tools: Read, Write, Edit
+            skills: vale-lint
+            ---
+
+            You write documentation.
+            """,
+        )
+
+        result = load_agents_from_directory(str(agents_dir))
+
+        assert mock_agent_def.call_count == 2
+
+        # Verify researcher call
+        researcher_call = mock_agent_def.call_args_list[0]
+        assert researcher_call.kwargs["description"] == "Research agent for web lookups"
+        assert researcher_call.kwargs["prompt"] == "You are a research assistant."
+        assert researcher_call.kwargs["tools"] == ["Read", "WebSearch", "WebFetch"]
+        assert researcher_call.kwargs["model"] == "sonnet"
+        assert researcher_call.kwargs["skills"] is None
+
+        # Verify writer call
+        writer_call = mock_agent_def.call_args_list[1]
+        assert writer_call.kwargs["description"] == "Technical documentation writer"
+        assert writer_call.kwargs["prompt"] == "You write documentation."
+        assert writer_call.kwargs["tools"] == ["Read", "Write", "Edit"]
+        assert writer_call.kwargs["skills"] == ["vale-lint"]
+
+        assert "researcher" in result
+        assert "docs-writer" in result
+
+    @patch("ambient_runner.bridges.claude.agents.AgentDefinition")
+    def test_fallback_name_from_filename(self, mock_agent_def, tmp_path: Path):
+        agents_dir = tmp_path / "agents"
+        self._write_agent(
+            agents_dir,
+            "my-agent.md",
+            """\
+            ---
+            description: An agent without a name field
+            ---
+
+            Do things.
+            """,
+        )
+
+        result = load_agents_from_directory(str(agents_dir))
+
+        assert "my-agent" in result
+        assert mock_agent_def.call_args.kwargs["description"] == "An agent without a name field"
+
+    @patch("ambient_runner.bridges.claude.agents.AgentDefinition")
+    def test_fallback_description(self, mock_agent_def, tmp_path: Path):
+        agents_dir = tmp_path / "agents"
+        self._write_agent(
+            agents_dir,
+            "bare.md",
+            """\
+            ---
+            name: bare-agent
+            ---
+
+            Minimal agent.
+            """,
+        )
+
+        result = load_agents_from_directory(str(agents_dir))
+
+        assert mock_agent_def.call_args.kwargs["description"] == "Agent: bare-agent"
+
+    def test_nonexistent_directory_returns_empty(self, tmp_path: Path):
+        result = load_agents_from_directory(str(tmp_path / "does-not-exist"))
+        assert result == {}
+
+    def test_empty_directory_returns_empty(self, tmp_path: Path):
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+
+        result = load_agents_from_directory(str(agents_dir))
+        assert result == {}
+
+    @patch("ambient_runner.bridges.claude.agents.AgentDefinition")
+    def test_ignores_non_md_files(self, mock_agent_def, tmp_path: Path):
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "readme.txt").write_text("Not an agent.")
+        self._write_agent(
+            agents_dir,
+            "real.md",
+            """\
+            ---
+            name: real
+            description: A real agent
+            ---
+
+            Hello.
+            """,
+        )
+
+        result = load_agents_from_directory(str(agents_dir))
+
+        assert len(result) == 1
+        assert "real" in result
+
+    @patch("ambient_runner.bridges.claude.agents.AgentDefinition", side_effect=Exception("boom"))
+    def test_bad_file_logged_and_skipped(self, mock_agent_def, tmp_path: Path):
+        agents_dir = tmp_path / "agents"
+        self._write_agent(
+            agents_dir,
+            "bad.md",
+            """\
+            ---
+            name: bad-agent
+            ---
+
+            Will fail.
+            """,
+        )
+
+        result = load_agents_from_directory(str(agents_dir))
+        assert result == {}

--- a/components/runners/ambient-runner/tests/test_custom_agents.py
+++ b/components/runners/ambient-runner/tests/test_custom_agents.py
@@ -4,8 +4,6 @@ import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from ambient_runner.bridges.claude.agents import (
     _parse_agent_file,
     _parse_string_list,
@@ -81,7 +79,9 @@ class TestParseAgentFile:
 
     def test_quoted_values_stripped(self, tmp_path: Path):
         md = tmp_path / "quoted.md"
-        md.write_text('---\nname: "my-agent"\ndescription: \'does things\'\n---\nBody.\n')
+        md.write_text(
+            "---\nname: \"my-agent\"\ndescription: 'does things'\n---\nBody.\n"
+        )
 
         metadata, body = _parse_agent_file(md)
 
@@ -213,7 +213,10 @@ class TestLoadAgentsFromDirectory:
         result = load_agents_from_directory(str(agents_dir))
 
         assert "my-agent" in result
-        assert mock_agent_def.call_args.kwargs["description"] == "An agent without a name field"
+        assert (
+            mock_agent_def.call_args.kwargs["description"]
+            == "An agent without a name field"
+        )
 
     @patch("ambient_runner.bridges.claude.agents.AgentDefinition")
     def test_fallback_description(self, mock_agent_def, tmp_path: Path):
@@ -230,7 +233,7 @@ class TestLoadAgentsFromDirectory:
             """,
         )
 
-        result = load_agents_from_directory(str(agents_dir))
+        load_agents_from_directory(str(agents_dir))
 
         assert mock_agent_def.call_args.kwargs["description"] == "Agent: bare-agent"
 
@@ -268,7 +271,10 @@ class TestLoadAgentsFromDirectory:
         assert len(result) == 1
         assert "real" in result
 
-    @patch("ambient_runner.bridges.claude.agents.AgentDefinition", side_effect=Exception("boom"))
+    @patch(
+        "ambient_runner.bridges.claude.agents.AgentDefinition",
+        side_effect=Exception("boom"),
+    )
     def test_bad_file_logged_and_skipped(self, mock_agent_def, tmp_path: Path):
         agents_dir = tmp_path / "agents"
         self._write_agent(


### PR DESCRIPTION
  ## Summary                                                                                                                                           
                                                                                                                                                       
  ACP sessions can only dispatch the 4 built-in agent types (`general-purpose`, `Explore`, `Plan`, `statusline-setup`). Custom agents defined as `.claude/agents/*.md` files in a project's repo are ignored because the runner never loads them into the SDK — even though `ClaudeAgentOptions.agents` supports exactly this via `dict[str, AgentDefinition]`.                                                                  
                                                            
This PR adds filesystem-based custom agent loading to the Claude bridge so that `.claude/agents/*.md` files are parsed at session startup and passed to the SDK as registered subagent types.
                                                                                                                                                       
  ## Changes                                                

  - **New `agents.py` module** — scans `.claude/agents/*.md`, parses frontmatter (`name`, `description`, `tools`, `model`, `skills`) and markdown body 
  (`prompt`), returns `dict[str, AgentDefinition]`
  - **`bridge.py`** — loads custom agents in `_setup_platform()` after workspace path resolution, passes them via `options["agents"]` in               
  `_ensure_adapter()`                                                                                                                                  
  - **17 unit tests** covering frontmatter parsing, string list conversion, directory loading, fallback defaults, and error handling
                                                                                                                                                       
  ## Rationale                                              
                                                                                                                                                       
The `.claude/agents/` filesystem loading is a Claude Code CLI feature — the CLI reads those files and converts them to `AgentDefinition` objects before passing them to the SDK. The ACP runner never did this conversion. The runner already parses these files for the workflow metadata endpoint (`content.py`), but only to surface names to the frontend UI — it never constructed SDK `AgentDefinition` objects for actual session dispatch.       
                                                            
The `build_options()` method in `adapter.py` already merges the full options dict into `ClaudeAgentOptions(**merged_kwargs)`, so adding `"agents"` to the dict passes through to the SDK with no adapter changes needed.
                                                                                                                                                       
  ## Testing                                                

  - [ ] `cd components/runners/ambient-runner && python -m pytest tests/test_custom_agents.py -v`                                                      
  - [ ] Existing runner tests still pass
  - [ ] Deploy to dev cluster with a project containing `.claude/agents/*.md` files                                                                    
  - [ ] Verify `Agent(subagent_type="<custom-agent-name>")` dispatches successfully                                                                    
  - [ ] Check runner logs for `"Loaded N custom agent(s)"` messages                                                                                    
                                                                                                                                                       
  ## Notes                                                                                                                                             
                                                                                                                                                       
  - No new dependencies — uses the same manual frontmatter parsing as `content.py` (no pyyaml)                                                         
  - `AgentDefinition` is from the existing `claude-agent-sdk>=0.1.50` dependency
  - Known SDK caveat: [anthropics/claude-agent-sdk-python#322](https://github.com/anthropics/claude-agent-sdk-python/issues/322) — custom agents are   
  silently dropped when combined system prompt + agent definitions exceed an undocumented token limit. This is tracked upstream. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for workspace-local custom Claude agents via markdown files in a `.claude/agents` directory. Agent metadata (name, description, model, tools, skills) and prompt body are parsed, with sensible fallbacks when fields are missing.
  * Loader skips invalid files and returns an empty set when no directory exists.

* **Tests**
  * Added unit tests covering parsing, list handling, fallbacks, and resilient loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->