### PR TITLE
Deployment for Observability Dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ RUNNER_IMAGE ?= vteam_claude_runner:$(IMAGE_TAG)
 STATE_SYNC_IMAGE ?= vteam_state_sync:$(IMAGE_TAG)
 PUBLIC_API_IMAGE ?= vteam_public_api:$(IMAGE_TAG)
 API_SERVER_IMAGE ?= vteam_api_server:$(IMAGE_TAG)
+OBSERVABILITY_DASHBOARD_IMAGE ?= vteam_observability_dashboard:$(IMAGE_TAG)
 
 # kind-local overlay always references localhost/vteam_* images.
 # Podman produces this prefix natively; for Docker we tag before loading.
@@ -162,7 +163,7 @@ help: ## Display this help message
 
 ##@ Building
 
-build-all: build-frontend build-backend build-operator build-runner build-state-sync build-public-api build-api-server ## Build all container images
+build-all: build-frontend build-backend build-operator build-runner build-state-sync build-public-api build-api-server build-observability-dashboard ## Build all container images
 
 build-frontend: ## Build frontend image
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Building frontend with $(CONTAINER_ENGINE)..."
@@ -206,6 +207,12 @@ build-api-server: ## Build ambient API server image
 	@cd components/ambient-api-server && $(CONTAINER_ENGINE) build $(PLATFORM_FLAG) $(BUILD_FLAGS) \
 		-t $(API_SERVER_IMAGE) .
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) API server built: $(API_SERVER_IMAGE)"
+
+build-observability-dashboard: ## Build observability dashboard image
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Building observability-dashboard with $(CONTAINER_ENGINE)..."
+	@cd ../observability/dashboard && $(CONTAINER_ENGINE) build $(PLATFORM_FLAG) $(BUILD_FLAGS) \
+		-t $(OBSERVABILITY_DASHBOARD_IMAGE) .
+	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Observability dashboard built: $(OBSERVABILITY_DASHBOARD_IMAGE)"
 
 build-cli: ## Build acpctl CLI binary
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Building acpctl CLI..."
@@ -251,7 +258,7 @@ registry-login: ## Login to container registry
 
 push-all: registry-login ## Push all images to registry
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Pushing images to $(REGISTRY)..."
-	@for image in $(FRONTEND_IMAGE) $(BACKEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE) $(PUBLIC_API_IMAGE) $(API_SERVER_IMAGE); do \
+	@for image in $(FRONTEND_IMAGE) $(BACKEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE) $(PUBLIC_API_IMAGE) $(API_SERVER_IMAGE) $(OBSERVABILITY_DASHBOARD_IMAGE); do \
 		echo "  Tagging and pushing $$image..."; \
 		$(CONTAINER_ENGINE) tag $$image $(REGISTRY)/$$image && \
 		$(CONTAINER_ENGINE) push $(REGISTRY)/$$image; \
@@ -1146,7 +1153,7 @@ check-architecture: ## Validate build architecture matches host
 
 _kind-load-images: ## Internal: Load images into kind cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Loading images into kind ($(KIND_CLUSTER_NAME))..."
-	@for img in $(BACKEND_IMAGE) $(FRONTEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE) $(PUBLIC_API_IMAGE) $(API_SERVER_IMAGE); do \
+	@for img in $(BACKEND_IMAGE) $(FRONTEND_IMAGE) $(OPERATOR_IMAGE) $(RUNNER_IMAGE) $(STATE_SYNC_IMAGE) $(PUBLIC_API_IMAGE) $(API_SERVER_IMAGE) $(OBSERVABILITY_DASHBOARD_IMAGE); do \
 		echo "  Loading $(KIND_IMAGE_PREFIX)$$img..."; \
 		if [ -n "$(KIND_HOST)" ] || [ "$(CONTAINER_ENGINE)" = "podman" ]; then \
 			$(CONTAINER_ENGINE) save $(KIND_IMAGE_PREFIX)$$img | \

--- a/components/manifests/base/core/kustomization.yaml
+++ b/components/manifests/base/core/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - unleash-deployment.yaml
 - agent-registry-configmap.yaml
 - limitrange.yaml
+- observability-dashboard-deployment.yaml
 
 configMapGenerator:
 - name: ambient-models

--- a/components/manifests/base/core/observability-dashboard-deployment.yaml
+++ b/components/manifests/base/core/observability-dashboard-deployment.yaml
@@ -17,28 +17,39 @@ spec:
       containers:
       - name: observability-dashboard
         imagePullPolicy: Always
-        image: quay.io/ambient_code/vteam_observability_dashboard:latest
+        image: ghcr.io/ambient-code/observability:latest
         ports:
-        - containerPort: 3000
+        - containerPort: 8000
           name: http
+        envFrom:
+        - secretRef:
+            name: observability-dashboard-env
+            optional: true
+        env:
+        - name: PORT
+          value: "8000"
+        - name: DATA_SOURCE
+          value: "langfuse"
+        - name: SYNC_INTERVAL
+          value: "300"
         resources:
           requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 200m
+            cpu: 100m
             memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
         livenessProbe:
           httpGet:
-            path: /
+            path: /api/health
             port: http
-          initialDelaySeconds: 10
+          initialDelaySeconds: 15
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /
+            path: /api/health
             port: http
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
 ---
 apiVersion: v1
@@ -51,7 +62,7 @@ spec:
   selector:
     app: observability-dashboard
   ports:
-  - port: 3000
+  - port: 8000
     targetPort: http
     protocol: TCP
     name: http

--- a/components/manifests/base/core/observability-dashboard-deployment.yaml
+++ b/components/manifests/base/core/observability-dashboard-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: observability-dashboard
+  labels:
+    app: observability-dashboard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: observability-dashboard
+  template:
+    metadata:
+      labels:
+        app: observability-dashboard
+    spec:
+      containers:
+      - name: observability-dashboard
+        imagePullPolicy: Always
+        image: quay.io/ambient_code/vteam_observability_dashboard:latest
+        ports:
+        - containerPort: 3000
+          name: http
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: observability-dashboard-service
+  labels:
+    app: observability-dashboard
+spec:
+  selector:
+    app: observability-dashboard
+  ports:
+  - port: 3000
+    targetPort: http
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/components/manifests/overlays/kind-local/kustomization.yaml
+++ b/components/manifests/overlays/kind-local/kustomization.yaml
@@ -49,6 +49,12 @@ patches:
     version: v1
     kind: Deployment
     name: ambient-api-server
+- path: image-pull-policy-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: observability-dashboard
 
 # Remap images from Quay.io to locally-built names
 # Podman tags images with localhost/ prefix, which kind preserves when loading
@@ -67,4 +73,7 @@ images:
   newTag: latest
 - name: quay.io/ambient_code/vteam_api_server
   newName: localhost/vteam_api_server
+  newTag: latest
+- name: quay.io/ambient_code/vteam_observability_dashboard
+  newName: localhost/vteam_observability_dashboard
   newTag: latest

--- a/components/manifests/overlays/kind-local/kustomization.yaml
+++ b/components/manifests/overlays/kind-local/kustomization.yaml
@@ -74,6 +74,6 @@ images:
 - name: quay.io/ambient_code/vteam_api_server
   newName: localhost/vteam_api_server
   newTag: latest
-- name: quay.io/ambient_code/vteam_observability_dashboard
-  newName: localhost/vteam_observability_dashboard
+- name: ghcr.io/ambient-code/observability
+  newName: localhost/observability
   newTag: latest

--- a/components/manifests/overlays/production/kustomization.yaml
+++ b/components/manifests/overlays/production/kustomization.yaml
@@ -95,3 +95,9 @@ images:
 - name: quay.io/ambient_code/vteam_state_sync:latest
   newName: quay.io/ambient_code/vteam_state_sync
   newTag: latest
+- name: quay.io/ambient_code/vteam_observability_dashboard
+  newName: quay.io/ambient_code/vteam_observability_dashboard
+  newTag: latest
+- name: quay.io/ambient_code/vteam_observability_dashboard:latest
+  newName: quay.io/ambient_code/vteam_observability_dashboard
+  newTag: latest

--- a/components/manifests/overlays/production/kustomization.yaml
+++ b/components/manifests/overlays/production/kustomization.yaml
@@ -95,9 +95,9 @@ images:
 - name: quay.io/ambient_code/vteam_state_sync:latest
   newName: quay.io/ambient_code/vteam_state_sync
   newTag: latest
-- name: quay.io/ambient_code/vteam_observability_dashboard
-  newName: quay.io/ambient_code/vteam_observability_dashboard
+- name: ghcr.io/ambient-code/observability
+  newName: ghcr.io/ambient-code/observability
   newTag: latest
-- name: quay.io/ambient_code/vteam_observability_dashboard:latest
-  newName: quay.io/ambient_code/vteam_observability_dashboard
+- name: ghcr.io/ambient-code/observability:latest
+  newName: ghcr.io/ambient-code/observability
   newTag: latest


### PR DESCRIPTION
This PR will deploy the Observability dashboard using K8s deployment patterns. 

Repo located here:
https://github.com/ambient-code/observability

Some things to note:
- using ghcr.io temporarily for the initial deployment
- observability dashboard is subject to change pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability dashboard deployed as a containerized service with health checks, resource limits, env-based configuration, and a ClusterIP service for internal access.
* **Chores**
  * Build and push workflows updated to include the observability dashboard and to load the image into local test clusters.
* **Configuration**
  * Local and production deployment overlays updated to map and pin the observability image for dev and prod environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->