### PR TITLE
Replace Content-Type with Accept on bodyless GET proxy routes

### DIFF
--- a/components/frontend/src/app/api/auth/github/install/route.ts
+++ b/components/frontend/src/app/api/auth/github/install/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: Request) {
 
   const resp = await fetch(`${BACKEND_URL}/auth/github/install`, {
     method: 'POST',
-    headers,
+    headers: { ...headers, 'Content-Type': 'application/json' },
     body,
   })
 

--- a/components/frontend/src/app/api/auth/github/pat/route.ts
+++ b/components/frontend/src/app/api/auth/github/pat/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: Request) {
 
   const resp = await fetch(`${BACKEND_URL}/auth/github/pat`, {
     method: 'POST',
-    headers,
+    headers: { ...headers, 'Content-Type': 'application/json' },
     body,
   })
 

--- a/components/frontend/src/app/api/auth/gitlab/connect/route.ts
+++ b/components/frontend/src/app/api/auth/gitlab/connect/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: Request) {
 
   const resp = await fetch(`${BACKEND_URL}/auth/gitlab/connect`, {
     method: 'POST',
-    headers,
+    headers: { ...headers, 'Content-Type': 'application/json' },
     body,
   })
 

--- a/components/frontend/src/app/api/auth/jira/connect/route.ts
+++ b/components/frontend/src/app/api/auth/jira/connect/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: Request) {
 
   const resp = await fetch(`${BACKEND_URL}/auth/jira/connect`, {
     method: 'POST',
-    headers,
+    headers: { ...headers, 'Content-Type': 'application/json' },
     body,
   })
 

--- a/components/frontend/src/app/api/cluster-info/route.ts
+++ b/components/frontend/src/app/api/cluster-info/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     const response = await fetch(`${BACKEND_URL}/cluster-info`, {
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
+        'Accept': 'application/json',
       },
     });
 

--- a/components/frontend/src/app/api/feature-flags/route.ts
+++ b/components/frontend/src/app/api/feature-flags/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
       method: 'GET',
       headers: {
         Authorization: clientKey,
-        'Content-Type': 'application/json',
+        'Accept': 'application/json',
       },
       next: { revalidate: 15 },
     });

--- a/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/git/configure-remote/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/git/configure-remote/route.ts
@@ -13,7 +13,7 @@ export async function POST(
     `${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/git/configure-remote`,
     {
       method: 'POST',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body,
     }
   );

--- a/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/repos/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/repos/route.ts
@@ -13,7 +13,7 @@ export async function POST(
     `${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/repos`,
     {
       method: 'POST',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body,
     }
   );

--- a/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/workflow/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/agentic-sessions/[sessionName]/workflow/route.ts
@@ -13,7 +13,7 @@ export async function POST(
     `${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions/${encodeURIComponent(sessionName)}/workflow`,
     {
       method: 'POST',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body,
     }
   );

--- a/components/frontend/src/app/api/projects/[name]/agentic-sessions/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/agentic-sessions/route.ts
@@ -33,7 +33,7 @@ export async function POST(
 
     const response = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/agentic-sessions`, {
       method: 'POST',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body,
     });
 

--- a/components/frontend/src/app/api/projects/[name]/feature-flags/[flagName]/override/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/feature-flags/[flagName]/override/route.ts
@@ -18,7 +18,7 @@ export async function PUT(
       `${BACKEND_URL}/projects/${encodeURIComponent(projectName)}/feature-flags/${encodeURIComponent(flagName)}/override`,
       {
         method: "PUT",
-        headers,
+        headers: { ...headers, 'Content-Type': 'application/json' },
         body,
       }
     );

--- a/components/frontend/src/app/api/projects/[name]/keys/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/keys/route.ts
@@ -35,7 +35,7 @@ export async function POST(
 
     const response = await fetch(`${BACKEND_URL}/projects/${name}/keys`, {
       method: 'POST',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
 

--- a/components/frontend/src/app/api/projects/[name]/permissions/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/permissions/route.ts
@@ -35,7 +35,7 @@ export async function POST(
 
     const response = await fetch(`${BACKEND_URL}/projects/${name}/permissions`, {
       method: 'POST',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
 

--- a/components/frontend/src/app/api/projects/[name]/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/route.ts
@@ -34,7 +34,7 @@ export async function PUT(
 
     const response = await fetch(`${BACKEND_URL}/projects/${name}`, {
       method: 'PUT',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
 

--- a/components/frontend/src/app/api/projects/[name]/settings/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/settings/route.ts
@@ -12,8 +12,7 @@ export async function GET(
     const response = await fetch(`${BACKEND_URL}/projects/${projectName}/settings`, {
       method: "GET",
       headers: {
-        "Content-Type": "application/json",
-        // Forward authentication headers from the client request
+        "Accept": "application/json",
         "X-User-ID": request.headers.get("X-User-ID") || "",
         "X-User-Groups": request.headers.get("X-User-Groups") || "",
       },

--- a/components/frontend/src/app/api/projects/[name]/users/forks/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/users/forks/route.ts
@@ -24,7 +24,7 @@ export async function POST(
   const body = await request.text()
   const resp = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/users/forks`, {
     method: 'POST',
-    headers,
+    headers: { ...headers, 'Content-Type': 'application/json' },
     body,
   })
   const data = await resp.text()

--- a/components/frontend/src/app/api/projects/route.ts
+++ b/components/frontend/src/app/api/projects/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
 
     const response = await fetch(`${BACKEND_URL}/projects`, {
       method: 'POST',
-      headers,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body: body,
     });
 

--- a/components/frontend/src/app/api/version/route.ts
+++ b/components/frontend/src/app/api/version/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     const response = await fetch(`${BACKEND_URL}/version`, {
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
+        'Accept': 'application/json',
       },
     });
 

--- a/components/frontend/src/app/api/workflows/ootb/route.ts
+++ b/components/frontend/src/app/api/workflows/ootb/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
 
     // Forward authorization header if present (enables GitHub token lookup for better rate limits)
     const headers: HeadersInit = {
-      "Content-Type": "application/json",
+      "Accept": "application/json",
     };
     const authHeader = request.headers.get("Authorization");
     if (authHeader) {

--- a/components/frontend/src/lib/auth.ts
+++ b/components/frontend/src/lib/auth.ts
@@ -33,7 +33,7 @@ export function extractAccessToken(request: Request): string | undefined {
 // Build headers to forward to backend, using only real incoming values.
 export function buildForwardHeaders(request: Request, extra?: Record<string, string>): ForwardHeaders {
   const headers: ForwardHeaders = {
-    'Content-Type': 'application/json',
+    'Accept': 'application/json',
   };
 
   const xfUser = request.headers.get('X-Forwarded-User');


### PR DESCRIPTION
Closes #1002

## What changed

The root cause is `buildForwardHeaders` in `lib/auth.ts` — it unconditionally sets `Content-Type: application/json` on every outbound request, even GET proxies with no body. Changed it to default to `Accept: application/json` instead, which fixes all ~40 GET routes that use the helper in one shot.

On top of that, replaced the literal `Content-Type` with `Accept` on the 5 routes called out in the issue (`version`, `cluster-info`, `settings` GET, `workflows/ootb`, `feature-flags`).

Since POST/PUT routes that send a body still need `Content-Type`, added it explicitly to the 14 routes that were relying on the helper for it (`projects`, `permissions`, `keys`, auth connect routes, `agentic-sessions`, `workflow`, `repos`, `configure-remote`, `feature-flag override`, `forks`). Routes that already had explicit `Content-Type` (`scheduled-sessions`, `runner-secrets`, `integration-secrets`, `agui`, `mcp/invoke`, workspace paths) were unaffected.

## Scope

| Category | Count | Action |
|---|---|---|
| `buildForwardHeaders` helper | 1 file | `Content-Type` → `Accept` |
| GET routes with literal `Content-Type` | 5 files | replaced with `Accept` |
| POST/PUT routes with body (relied on helper) | 14 files | added explicit `Content-Type` |
| POST/PUT routes with explicit `Content-Type` already | ~10 files | no change needed |
| Bodyless POST/DELETE routes | ~8 files | no change needed |

Full audit of all 94 route files under `src/app/api/` — nothing missed.

## How I tested

**Static analysis** — `tsc --noEmit`, `eslint` on all 20 changed files, `vitest run` (631 passed, 0 failures).

**Live testing against the Kind cluster** — ran the frontend locally (Next.js dev server on port 3000) with the backend port-forwarded from the `ambient-main` Kind cluster, then curled every modified route type through the proxy layer:

| Route | Method | Result |
|-------|--------|--------|
| `/api/version` | GET | 200 — returned version JSON |
| `/api/cluster-info` | GET | 200 — returned cluster info |
| `/api/workflows/ootb` | GET | 200 — returned workflows list |
| `/api/projects` | GET | 200 — returned projects |
| `/api/projects` | POST | 400 on invalid name (body parsed correctly), 201 on valid name |

The POST test confirms `Content-Type: application/json` is still being sent on mutation routes — the backend parsed the JSON body and returned a meaningful validation error, not a "can't parse request" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized proxied API headers: write operations (POST/PUT) now include an explicit Content-Type: application/json; read operations (GET) now use Accept: application/json to request JSON responses.
  * No other request/response behavior, status handling, or public API signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->