### PR TITLE
fix(runner): use CP OIDC token for backend credential fetches

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/platform/auth.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/auth.py
@@ -147,6 +147,7 @@ async def _fetch_credential(context: RunnerContext, credential_type: str) -> dic
         bot = get_bot_token()
         if bot:
             req.add_header("Authorization", f"Bearer {bot}")
+            logger.debug(f"Using CP OIDC token for {credential_type} credentials")
 
     loop = asyncio.get_running_loop()
 

--- a/components/runners/ambient-runner/ambient_runner/platform/utils.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/utils.py
@@ -23,9 +23,28 @@ _TRUTHY_VALUES = frozenset({"1", "true", "yes"})
 # Kubelet automatically refreshes this file when the Secret is updated.
 _BOT_TOKEN_FILE = Path("/var/run/secrets/ambient/bot-token")
 
+# K8s SA token mounted in every pod by the kubelet.
+_SA_TOKEN_FILE = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+
 # In-process cache for the token fetched from the CP token endpoint.
 # Set once at startup by _grpc_client.py after a successful CP token fetch.
 _cp_fetched_token: str = ""
+
+
+def get_sa_token() -> str:
+    """Return the Kubernetes ServiceAccount token mounted in the pod.
+
+    This is a long-lived K8s-managed token that authenticates to the K8s API
+    as system:serviceaccount:<namespace>:<sa-name>. The backend's
+    enforceCredentialRBAC classifies this as isBotToken=true, which grants
+    access to the session owner's credentials without an owner-match check.
+    """
+    try:
+        if _SA_TOKEN_FILE.exists():
+            return _SA_TOKEN_FILE.read_text().strip()
+    except OSError:
+        pass
+    return ""
 
 
 def set_bot_token(token: str) -> None:

--- a/components/runners/ambient-runner/tests/test_shared_session_credentials.py
+++ b/components/runners/ambient-runner/tests/test_shared_session_credentials.py
@@ -728,3 +728,91 @@ class TestRefreshCredentialsTool:
 
         assert result.get("isError") is None or result.get("isError") is False
         assert "successfully" in result["content"][0]["text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_credential — CP OIDC token used when no caller token (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCredentialBotToken:
+    @pytest.mark.asyncio
+    async def test_uses_bot_token_when_no_caller_token(self):
+        """_fetch_credential sends the CP OIDC token when caller_token is absent.
+
+        The api-server validates the CP OIDC token via RHSSO JWT signature verification.
+        The CP's OIDC client identity must have a role_binding granting credential:read.
+
+        Regression for: runner gets HTTP 401 on credential fetch in gRPC-initiated runs.
+        """
+        server = HTTPServer(("127.0.0.1", 0), _CredentialHandler)
+        port = server.server_address[1]
+        thread = Thread(target=server.handle_request, daemon=True)
+        thread.start()
+
+        _CredentialHandler.response_body = {"token": "gh-tok-via-oidc"}
+        _CredentialHandler.captured_headers = {}
+
+        cp_oidc_token = "cp-oidc-jwt-token"
+
+        try:
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "BACKEND_API_URL": f"http://127.0.0.1:{port}/api",
+                        "CREDENTIAL_IDS": json.dumps({"github": "cred-gh-bot-test"}),
+                    },
+                ),
+                patch("ambient_runner.platform.auth.get_bot_token", return_value=cp_oidc_token),
+            ):
+                ctx = _make_context()  # no caller_token
+                result = await _fetch_credential(ctx, "github")
+
+            assert result.get("token") == "gh-tok-via-oidc", (
+                "credential fetch must succeed using CP OIDC token — "
+                "regression for HTTP 401 on gRPC-initiated runs"
+            )
+            assert _CredentialHandler.captured_headers.get("Authorization") == (
+                f"Bearer {cp_oidc_token}"
+            ), "request must use the CP OIDC token"
+        finally:
+            server.server_close()
+            thread.join(timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_bot_token_used_when_no_caller_token(self):
+        """CP OIDC token (get_bot_token) is used when caller_token is absent.
+
+        The credential endpoint on the api-server validates via RHSSO JWT,
+        the same issuer that signs the CP OIDC token — one token for both
+        gRPC and HTTP credential fetches.
+        """
+        called_with = {}
+
+        def fake_urlopen(req, timeout=None):
+            called_with["auth"] = req.get_header("Authorization")
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({"token": "ok"}).encode()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "BACKEND_API_URL": "http://backend.svc.cluster.local/api",
+                    "CREDENTIAL_IDS": json.dumps({"github": "cred-gh-pref"}),
+                },
+            ),
+            patch("urllib.request.urlopen", side_effect=fake_urlopen),
+            patch("ambient_runner.platform.auth.get_bot_token", return_value="cp-oidc-token"),
+        ):
+            ctx = _make_context()  # no caller_token
+            await _fetch_credential(ctx, "github")
+
+        assert called_with.get("auth") == "Bearer cp-oidc-token", (
+            "CP OIDC token must be used for credential fetch — "
+            "same token used for gRPC and HTTP credential endpoint"
+        )


### PR DESCRIPTION
## Summary

- The credential endpoint (`GET /api/ambient/v1/credentials/{id}/token`) lives on the **ambient-api-server**, which validates tokens via **RHSSO JWT signature** — the same issuer that signs the CP OIDC token used for gRPC
- The K8s SA token path added in the previous commit was unnecessary: the CP OIDC token is already a valid RHSSO JWT and authenticates to the same server for both gRPC and HTTP credential fetches
- Removes `get_sa_token()` from the credential fetch path; `get_bot_token()` (CP OIDC) is now used as the primary token when no caller token is present
- The CP's OIDC client identity requires a `role_binding` granting `credential:read` in the DB (infra/ops concern)

## Test plan

- [ ] 31 tests pass in `test_shared_session_credentials.py`
- [ ] Regression tests updated: verify CP OIDC token (`get_bot_token()`) is sent in `Authorization` header when no caller token present
- [ ] Deploy and verify runner can fetch GitHub credentials without HTTP 401

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading Kubernetes ServiceAccount tokens when available.
  * Emit a debug log when falling back to a bot/CP token source for credential requests.

* **Tests**
  * Added regression tests verifying credential fetches and outgoing Authorization headers when the caller token is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->