### PR TITLE
feat: add e2e tests for scheduled sessions and fix edit form workflow state

### DIFF
--- a/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
+++ b/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
@@ -93,6 +93,7 @@ type ScheduledSessionFormProps = {
   initialData?: ScheduledSession;
 };
 
+/** Maps a cron string to a preset select value, falling back to "custom". */
 function resolveSchedulePreset(schedule: string): { preset: string; customCron: string } {
   const match = SCHEDULE_PRESETS.find((p) => p.value !== "custom" && p.value === schedule);
   if (match) {
@@ -101,6 +102,7 @@ function resolveSchedulePreset(schedule: string): { preset: string; customCron: 
   return { preset: "custom", customCron: schedule };
 }
 
+/** Reverse-matches stored workflow fields against OOTB workflows, returning the select value and custom fields. */
 function resolveWorkflowState(
   activeWorkflow: WorkflowSelection | undefined,
   ootbWorkflows: { id: string; gitUrl: string; branch: string; path?: string }[]

--- a/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
+++ b/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
@@ -101,28 +101,6 @@ function resolveSchedulePreset(schedule: string): { preset: string; customCron: 
   return { preset: "custom", customCron: schedule };
 }
 
-function resolveWorkflowState(
-  activeWorkflow: WorkflowSelection | undefined,
-  ootbWorkflows: { id: string; gitUrl: string; branch: string; path?: string }[]
-): { selectedWorkflow: string; customGitUrl: string; customBranch: string; customPath: string } {
-  if (!activeWorkflow) {
-    return { selectedWorkflow: "none", customGitUrl: "", customBranch: "main", customPath: "" };
-  }
-  const match = ootbWorkflows.find(
-    (w) => w.gitUrl === activeWorkflow.gitUrl && w.branch === activeWorkflow.branch
-      && (w.path ?? "") === (activeWorkflow.path ?? "")
-  );
-  if (match) {
-    return { selectedWorkflow: match.id, customGitUrl: "", customBranch: "main", customPath: "" };
-  }
-  return {
-    selectedWorkflow: "custom",
-    customGitUrl: activeWorkflow.gitUrl,
-    customBranch: activeWorkflow.branch || "main",
-    customPath: activeWorkflow.path ?? "",
-  };
-}
-
 export function ScheduledSessionForm({ projectName, mode, initialData }: ScheduledSessionFormProps) {
   const router = useRouter();
   const isEdit = mode === "edit";
@@ -131,10 +109,19 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
     ? resolveSchedulePreset(initialData.schedule)
     : { preset: "0 * * * *", customCron: "" };
 
-  const [selectedWorkflow, setSelectedWorkflow] = useState("none");
-  const [customGitUrl, setCustomGitUrl] = useState("");
-  const [customBranch, setCustomBranch] = useState("main");
-  const [customPath, setCustomPath] = useState("");
+  const initialWorkflow = isEdit && initialData?.sessionTemplate.activeWorkflow
+    ? {
+        selectedWorkflow: "custom" as string,
+        customGitUrl: initialData.sessionTemplate.activeWorkflow.gitUrl,
+        customBranch: initialData.sessionTemplate.activeWorkflow.branch || "main",
+        customPath: initialData.sessionTemplate.activeWorkflow.path ?? "",
+      }
+    : { selectedWorkflow: "none", customGitUrl: "", customBranch: "main", customPath: "" };
+
+  const [selectedWorkflow, setSelectedWorkflow] = useState(initialWorkflow.selectedWorkflow);
+  const [customGitUrl, setCustomGitUrl] = useState(initialWorkflow.customGitUrl);
+  const [customBranch, setCustomBranch] = useState(initialWorkflow.customBranch);
+  const [customPath, setCustomPath] = useState(initialWorkflow.customPath);
   const [repos, setRepos] = useState<SessionRepo[]>(
     isEdit && initialData?.sessionTemplate.repos ? [...initialData.sessionTemplate.repos] : []
   );
@@ -197,18 +184,8 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
     }
   }, [modelsData?.defaultModel, form, isEdit, initialData]);
 
-  // Resolve workflow state once OOTB workflows are loaded (edit mode)
-  const [workflowResolved, setWorkflowResolved] = useState(false);
-  useEffect(() => {
-    if (isEdit && initialData && !workflowsLoading && !workflowResolved) {
-      const resolved = resolveWorkflowState(initialData.sessionTemplate.activeWorkflow, ootbWorkflows);
-      setSelectedWorkflow(resolved.selectedWorkflow);
-      setCustomGitUrl(resolved.customGitUrl);
-      setCustomBranch(resolved.customBranch);
-      setCustomPath(resolved.customPath);
-      setWorkflowResolved(true);
-    }
-  }, [isEdit, initialData, ootbWorkflows, workflowsLoading, workflowResolved]);
+  // Workflow state is initialized from initialData in useState above.
+  // No useEffect needed — avoids timing issues with Radix Select.
 
   const effectiveCron = schedulePreset === "custom" ? (customCron ?? "") : schedulePreset;
   const nextRuns = useMemo(() => getNextRuns(effectiveCron, 3), [effectiveCron]);

--- a/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
+++ b/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
@@ -101,6 +101,29 @@ function resolveSchedulePreset(schedule: string): { preset: string; customCron: 
   return { preset: "custom", customCron: schedule };
 }
 
+function resolveWorkflowState(
+  activeWorkflow: WorkflowSelection | undefined,
+  ootbWorkflows: { id: string; gitUrl: string; branch: string; path?: string }[]
+): { selectedWorkflow: string; customGitUrl: string; customBranch: string; customPath: string } {
+  if (!activeWorkflow) {
+    return { selectedWorkflow: "none", customGitUrl: "", customBranch: "main", customPath: "" };
+  }
+  const match = ootbWorkflows.find(
+    (w) => w.gitUrl === activeWorkflow.gitUrl
+      && w.branch === activeWorkflow.branch
+      && (w.path ?? "") === (activeWorkflow.path ?? "")
+  );
+  if (match) {
+    return { selectedWorkflow: match.id, customGitUrl: "", customBranch: "main", customPath: "" };
+  }
+  return {
+    selectedWorkflow: "custom",
+    customGitUrl: activeWorkflow.gitUrl,
+    customBranch: activeWorkflow.branch || "main",
+    customPath: activeWorkflow.path ?? "",
+  };
+}
+
 export function ScheduledSessionForm({ projectName, mode, initialData }: ScheduledSessionFormProps) {
   const router = useRouter();
   const isEdit = mode === "edit";
@@ -122,6 +145,9 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
   const [customGitUrl, setCustomGitUrl] = useState(initialWorkflow.customGitUrl);
   const [customBranch, setCustomBranch] = useState(initialWorkflow.customBranch);
   const [customPath, setCustomPath] = useState(initialWorkflow.customPath);
+  const [workflowResolved, setWorkflowResolved] = useState(
+    !isEdit || !initialData?.sessionTemplate.activeWorkflow
+  );
   const [repos, setRepos] = useState<SessionRepo[]>(
     isEdit && initialData?.sessionTemplate.repos ? [...initialData.sessionTemplate.repos] : []
   );
@@ -184,8 +210,24 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
     }
   }, [modelsData?.defaultModel, form, isEdit, initialData]);
 
-  // Workflow state is initialized from initialData in useState above.
-  // No useEffect needed — avoids timing issues with Radix Select.
+  // Resolve workflow state once OOTB workflows finish loading. The Skeleton
+  // guard on the Select (workflowsLoading || !workflowResolved) ensures Radix
+  // never sees a value change after mount — the Select only mounts after this
+  // effect has set the final selectedWorkflow value.
+  useEffect(() => {
+    if (workflowResolved) return;
+    if (workflowsLoading) return;
+
+    const resolved = resolveWorkflowState(
+      initialData!.sessionTemplate.activeWorkflow,
+      ootbWorkflows
+    );
+    setSelectedWorkflow(resolved.selectedWorkflow);
+    setCustomGitUrl(resolved.customGitUrl);
+    setCustomBranch(resolved.customBranch);
+    setCustomPath(resolved.customPath);
+    setWorkflowResolved(true);
+  }, [workflowResolved, workflowsLoading, ootbWorkflows, initialData]);
 
   const effectiveCron = schedulePreset === "custom" ? (customCron ?? "") : schedulePreset;
   const nextRuns = useMemo(() => getNextRuns(effectiveCron, 3), [effectiveCron]);
@@ -444,7 +486,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
 
               <div className="space-y-2">
                 <FormLabel>Workflow</FormLabel>
-                {workflowsLoading ? (
+                {(workflowsLoading || !workflowResolved) ? (
                   <Skeleton className="h-10 w-full" />
                 ) : (
                   <Select
@@ -469,7 +511,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                     </SelectContent>
                   </Select>
                 )}
-                {selectedWorkflow === "custom" && (
+                {selectedWorkflow === "custom" && workflowResolved && (
                   <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 pt-1">
                     <div className="sm:col-span-2 space-y-1">
                       <FormLabel className="text-xs">Git Repository URL *</FormLabel>

--- a/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
+++ b/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
@@ -475,7 +475,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                     onValueChange={handleWorkflowChange}
                     disabled={mutation.isPending}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger className="w-full" data-testid="workflow-select">
                       <SelectValue placeholder="Select workflow..." />
                     </SelectTrigger>
                     <SelectContent>
@@ -501,6 +501,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                         onChange={(e) => setCustomGitUrl(e.target.value)}
                         placeholder="https://github.com/org/workflow-repo.git"
                         disabled={mutation.isPending}
+                        data-testid="workflow-git-url"
                       />
                     </div>
                     <div className="space-y-1">
@@ -510,6 +511,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                         onChange={(e) => setCustomBranch(e.target.value)}
                         placeholder="main"
                         disabled={mutation.isPending}
+                        data-testid="workflow-branch"
                       />
                     </div>
                     <div className="sm:col-span-3 space-y-1">
@@ -519,6 +521,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                         onChange={(e) => setCustomPath(e.target.value)}
                         placeholder="workflows/my-workflow"
                         disabled={mutation.isPending}
+                        data-testid="workflow-path"
                       />
                     </div>
                   </div>

--- a/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
+++ b/components/frontend/src/app/projects/[name]/scheduled-sessions/_components/scheduled-session-form.tsx
@@ -345,7 +345,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <Input {...field} placeholder="Enter a display name..." maxLength={50} disabled={mutation.isPending} />
+                      <Input {...field} placeholder="Enter a display name..." maxLength={50} disabled={mutation.isPending} data-testid="scheduled-session-name-input" />
                     </FormControl>
                     <p className="text-xs text-muted-foreground">{(field.value ?? "").length}/50 characters</p>
                     <FormMessage />
@@ -361,7 +361,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                     <FormLabel>Schedule</FormLabel>
                     <Select onValueChange={field.onChange} value={field.value}>
                       <FormControl>
-                        <SelectTrigger className="w-full">
+                        <SelectTrigger className="w-full" data-testid="schedule-preset-select">
                           <SelectValue placeholder="Select a schedule" />
                         </SelectTrigger>
                       </FormControl>
@@ -384,7 +384,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                     <FormItem>
                       <FormLabel>Cron Expression</FormLabel>
                       <FormControl>
-                        <Input {...field} placeholder="*/15 * * * *" disabled={mutation.isPending} />
+                        <Input {...field} placeholder="*/15 * * * *" disabled={mutation.isPending} data-testid="custom-cron-input" />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -393,7 +393,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
               )}
 
               {effectiveCron && (
-                <div className="rounded-md border p-3 space-y-2">
+                <div className="rounded-md border p-3 space-y-2" data-testid="cron-preview">
                   <p className="text-sm font-medium">{cronDescription}</p>
                   {nextRuns.length > 0 && (
                     <div className="text-xs text-muted-foreground space-y-0.5">
@@ -458,7 +458,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                   <FormItem>
                     <FormLabel>Initial Prompt</FormLabel>
                     <FormControl>
-                      <Textarea {...field} placeholder="Enter the prompt for each scheduled session..." rows={4} disabled={mutation.isPending} />
+                      <Textarea {...field} placeholder="Enter the prompt for each scheduled session..." rows={4} disabled={mutation.isPending} data-testid="initial-prompt-input" />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -553,7 +553,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                       ) : (
                         <Select onValueChange={(v) => handleRunnerTypeChange(v, field.onChange)} value={field.value}>
                           <FormControl>
-                            <SelectTrigger className="w-full">
+                            <SelectTrigger className="w-full" data-testid="runner-type-select">
                               <SelectValue placeholder="Select a runner type" />
                             </SelectTrigger>
                           </FormControl>
@@ -579,7 +579,7 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
                       <FormLabel>Model</FormLabel>
                       <Select onValueChange={field.onChange} value={field.value} disabled={modelsLoading || (modelsError && models.length === 0)}>
                         <FormControl>
-                          <SelectTrigger className="w-full">
+                          <SelectTrigger className="w-full" data-testid="model-select">
                             <SelectValue placeholder={modelsLoading ? "Loading models..." : "Select a model"} />
                           </SelectTrigger>
                         </FormControl>
@@ -722,12 +722,13 @@ export function ScheduledSessionForm({ projectName, mode, initialData }: Schedul
 
           {/* Actions */}
           <div className="flex justify-end gap-3 pb-6">
-            <Button type="button" variant="outline" onClick={() => router.push(backUrl)} disabled={mutation.isPending}>
+            <Button type="button" variant="outline" onClick={() => router.push(backUrl)} disabled={mutation.isPending} data-testid="scheduled-session-cancel">
               Cancel
             </Button>
             <Button
               type="submit"
               disabled={mutation.isPending || runnerTypesLoading || runnerTypesError || modelsLoading || (modelsError && models.length === 0)}
+              data-testid="scheduled-session-submit"
             >
               {mutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {isEdit ? "Save Changes" : "Create Scheduled Session"}

--- a/components/frontend/src/components/workspace-sections/scheduled-sessions-tab.tsx
+++ b/components/frontend/src/components/workspace-sections/scheduled-sessions-tab.tsx
@@ -93,7 +93,7 @@ export function SchedulesSection({ projectName }: SchedulesSectionProps) {
               <RefreshCw className={`w-4 h-4 mr-2 ${isFetching ? "animate-spin" : ""}`} />
               Refresh
             </Button>
-            <Button asChild>
+            <Button asChild data-testid="new-scheduled-session-btn">
               <Link href={`/projects/${projectName}/scheduled-sessions/new`}>
                 <Plus className="w-4 h-4 mr-2" />
                 New Scheduled Session
@@ -139,7 +139,7 @@ export function SchedulesSection({ projectName }: SchedulesSectionProps) {
                     (triggerMutation.isPending && triggerMutation.variables?.name === ss.name);
 
                   return (
-                    <TableRow key={ss.name}>
+                    <TableRow key={ss.name} data-testid={`scheduled-session-row-${ss.name}`}>
                       <TableCell className="font-medium">
                         <Link
                           href={`/projects/${projectName}/scheduled-sessions/${ss.name}`}
@@ -184,7 +184,7 @@ export function SchedulesSection({ projectName }: SchedulesSectionProps) {
                         ) : (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" data-testid={`scheduled-session-actions-${ss.name}`}>
                                 <MoreVertical className="h-4 w-4" />
                                 <span className="sr-only">Open menu</span>
                               </Button>
@@ -211,7 +211,7 @@ export function SchedulesSection({ projectName }: SchedulesSectionProps) {
                                   Suspend
                                 </DropdownMenuItem>
                               )}
-                              <DropdownMenuItem onClick={() => handleDelete(ss.name)} className="text-red-600">
+                              <DropdownMenuItem onClick={() => handleDelete(ss.name)} className="text-red-600" data-testid="scheduled-session-delete">
                                 <Trash2 className="h-4 w-4 mr-2" />
                                 Delete
                               </DropdownMenuItem>

--- a/e2e/cypress/e2e/scheduled-sessions.cy.ts
+++ b/e2e/cypress/e2e/scheduled-sessions.cy.ts
@@ -267,6 +267,114 @@ describe('Scheduled Sessions', () => {
     })
   })
 
+  // ─── Custom Workflow ────────────────────────────────────────
+
+  describe('Custom Workflow', () => {
+    it('should create a scheduled session with a custom workflow', () => {
+      cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+
+      // Fill display name
+      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+        .type('Custom Workflow Test')
+
+      // Leave default schedule preset (Every hour)
+
+      // Fill initial prompt
+      cy.get('[data-testid="initial-prompt-input"]').type('Run with custom workflow')
+
+      // Select "Custom workflow..." from workflow dropdown
+      cy.get('[data-testid="workflow-select"]').click()
+      cy.get('[role="option"]').contains('Custom workflow...').click()
+
+      // Fill custom workflow fields
+      cy.get('[data-testid="workflow-git-url"]', { timeout: 5000 })
+        .should('be.visible')
+        .type('https://github.com/ambient-code/workflows.git')
+      cy.get('[data-testid="workflow-branch"]').clear().type('main')
+      cy.get('[data-testid="workflow-path"]').type('workflows/bugfix')
+
+      // Wait for runner/model to load
+      cy.get('[data-testid="runner-type-select"]', { timeout: 10000 }).should('not.be.disabled')
+      cy.get('[data-testid="model-select"]', { timeout: 10000 }).should('not.be.disabled')
+
+      // Submit
+      cy.get('[data-testid="scheduled-session-submit"]').click()
+
+      // Verify redirect to list
+      cy.url({ timeout: 15000 }).should('include', `/projects/${workspaceSlug}/scheduled-sessions`)
+      cy.url().should('not.include', '/new')
+
+      // Verify it appears in the list
+      cy.contains('Custom Workflow Test', { timeout: 10000 }).should('be.visible')
+    })
+
+    it('should edit the custom workflow on an existing scheduled session', () => {
+      // Create a scheduled session with a custom workflow via API
+      cy.request({
+        method: 'POST',
+        url: `/api/projects/${workspaceSlug}/scheduled-sessions`,
+        headers: apiHeaders(),
+        body: {
+          displayName: 'Workflow Edit Test',
+          schedule: '0 * * * *',
+          sessionTemplate: {
+            initialPrompt: 'original prompt',
+            runnerType: 'claude-code',
+            llmSettings: { model: 'claude-sonnet-4-20250514', temperature: 0.7, maxTokens: 4000 },
+            timeout: 300,
+            activeWorkflow: {
+              gitUrl: 'https://github.com/ambient-code/workflows.git',
+              branch: 'main',
+              path: 'workflows/bugfix',
+            },
+          },
+        },
+      }).then((resp) => {
+        expect(resp.status).to.be.oneOf([200, 201])
+        const scheduleName = resp.body.name
+
+        // Navigate to edit page
+        cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}/edit`)
+
+        // Wait for form to load — workflow fields should be pre-populated
+        cy.get('[data-testid="workflow-select"]', { timeout: 10000 })
+          .should('contain.text', 'Custom workflow...')
+
+        // Verify pre-populated custom workflow fields
+        cy.get('[data-testid="workflow-git-url"]')
+          .should('have.value', 'https://github.com/ambient-code/workflows.git')
+        cy.get('[data-testid="workflow-branch"]')
+          .should('have.value', 'main')
+        cy.get('[data-testid="workflow-path"]')
+          .should('have.value', 'workflows/bugfix')
+
+        // Update the workflow fields
+        cy.get('[data-testid="workflow-git-url"]').clear().type('https://github.com/ambient-code/workflows.git')
+        cy.get('[data-testid="workflow-branch"]').clear().type('develop')
+        cy.get('[data-testid="workflow-path"]').clear().type('workflows/triage')
+
+        // Submit
+        cy.get('[data-testid="scheduled-session-submit"]').click()
+
+        // Verify redirect
+        cy.url({ timeout: 15000 }).should('include', `/projects/${workspaceSlug}/scheduled-sessions`)
+        cy.url().should('not.include', '/edit')
+
+        // Verify via API that the workflow was updated
+        cy.request({
+          url: `/api/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}`,
+          headers: apiHeaders(),
+        }).then((getResp) => {
+          expect(getResp.status).to.eq(200)
+          const workflow = getResp.body.sessionTemplate.activeWorkflow
+          expect(workflow.gitUrl).to.eq('https://github.com/ambient-code/workflows.git')
+          expect(workflow.branch).to.eq('develop')
+          expect(workflow.path).to.eq('workflows/triage')
+        })
+      })
+    })
+  })
+
   // ─── Schedule Deletion ────────────────────────────────────────
 
   describe('Schedule Deletion', () => {

--- a/e2e/cypress/e2e/scheduled-sessions.cy.ts
+++ b/e2e/cypress/e2e/scheduled-sessions.cy.ts
@@ -1,0 +1,305 @@
+/**
+ * E2E Tests for Scheduled Sessions
+ *
+ * Covers: creation (preset & custom cron), cron validation (client & server),
+ * schedule update, and deletion.
+ */
+describe('Scheduled Sessions', () => {
+  const workspaceName = `e2e-sched-${Date.now()}`
+  let workspaceSlug: string
+
+  Cypress.on('uncaught:exception', (err) => {
+    if (err.message.includes('Minified React error #418') ||
+        err.message.includes('Minified React error #423') ||
+        err.message.includes('Hydration')) {
+      return false
+    }
+    return true
+  })
+
+  function apiHeaders() {
+    return { Authorization: `Bearer ${Cypress.env('TEST_TOKEN')}` }
+  }
+
+  before(() => {
+    const token = Cypress.env('TEST_TOKEN')
+    expect(token, 'TEST_TOKEN should be set').to.exist
+
+    // Create workspace via API
+    cy.request({
+      method: 'POST',
+      url: '/api/projects',
+      headers: apiHeaders(),
+      body: { name: workspaceName, displayName: workspaceName },
+    }).then((resp) => {
+      expect(resp.status).to.be.oneOf([200, 201])
+      workspaceSlug = resp.body.name || workspaceName
+
+      // Poll until namespace is ready
+      const pollProject = (attempt: number): void => {
+        if (attempt > 30) throw new Error('Namespace timeout')
+        cy.request({
+          url: `/api/projects/${workspaceSlug}`,
+          headers: apiHeaders(),
+          failOnStatusCode: false,
+        }).then((response) => {
+          if (response.status !== 200) {
+            cy.wait(1500, { log: false })
+            pollProject(attempt + 1)
+          }
+        })
+      }
+      pollProject(1)
+    })
+
+    // Set runner secrets (needed for session template validation)
+    cy.then(() => cy.request({
+      method: 'PUT',
+      url: `/api/projects/${workspaceSlug}/runner-secrets`,
+      headers: apiHeaders(),
+      body: { data: { ANTHROPIC_API_KEY: 'mock-replay-key' } },
+    })).then((r) => expect(r.status).to.eq(200))
+  })
+
+  after(() => {
+    if (!Cypress.env('KEEP_WORKSPACES')) {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/projects/${workspaceSlug}`,
+        headers: apiHeaders(),
+        failOnStatusCode: false,
+      })
+    }
+  })
+
+  // Helper: create a scheduled session via API, return its name
+  function createScheduledSessionViaApi(schedule: string, displayName?: string): Cypress.Chainable<string> {
+    return cy.request({
+      method: 'POST',
+      url: `/api/projects/${workspaceSlug}/scheduled-sessions`,
+      headers: apiHeaders(),
+      body: {
+        ...(displayName ? { displayName } : {}),
+        schedule,
+        sessionTemplate: {
+          initialPrompt: 'e2e test prompt',
+          runnerType: 'claude-code',
+          llmSettings: { model: 'claude-sonnet-4-20250514', temperature: 0.7, maxTokens: 4000 },
+          timeout: 300,
+        },
+      },
+    }).then((resp) => {
+      expect(resp.status).to.be.oneOf([200, 201])
+      return resp.body.name as string
+    })
+  }
+
+  // ─── Schedule Creation ────────────────────────────────────────
+
+  describe('Schedule Creation', () => {
+    it('should create a scheduled session with a preset schedule', () => {
+      cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+
+      // Fill display name
+      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+        .type('Preset Schedule Test')
+
+      // Select "Daily at 9:00 AM" preset
+      cy.get('[data-testid="schedule-preset-select"]').click()
+      cy.get('[role="option"]').contains('Daily at 9:00 AM').click()
+
+      // Verify cron preview shows description and next runs
+      cy.get('[data-testid="cron-preview"]', { timeout: 5000 }).should('exist')
+      cy.get('[data-testid="cron-preview"]').should('contain.text', 'Next 3 runs')
+
+      // Fill initial prompt
+      cy.get('[data-testid="initial-prompt-input"]').type('Run daily health check')
+
+      // Wait for runner type and model to load, leave defaults
+      cy.get('[data-testid="runner-type-select"]', { timeout: 10000 }).should('not.be.disabled')
+      cy.get('[data-testid="model-select"]', { timeout: 10000 }).should('not.be.disabled')
+
+      // Submit
+      cy.get('[data-testid="scheduled-session-submit"]').click()
+
+      // Verify redirect to scheduled sessions list
+      cy.url({ timeout: 15000 }).should('include', `/projects/${workspaceSlug}/scheduled-sessions`)
+      cy.url().should('not.include', '/new')
+
+      // Verify the schedule appears in the list
+      cy.contains('Preset Schedule Test', { timeout: 10000 }).should('be.visible')
+      cy.contains('Active').should('exist')
+    })
+
+    it('should create a scheduled session with a custom cron expression', () => {
+      cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+
+      // Fill display name
+      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+        .type('Custom Cron Test')
+
+      // Select "Custom" preset
+      cy.get('[data-testid="schedule-preset-select"]').click()
+      cy.get('[role="option"]').contains('Custom').click()
+
+      // Enter custom cron expression
+      cy.get('[data-testid="custom-cron-input"]').type('*/30 * * * *')
+
+      // Verify cron preview updates
+      cy.get('[data-testid="cron-preview"]').should('contain.text', 'Every 30 minutes')
+      cy.get('[data-testid="cron-preview"]').should('contain.text', 'Next 3 runs')
+
+      // Fill initial prompt
+      cy.get('[data-testid="initial-prompt-input"]').type('Run every 30 minutes')
+
+      // Wait for runner/model to load
+      cy.get('[data-testid="runner-type-select"]', { timeout: 10000 }).should('not.be.disabled')
+      cy.get('[data-testid="model-select"]', { timeout: 10000 }).should('not.be.disabled')
+
+      // Submit
+      cy.get('[data-testid="scheduled-session-submit"]').click()
+
+      // Verify redirect and listing
+      cy.url({ timeout: 15000 }).should('include', `/projects/${workspaceSlug}/scheduled-sessions`)
+      cy.url().should('not.include', '/new')
+      cy.contains('Custom Cron Test', { timeout: 10000 }).should('be.visible')
+    })
+  })
+
+  // ─── Cron Validation ──────────────────────────────────────────
+
+  describe('Cron Validation', () => {
+    it('should show client-side validation error when custom cron is empty', () => {
+      cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+
+      // Select "Custom" preset
+      cy.get('[data-testid="schedule-preset-select"]', { timeout: 10000 }).click()
+      cy.get('[role="option"]').contains('Custom').click()
+
+      // Leave custom cron input empty
+
+      // Fill initial prompt so only the cron field blocks submission
+      cy.get('[data-testid="initial-prompt-input"]').type('This should not submit')
+
+      // Wait for runner/model to load
+      cy.get('[data-testid="runner-type-select"]', { timeout: 10000 }).should('not.be.disabled')
+      cy.get('[data-testid="model-select"]', { timeout: 10000 }).should('not.be.disabled')
+
+      // Click submit
+      cy.get('[data-testid="scheduled-session-submit"]').click()
+
+      // Verify form validation error appears
+      cy.contains('Cron expression is required', { timeout: 5000 }).should('be.visible')
+
+      // Verify we are still on the new page (no redirect)
+      cy.url().should('include', '/new')
+    })
+
+    it('should show server-side validation error for invalid cron syntax', () => {
+      cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+
+      // Select "Custom" preset
+      cy.get('[data-testid="schedule-preset-select"]', { timeout: 10000 }).click()
+      cy.get('[role="option"]').contains('Custom').click()
+
+      // Enter invalid cron (3 fields instead of required 5)
+      cy.get('[data-testid="custom-cron-input"]').type('* * *')
+
+      // Fill initial prompt
+      cy.get('[data-testid="initial-prompt-input"]').type('This should fail server-side')
+
+      // Wait for runner/model to load
+      cy.get('[data-testid="runner-type-select"]', { timeout: 10000 }).should('not.be.disabled')
+      cy.get('[data-testid="model-select"]', { timeout: 10000 }).should('not.be.disabled')
+
+      // Submit — should pass client-side validation but fail server-side
+      cy.get('[data-testid="scheduled-session-submit"]').click()
+
+      // Verify error toast from backend (assert type, not message text, to avoid coupling to backend wording)
+      cy.get('[data-sonner-toast][data-type="error"]', { timeout: 10000 })
+        .should('exist')
+
+      // Verify we are still on the new page (no redirect)
+      cy.url().should('include', '/new')
+    })
+  })
+
+  // ─── Schedule Update ──────────────────────────────────────────
+
+  describe('Schedule Update', () => {
+    let scheduleName: string
+
+    before(() => {
+      createScheduledSessionViaApi('0 * * * *', 'Update Test Schedule').then((name) => {
+        scheduleName = name
+      })
+    })
+
+    it('should update a scheduled session cron schedule', () => {
+      cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}/edit`)
+
+      // Wait for form to load with existing data and verify pre-selected value
+      cy.get('[data-testid="schedule-preset-select"]', { timeout: 10000 })
+        .should('contain.text', 'Every hour')
+
+      // Change schedule to "Weekly on Monday"
+      cy.get('[data-testid="schedule-preset-select"]').click()
+      cy.get('[role="option"]').contains('Weekly on Monday').click()
+
+      // Verify cron preview updates
+      cy.get('[data-testid="cron-preview"]').should('contain.text', 'Next 3 runs')
+
+      // Submit
+      cy.get('[data-testid="scheduled-session-submit"]').click()
+
+      // Verify redirect back to list
+      cy.url({ timeout: 15000 }).should('include', `/projects/${workspaceSlug}/scheduled-sessions`)
+      cy.url().should('not.include', '/edit')
+
+      // Verify via API that the schedule was updated
+      cy.request({
+        url: `/api/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}`,
+        headers: apiHeaders(),
+      }).then((resp) => {
+        expect(resp.status).to.eq(200)
+        expect(resp.body.schedule).to.eq('0 9 * * 1')
+      })
+    })
+  })
+
+  // ─── Schedule Deletion ────────────────────────────────────────
+
+  describe('Schedule Deletion', () => {
+    let scheduleName: string
+
+    before(() => {
+      createScheduledSessionViaApi('0 * * * *', 'Delete Test Schedule').then((name) => {
+        scheduleName = name
+      })
+    })
+
+    it('should delete a scheduled session from the list', () => {
+      cy.visit(`/projects/${workspaceSlug}/scheduled-sessions`)
+
+      // Wait for the list to load and find the session row
+      cy.get(`[data-testid="scheduled-session-row-${scheduleName}"]`, { timeout: 10000 })
+        .should('exist')
+
+      // Stub confirm dialog to accept
+      cy.on('window:confirm', () => true)
+
+      // Open actions dropdown
+      cy.get(`[data-testid="scheduled-session-actions-${scheduleName}"]`).click()
+
+      // Click delete
+      cy.get('[data-testid="scheduled-session-delete"]').click()
+
+      // Verify success toast
+      cy.get('[data-sonner-toast]', { timeout: 10000 })
+        .should('contain.text', 'Deleted')
+
+      // Verify the session is removed from the list
+      cy.get(`[data-testid="scheduled-session-row-${scheduleName}"]`).should('not.exist')
+    })
+  })
+})

--- a/e2e/cypress/e2e/scheduled-sessions.cy.ts
+++ b/e2e/cypress/e2e/scheduled-sessions.cy.ts
@@ -310,6 +310,7 @@ describe('Scheduled Sessions', () => {
 
     it('should edit the custom workflow on an existing scheduled session', () => {
       // Create a scheduled session with a custom workflow via API
+      // Use fields that do NOT match any OOTB workflow so it stays as "Custom workflow..."
       cy.request({
         method: 'POST',
         url: `/api/projects/${workspaceSlug}/scheduled-sessions`,
@@ -319,6 +320,71 @@ describe('Scheduled Sessions', () => {
           schedule: '0 * * * *',
           sessionTemplate: {
             initialPrompt: 'original prompt',
+            runnerType: 'claude-code',
+            llmSettings: { model: 'claude-sonnet-4-20250514', temperature: 0.7, maxTokens: 4000 },
+            timeout: 300,
+            activeWorkflow: {
+              gitUrl: 'https://github.com/my-org/my-custom-workflows.git',
+              branch: 'main',
+              path: 'workflows/custom-one',
+            },
+          },
+        },
+      }).then((resp) => {
+        expect(resp.status).to.be.oneOf([200, 201])
+        const scheduleName = resp.body.name
+
+        // Navigate to edit page
+        cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}/edit`)
+
+        // Wait for form to load — should show "Custom workflow..." (no OOTB match)
+        cy.get('[data-testid="workflow-select"]', { timeout: 10000 })
+          .should('contain.text', 'Custom workflow...')
+
+        // Verify pre-populated custom workflow fields
+        cy.get('[data-testid="workflow-git-url"]')
+          .should('have.value', 'https://github.com/my-org/my-custom-workflows.git')
+        cy.get('[data-testid="workflow-branch"]')
+          .should('have.value', 'main')
+        cy.get('[data-testid="workflow-path"]')
+          .should('have.value', 'workflows/custom-one')
+
+        // Update the workflow fields
+        cy.get('[data-testid="workflow-branch"]').clear().type('develop')
+        cy.get('[data-testid="workflow-path"]').clear().type('workflows/custom-two')
+
+        // Submit
+        cy.get('[data-testid="scheduled-session-submit"]').click()
+
+        // Verify redirect
+        cy.url({ timeout: 15000 }).should('include', `/projects/${workspaceSlug}/scheduled-sessions`)
+        cy.url().should('not.include', '/edit')
+
+        // Verify via API that the workflow was updated
+        cy.request({
+          url: `/api/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}`,
+          headers: apiHeaders(),
+        }).then((getResp) => {
+          expect(getResp.status).to.eq(200)
+          const workflow = getResp.body.sessionTemplate.activeWorkflow
+          expect(workflow.gitUrl).to.eq('https://github.com/my-org/my-custom-workflows.git')
+          expect(workflow.branch).to.eq('develop')
+          expect(workflow.path).to.eq('workflows/custom-two')
+        })
+      })
+    })
+
+    it('should show OOTB workflow name when editing a session created with an OOTB workflow', () => {
+      // Create a session with fields that match the "bugfix" OOTB workflow
+      cy.request({
+        method: 'POST',
+        url: `/api/projects/${workspaceSlug}/scheduled-sessions`,
+        headers: apiHeaders(),
+        body: {
+          displayName: 'OOTB Workflow Edit Test',
+          schedule: '0 * * * *',
+          sessionTemplate: {
+            initialPrompt: 'run bugfix workflow',
             runnerType: 'claude-code',
             llmSettings: { model: 'claude-sonnet-4-20250514', temperature: 0.7, maxTokens: 4000 },
             timeout: 300,
@@ -336,41 +402,27 @@ describe('Scheduled Sessions', () => {
         // Navigate to edit page
         cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}/edit`)
 
-        // Wait for form to load — workflow fields should be pre-populated
+        // The workflow select should show the OOTB workflow name, not "Custom workflow..."
         cy.get('[data-testid="workflow-select"]', { timeout: 10000 })
-          .should('contain.text', 'Custom workflow...')
+          .should('contain.text', 'Fix a bug')
 
-        // Verify pre-populated custom workflow fields
-        cy.get('[data-testid="workflow-git-url"]')
-          .should('have.value', 'https://github.com/ambient-code/workflows.git')
-        cy.get('[data-testid="workflow-branch"]')
-          .should('have.value', 'main')
-        cy.get('[data-testid="workflow-path"]')
-          .should('have.value', 'workflows/bugfix')
+        // Custom workflow fields should NOT be visible (OOTB selected, not custom)
+        cy.get('[data-testid="workflow-git-url"]').should('not.exist')
+      })
+    })
 
-        // Update the workflow fields
-        cy.get('[data-testid="workflow-git-url"]').clear().type('https://github.com/ambient-code/workflows.git')
-        cy.get('[data-testid="workflow-branch"]').clear().type('develop')
-        cy.get('[data-testid="workflow-path"]').clear().type('workflows/triage')
+    it('should show General chat when editing a session with no workflow', () => {
+      // Create a session without any workflow
+      createScheduledSessionViaApi('0 * * * *', 'No Workflow Edit Test').then((scheduleName) => {
+        // Navigate to edit page
+        cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}/edit`)
 
-        // Submit
-        cy.get('[data-testid="scheduled-session-submit"]').click()
+        // The workflow select should show "General chat"
+        cy.get('[data-testid="workflow-select"]', { timeout: 10000 })
+          .should('contain.text', 'General chat')
 
-        // Verify redirect
-        cy.url({ timeout: 15000 }).should('include', `/projects/${workspaceSlug}/scheduled-sessions`)
-        cy.url().should('not.include', '/edit')
-
-        // Verify via API that the workflow was updated
-        cy.request({
-          url: `/api/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}`,
-          headers: apiHeaders(),
-        }).then((getResp) => {
-          expect(getResp.status).to.eq(200)
-          const workflow = getResp.body.sessionTemplate.activeWorkflow
-          expect(workflow.gitUrl).to.eq('https://github.com/ambient-code/workflows.git')
-          expect(workflow.branch).to.eq('develop')
-          expect(workflow.path).to.eq('workflows/triage')
-        })
+        // Custom workflow fields should NOT be visible
+        cy.get('[data-testid="workflow-git-url"]').should('not.exist')
       })
     })
   })


### PR DESCRIPTION
## Summary

- Adds Cypress e2e tests for scheduled sessions: creation (preset and custom cron), cron validation (client-side and server-side), schedule update, deletion, and custom workflow create/edit flows
- Fixes a bug where editing a scheduled session with a custom workflow showed "Select workflow..." instead of pre-populating the workflow fields — caused by a two-phase render race with Radix Select
- Restores OOTB workflow reverse-matching on edit: if the stored workflow fields match an OOTB workflow, the dropdown shows the OOTB name (e.g., "Fix a bug") instead of "Custom workflow..."
- Uses a `workflowResolved` state guard to keep the workflow Skeleton visible until resolution completes, ensuring Radix Select never sees a post-mount value change
- Adds `data-testid` attributes to scheduled session form and list components for stable test selectors

## Test plan

- [x] All 10 e2e tests pass against Kind deployment (create preset/custom cron, client/server cron validation, schedule update, custom workflow create/edit, OOTB workflow edit, no-workflow edit, deletion)
- [ ] Verify scheduled session create/edit/delete flows manually
- [ ] Confirm edit form pre-populates custom workflow fields correctly for custom workflows
- [ ] Confirm edit form shows OOTB workflow name when session was created with an OOTB workflow
- [ ] Confirm edit form shows "General chat" when session has no workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release focuses on testing infrastructure and internal improvements with no user-facing changes.

* **Tests**
  * Added comprehensive end-to-end test suite covering scheduled sessions workflows, including creation, validation, updates, and deletion
  * Enhanced testability across scheduled sessions components with improved test identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->