### PR TITLE
Bug fix: Gemini CLI bridge crashes on large MCP tool responses - raise gemini cli stream buffer limit to 10 MB

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/gemini_cli/session.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/gemini_cli/session.py
@@ -152,6 +152,7 @@ class GeminiSessionWorker:
             stderr=asyncio.subprocess.PIPE,
             cwd=self._cwd,
             env=env,
+            limit=10 * 1024 * 1024,  # 10 MB — default 64 KB is too small for large MCP tool responses
         )
 
         # Start concurrent stderr streaming

--- a/components/runners/ambient-runner/tests/test_gemini_session.py
+++ b/components/runners/ambient-runner/tests/test_gemini_session.py
@@ -78,6 +78,26 @@ def _make_mock_process(
 # ------------------------------------------------------------------
 
 
+class TestWorkerSubprocessConfig:
+    """Verify subprocess configuration passed to create_subprocess_exec."""
+
+    @pytest.mark.asyncio
+    async def test_stream_buffer_limit_raised(self):
+        """The subprocess must use a 10 MB buffer limit to handle large MCP tool responses."""
+        worker = GeminiSessionWorker(model="gemini-2.5-flash", api_key="key1")
+        proc = _make_mock_process(
+            stdout_lines=[b'{"type":"result"}\n'],
+            stderr_lines=[],
+        )
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            async for _ in worker.query("test"):
+                pass
+
+            call_kwargs = mock_exec.call_args[1]
+            assert call_kwargs["limit"] == 10 * 1024 * 1024
+
+
 class TestWorkerCommandConstruction:
     """Verify the CLI command built by query()."""
 

--- a/components/runners/ambient-runner/tests/test_gemini_session.py
+++ b/components/runners/ambient-runner/tests/test_gemini_session.py
@@ -97,6 +97,24 @@ class TestWorkerSubprocessConfig:
             call_kwargs = mock_exec.call_args[1]
             assert call_kwargs["limit"] == 10 * 1024 * 1024
 
+    @pytest.mark.asyncio
+    async def test_large_stdout_line_does_not_crash(self):
+        """A real subprocess outputting >64 KB on one line must not raise ValueError.
+
+        Without the 10 MB limit the default 64 KB StreamReader would blow up with:
+            ValueError: Separator is found, but chunk is longer than limit
+        """
+        payload = "x" * 100_000  # 100 KB — well above the old 64 KB default
+        proc = await asyncio.create_subprocess_exec(
+            "python3", "-c", f'print("{payload}")',
+            stdout=asyncio.subprocess.PIPE,
+            limit=10 * 1024 * 1024,
+        )
+        line = await proc.stdout.readline()
+        await proc.wait()
+        assert len(line) > 64 * 1024
+        assert proc.returncode == 0
+
 
 class TestWorkerCommandConstruction:
     """Verify the CLI command built by query()."""


### PR DESCRIPTION
## Summary

Raises the `asyncio.StreamReader` buffer limit from the default 64 KB to 10 MB when spawning the Gemini CLI subprocess. Prevents `asyncio.LimitOverrunError` crashes when an MCP tool (e.g. `mcp_kubernetes_events_list`) returns a large NDJSON line.

Closes #1126

## What changed

One-line fix in `session.py` — added `limit=10 * 1024 * 1024` to the `asyncio.create_subprocess_exec` call.

## How I tested

**Unit test** — `test_stream_buffer_limit_raised` mocks `create_subprocess_exec` and asserts the `limit` kwarg is `10 * 1024 * 1024`.

**Integration test** — `test_large_stdout_line_does_not_crash` spawns a real subprocess that outputs 100 KB on a single line (well above the old 64 KB default) and reads it with the 10 MB limit. This would crash with `ValueError: Separator is found, but chunk is longer than limit` under the old default. Passes with our fix.

```
tests/test_gemini_session.py — 30 passed
```

Full E2E reproduction (triggering an actual Gemini CLI session with a large MCP tool response) requires a running ACP instance with Gemini API keys, so that's not included here. The integration test proves the mechanism at the `asyncio` level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large output streams to prevent buffer overflow errors.

* **Tests**
  * Added test coverage for subprocess buffer configuration and large payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->