### PR TITLE
fix(manifests): add CP token Service and wire CP_RUNTIME_NAMESPACE + CP_TOKEN_URL

### DIFF
--- a/components/manifests/overlays/mpp-openshift/ambient-control-plane-svc.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-control-plane-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ambient-control-plane
+  namespace: ambient-code--runtime-int
+  labels:
+    app: ambient-control-plane
+spec:
+  selector:
+    app: ambient-control-plane
+  ports:
+    - name: token
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/components/manifests/overlays/mpp-openshift/ambient-control-plane.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-control-plane.yaml
@@ -76,6 +76,12 @@ spec:
               value: "ambient-vertex"
             - name: VERTEX_SECRET_NAMESPACE
               value: "ambient-code--runtime-int"
+            - name: CP_RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CP_TOKEN_URL
+              value: "http://ambient-control-plane.ambient-code--ambient-s0.svc:8080/token"
           volumeMounts:
             - name: project-kube-token
               mountPath: /var/run/secrets/project-kube

--- a/components/manifests/overlays/mpp-openshift/kustomization.yaml
+++ b/components/manifests/overlays/mpp-openshift/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ambient-api-server-db.yaml
 - ambient-api-server.yaml
 - ambient-control-plane.yaml
+- ambient-control-plane-svc.yaml
 - ambient-api-server-route.yaml
 - ambient-control-plane-sa.yaml
 - tenant-rbac/


### PR DESCRIPTION
## Summary

Follow-up to #1213. The CP token endpoint was running but unreachable because:

1. **No Service** — port 8080 (token server) had no ClusterIP Service, so runner pods had no DNS target and the NetworkPolicy peer had no stable reference
2. **Wrong `CP_RUNTIME_NAMESPACE`** — defaulted to `ambient-code--runtime-int` but the actual deployed namespace is `ambient-code--ambient-s0`, so `ensureAPIServerNetworkPolicy()` was creating a NetworkPolicy that matched the wrong namespace selector — causing `acpctl session events` to still 502

## Changes

- `ambient-control-plane-svc.yaml` — new ClusterIP Service exposing port 8080 on the CP pod
- `ambient-control-plane.yaml` — inject `CP_RUNTIME_NAMESPACE` via downward API (`metadata.namespace`) so the NetworkPolicy peer label matches the actual runtime namespace; set `CP_TOKEN_URL` to the FQDN of the new Service

## Test plan

- [ ] Deploy to int spoke
- [ ] Verify `oc get svc ambient-control-plane -n ambient-code--ambient-s0` exists with port 8080
- [ ] Start new session; verify `allow-ambient-api-server` NetworkPolicy in session namespace uses correct namespace selector (`ambient-code--ambient-s0`)
- [ ] `acpctl session events <id>` streams without 502

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ambient control plane service with token authentication capability
  * Configured control plane to integrate with token service endpoint for runtime authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->