### PR TITLE
fix(runner): use unbounded SSE tap queue

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/app.py
+++ b/components/runners/ambient-runner/ambient_runner/app.py
@@ -150,7 +150,7 @@ def create_ambient_app(
             # This closes the race between listener.ready and the first event fan-out.
             active_streams = getattr(bridge, "_active_streams", None)
             if active_streams is not None and session_id not in active_streams:
-                active_streams[session_id] = asyncio.Queue(maxsize=100)
+                active_streams[session_id] = asyncio.Queue()
                 logger.info("Pre-registered SSE queue for session=%s", session_id)
 
         # Auto-execute prompts when present (skipped only for resumes,

--- a/components/runners/ambient-runner/ambient_runner/endpoints/events.py
+++ b/components/runners/ambient-runner/ambient_runner/endpoints/events.py
@@ -69,7 +69,7 @@ async def get_events(thread_id: str, request: Request):
         )
         queue: asyncio.Queue = existing
     else:
-        queue = asyncio.Queue(maxsize=100)
+        queue = asyncio.Queue()
         active_streams[thread_id] = queue
         logger.info(
             "[SSE TAP] Queue registered: thread=%s (active_streams count=%d)",


### PR DESCRIPTION
## Summary

- SSE tap queues were bounded at `maxsize=100`, causing silent event drops when no consumer was connected (CLI sessions, background agent runs, slow frontends)
- Each queue is ephemeral — created per session, drained or GC'd when the run ends — so unbounded buffering is safe
- Worst case: transient memory growth during a long Claude turn with no SSE consumer; acceptable within the 4Gi pod memory limit

## Test plan

- [ ] Start a session via CLI (no SSE consumer) and verify no "SSE tap queue full" warnings in runner logs
- [ ] Confirm session messages are delivered correctly end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of real-time event streaming by removing queue capacity limitations, preventing potential event loss during high-volume scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->