### PR TITLE
fix(manifests): add NetworkPolicy allowing runner pods to reach CP token server

### DIFF
--- a/components/manifests/overlays/mpp-openshift/ambient-cp-token-netpol.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-cp-token-netpol.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-runner-token-fetch
+  namespace: ambient-code--runtime-int
+  labels:
+    app: ambient-control-plane
+spec:
+  podSelector:
+    matchLabels:
+      app: ambient-control-plane
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          tenant.paas.redhat.com/tenant: ambient-code
+    ports:
+    - protocol: TCP
+      port: 8080
+  policyTypes:
+  - Ingress

--- a/components/manifests/overlays/mpp-openshift/kustomization.yaml
+++ b/components/manifests/overlays/mpp-openshift/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ambient-api-server.yaml
 - ambient-control-plane.yaml
 - ambient-control-plane-svc.yaml
+- ambient-cp-token-netpol.yaml
 - ambient-api-server-route.yaml
 - ambient-control-plane-sa.yaml
 - tenant-rbac/


### PR DESCRIPTION
## Summary

- Adds `ambient-cp-token-netpol.yaml`: NetworkPolicy in the CP namespace allowing runner pods (any namespace with `tenant.paas.redhat.com/tenant: ambient-code`) to call the CP token server on port 8080
- Namespace placeholder is `ambient-code--runtime-int`; actual spoke namespace is patched by the GitOps config repo

## Context

Runner pods were crashing with `CP token endpoint unreachable after 3 attempts` because the `internal-1` NetworkPolicy in the CP namespace blocks cross-namespace ingress by default. This NetworkPolicy was applied manually as a hotfix and this PR adds it to the manifests.

## Test plan

- [ ] Deploy to spoke and confirm runner pods can reach `CP_TOKEN_URL` on startup
- [ ] Confirm `acpctl session events $id` streams without 502

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Implemented network security policies for control plane components to enforce strict access controls, restricting inbound traffic to authorized namespaces on designated ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->