### PR TITLE
fix(control-plane): inject AMBIENT_TOKEN into MCP sidecar at pod creation

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -441,7 +441,12 @@ func (r *SimpleKubeReconciler) ensurePod(ctx context.Context, namespace string, 
 	}
 
 	if useMCPSidecar {
-		containers = append(containers, r.buildMCPSidecar())
+		ambientToken, err := r.factory.Token(ctx)
+		if err != nil {
+			r.logger.Warn().Err(err).Str("session_id", session.ID).Msg("failed to fetch token for MCP sidecar; sidecar will start without AMBIENT_TOKEN")
+			ambientToken = ""
+		}
+		containers = append(containers, r.buildMCPSidecar(ambientToken))
 		r.logger.Info().Str("session_id", session.ID).Msg("MCP sidecar enabled for session")
 	}
 
@@ -811,11 +816,21 @@ func boolToStr(b bool) string {
 	return "false"
 }
 
-func (r *SimpleKubeReconciler) buildMCPSidecar() interface{} {
+func (r *SimpleKubeReconciler) buildMCPSidecar(ambientToken string) interface{} {
 	mcpImage := r.cfg.MCPImage
 	imagePullPolicy := "Always"
 	if strings.HasPrefix(mcpImage, "localhost/") {
 		imagePullPolicy = "IfNotPresent"
+	}
+	env := []interface{}{
+		envVar("MCP_TRANSPORT", "sse"),
+		envVar("MCP_BIND_ADDR", fmt.Sprintf(":%d", mcpSidecarPort)),
+		envVar("AMBIENT_API_URL", r.cfg.MCPAPIServerURL),
+		envVar("AMBIENT_CP_TOKEN_URL", r.cfg.CPTokenURL),
+		envVar("AMBIENT_CP_TOKEN_PUBLIC_KEY", r.cfg.CPTokenPublicKey),
+	}
+	if ambientToken != "" {
+		env = append(env, envVar("AMBIENT_TOKEN", ambientToken))
 	}
 	return map[string]interface{}{
 		"name":            "ambient-mcp",
@@ -828,13 +843,7 @@ func (r *SimpleKubeReconciler) buildMCPSidecar() interface{} {
 				"protocol":      "TCP",
 			},
 		},
-		"env": []interface{}{
-			envVar("MCP_TRANSPORT", "sse"),
-			envVar("MCP_BIND_ADDR", fmt.Sprintf(":%d", mcpSidecarPort)),
-			envVar("AMBIENT_API_URL", r.cfg.MCPAPIServerURL),
-			envVar("AMBIENT_CP_TOKEN_URL", r.cfg.CPTokenURL),
-			envVar("AMBIENT_CP_TOKEN_PUBLIC_KEY", r.cfg.CPTokenPublicKey),
-		},
+		"env": env,
 		"resources": map[string]interface{}{
 			"requests": map[string]interface{}{
 				"cpu":    "100m",


### PR DESCRIPTION
## Summary

- The `ambient-mcp` sidecar uses the Go SDK which requires `AMBIENT_TOKEN` to start
- Fetches the CP's current API token via `factory.Token(ctx)` at pod-creation time and injects it as `AMBIENT_TOKEN` into the sidecar env
- If token fetch fails, logs a warning and starts the sidecar without it (non-fatal)

Fixes: MCP sidecar crash `AMBIENT_TOKEN is required` (seen in mpp-openshift runner pods)

## Test plan

- [ ] Deploy mpp-openshift overlay with this change
- [ ] Start a session and confirm the `ambient-mcp` sidecar starts successfully (no `AMBIENT_TOKEN is required` crash)
- [ ] Confirm MCP tools are reachable from the runner at `http://localhost:8090`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP sidecar pod resilience. Ambient token retrieval failures now trigger warning logs instead of blocking pod creation, allowing the configuration process to continue with default settings. Sidecar environment variables are now dynamically constructed based on available tokens, enabling more flexible deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->