### PR TITLE
feat(mcp-sidecar): implement RSA-OAEP token exchange for dynamic token refresh

### DIFF
--- a/components/ambient-control-plane/internal/config/config.go
+++ b/components/ambient-control-plane/internal/config/config.go
@@ -70,11 +70,15 @@ func Load() (*ControlPlaneConfig, error) {
 		VertexSecretNamespace: envOrDefault("VERTEX_SECRET_NAMESPACE", "ambient-code"),
 		RunnerImageNamespace:  os.Getenv("RUNNER_IMAGE_NAMESPACE"),
 		MCPImage:              os.Getenv("MCP_IMAGE"),
-		MCPAPIServerURL:       envOrDefault("MCP_API_SERVER_URL", "http://ambient-api-server.ambient-code.svc:8000"),
+		MCPAPIServerURL:       envOrDefault("MCP_API_SERVER_URL", ""),
 		RunnerLogLevel:        envOrDefault("RUNNER_LOG_LEVEL", "info"),
 		ProjectKubeTokenFile: os.Getenv("PROJECT_KUBE_TOKEN_FILE"),
 		CPTokenListenAddr:    envOrDefault("CP_TOKEN_LISTEN_ADDR", ":8080"),
 		CPTokenURL:           os.Getenv("CP_TOKEN_URL"),
+	}
+
+	if cfg.MCPAPIServerURL == "" {
+		cfg.MCPAPIServerURL = cfg.APIServerURL
 	}
 
 	if cfg.APIToken == "" && (cfg.OIDCClientID == "" || cfg.OIDCClientSecret == "") {

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -441,12 +441,7 @@ func (r *SimpleKubeReconciler) ensurePod(ctx context.Context, namespace string, 
 	}
 
 	if useMCPSidecar {
-		ambientToken, err := r.factory.Token(ctx)
-		if err != nil {
-			r.logger.Warn().Err(err).Str("session_id", session.ID).Msg("failed to fetch token for MCP sidecar; sidecar will start without AMBIENT_TOKEN")
-			ambientToken = ""
-		}
-		containers = append(containers, r.buildMCPSidecar(ambientToken))
+		containers = append(containers, r.buildMCPSidecar(session.ID))
 		r.logger.Info().Str("session_id", session.ID).Msg("MCP sidecar enabled for session")
 	}
 
@@ -816,7 +811,7 @@ func boolToStr(b bool) string {
 	return "false"
 }
 
-func (r *SimpleKubeReconciler) buildMCPSidecar(ambientToken string) interface{} {
+func (r *SimpleKubeReconciler) buildMCPSidecar(sessionID string) interface{} {
 	mcpImage := r.cfg.MCPImage
 	imagePullPolicy := "Always"
 	if strings.HasPrefix(mcpImage, "localhost/") {
@@ -828,9 +823,7 @@ func (r *SimpleKubeReconciler) buildMCPSidecar(ambientToken string) interface{} 
 		envVar("AMBIENT_API_URL", r.cfg.MCPAPIServerURL),
 		envVar("AMBIENT_CP_TOKEN_URL", r.cfg.CPTokenURL),
 		envVar("AMBIENT_CP_TOKEN_PUBLIC_KEY", r.cfg.CPTokenPublicKey),
-	}
-	if ambientToken != "" {
-		env = append(env, envVar("AMBIENT_TOKEN", ambientToken))
+		envVar("SESSION_ID", sessionID),
 	}
 	return map[string]interface{}{
 		"name":            "ambient-mcp",

--- a/components/ambient-mcp/client/client.go
+++ b/components/ambient-mcp/client/client.go
@@ -9,12 +9,14 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
 type Client struct {
 	httpClient *http.Client
 	baseURL    string
+	mu         sync.RWMutex
 	token      string
 }
 
@@ -27,7 +29,18 @@ func New(baseURL, token string) *Client {
 }
 
 func (c *Client) BaseURL() string { return c.baseURL }
-func (c *Client) Token() string   { return c.token }
+
+func (c *Client) Token() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.token
+}
+
+func (c *Client) SetToken(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.token = token
+}
 
 func (c *Client) do(ctx context.Context, method, path string, body []byte, result interface{}, expectedStatuses ...int) error {
 	reqURL := c.baseURL + "/api/ambient/v1" + path
@@ -42,7 +55,7 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte, resul
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Authorization", "Bearer "+c.Token())
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)

--- a/components/ambient-mcp/client/client_test.go
+++ b/components/ambient-mcp/client/client_test.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	c := New("http://localhost:8080/", "my-token")
+	if c.BaseURL() != "http://localhost:8080" {
+		t.Errorf("BaseURL() = %q, want trailing slash stripped", c.BaseURL())
+	}
+	if c.Token() != "my-token" {
+		t.Errorf("Token() = %q, want %q", c.Token(), "my-token")
+	}
+}
+
+func TestSetToken(t *testing.T) {
+	c := New("http://localhost:8080", "initial")
+	c.SetToken("refreshed")
+	if c.Token() != "refreshed" {
+		t.Errorf("Token() after SetToken = %q, want %q", c.Token(), "refreshed")
+	}
+}
+
+func TestSetToken_ConcurrentAccess(t *testing.T) {
+	c := New("http://localhost:8080", "initial")
+	var wg sync.WaitGroup
+
+	for i := range 100 {
+		wg.Add(2)
+		go func(n int) {
+			defer wg.Done()
+			c.SetToken("token-" + string(rune('A'+n%26)))
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = c.Token()
+		}()
+	}
+	wg.Wait()
+
+	got := c.Token()
+	if got == "" {
+		t.Error("Token() is empty after concurrent access")
+	}
+}
+
+func TestGet_SendsBearerToken(t *testing.T) {
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-bearer")
+	var result map[string]string
+	err := c.Get(context.Background(), "/healthz", &result)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if receivedAuth != "Bearer test-bearer" {
+		t.Errorf("Authorization = %q, want %q", receivedAuth, "Bearer test-bearer")
+	}
+}
+
+func TestGet_UsesRefreshedToken(t *testing.T) {
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "old-token")
+	c.SetToken("new-token")
+
+	var result map[string]string
+	err := c.Get(context.Background(), "/healthz", &result)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if receivedAuth != "Bearer new-token" {
+		t.Errorf("Authorization = %q, want %q", receivedAuth, "Bearer new-token")
+	}
+}
+
+func TestGet_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "token")
+	err := c.Get(context.Background(), "/missing", nil)
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestPost_SendsBody(t *testing.T) {
+	var receivedBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"id": "123"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "token")
+	body := map[string]string{"name": "test"}
+	var result map[string]string
+	err := c.Post(context.Background(), "/items", body, &result, http.StatusCreated)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if receivedBody["name"] != "test" {
+		t.Errorf("received body name = %q, want %q", receivedBody["name"], "test")
+	}
+	if result["id"] != "123" {
+		t.Errorf("result id = %q, want %q", result["id"], "123")
+	}
+}

--- a/components/ambient-mcp/main.go
+++ b/components/ambient-mcp/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/ambient-code/platform/components/ambient-mcp/client"
+	"github.com/ambient-code/platform/components/ambient-mcp/tokenexchange"
 )
 
 func main() {
@@ -16,18 +17,50 @@ func main() {
 		apiURL = "http://localhost:8080"
 	}
 
-	token := os.Getenv("AMBIENT_TOKEN")
-	if token == "" {
-		fmt.Fprintln(os.Stderr, "AMBIENT_TOKEN is required")
-		os.Exit(1)
-	}
-
 	transport := os.Getenv("MCP_TRANSPORT")
 	if transport == "" {
 		transport = "stdio"
 	}
 
+	cpTokenURL := os.Getenv("AMBIENT_CP_TOKEN_URL")
+	cpPublicKey := os.Getenv("AMBIENT_CP_TOKEN_PUBLIC_KEY")
+	sessionID := os.Getenv("SESSION_ID")
+
+	var token string
+	var exchanger *tokenexchange.Exchanger
+
+	if cpTokenURL != "" && cpPublicKey != "" && sessionID != "" {
+		var err error
+		exchanger, err = tokenexchange.New(cpTokenURL, cpPublicKey, sessionID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "token exchange init failed: %v\n", err)
+			os.Exit(1)
+		}
+		token, err = exchanger.FetchToken()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "initial token fetch failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "bootstrapped token via CP token exchange")
+	} else {
+		token = os.Getenv("AMBIENT_TOKEN")
+		if token == "" {
+			fmt.Fprintln(os.Stderr, "AMBIENT_TOKEN is required when CP token exchange env vars are not set")
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "using static AMBIENT_TOKEN (no CP token exchange)")
+	}
+
 	c := client.New(apiURL, token)
+
+	if exchanger != nil {
+		exchanger.OnRefresh(func(freshToken string) {
+			c.SetToken(freshToken)
+		})
+		exchanger.StartBackgroundRefresh()
+		defer exchanger.Stop()
+	}
+
 	s := newServer(c, transport)
 
 	switch transport {

--- a/components/ambient-mcp/mention/resolve.go
+++ b/components/ambient-mcp/mention/resolve.go
@@ -18,16 +18,18 @@ type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+type TokenFunc func() string
+
 type Resolver struct {
 	baseURL string
-	token   string
+	tokenFn TokenFunc
 	http    *http.Client
 }
 
-func NewResolver(baseURL, token string) *Resolver {
+func NewResolver(baseURL string, tokenFn TokenFunc) *Resolver {
 	return &Resolver{
 		baseURL: strings.TrimSuffix(baseURL, "/"),
-		token:   token,
+		tokenFn: tokenFn,
 		http:    &http.Client{},
 	}
 }
@@ -43,7 +45,7 @@ func (r *Resolver) Resolve(ctx context.Context, projectID, identifier string) (s
 	if uuidPattern.MatchString(strings.ToLower(identifier)) {
 		path := r.baseURL + "/api/ambient/v1/projects/" + url.PathEscape(projectID) + "/agents/" + url.PathEscape(identifier)
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
-		req.Header.Set("Authorization", "Bearer "+r.token)
+		req.Header.Set("Authorization", "Bearer "+r.tokenFn())
 		resp, err := r.http.Do(req)
 		if err != nil {
 			return "", fmt.Errorf("lookup agent by ID: %w", err)
@@ -66,7 +68,7 @@ func (r *Resolver) Resolve(ctx context.Context, projectID, identifier string) (s
 
 	path := r.baseURL + "/api/ambient/v1/projects/" + url.PathEscape(projectID) + "/agents?search=name='" + url.QueryEscape(identifier) + "'"
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
-	req.Header.Set("Authorization", "Bearer "+r.token)
+	req.Header.Set("Authorization", "Bearer "+r.tokenFn())
 	resp, err := r.http.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("search agent by name: %w", err)

--- a/components/ambient-mcp/mention/resolve_test.go
+++ b/components/ambient-mcp/mention/resolve_test.go
@@ -1,0 +1,167 @@
+package mention
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestNewResolver_TokenFunc(t *testing.T) {
+	callCount := 0
+	tokenFn := func() string {
+		callCount++
+		return "dynamic-token"
+	}
+	r := NewResolver("http://localhost:8080", tokenFn)
+	if r == nil {
+		t.Fatal("NewResolver returned nil")
+	}
+	if callCount != 0 {
+		t.Errorf("tokenFn called %d times at construction, want 0", callCount)
+	}
+}
+
+func TestResolve_ByUUID_SendsCurrentToken(t *testing.T) {
+	var tokenSeq atomic.Int32
+	tokens := []string{"token-v1", "token-v2"}
+
+	var receivedAuths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuths = append(receivedAuths, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"id": "550e8400-e29b-41d4-a716-446655440000"})
+	}))
+	defer srv.Close()
+
+	r := NewResolver(srv.URL, func() string {
+		idx := tokenSeq.Load()
+		if int(idx) < len(tokens) {
+			return tokens[idx]
+		}
+		return tokens[len(tokens)-1]
+	})
+
+	ctx := context.Background()
+	agentID, err := r.Resolve(ctx, "proj1", "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if agentID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("agentID = %q, want UUID", agentID)
+	}
+	if receivedAuths[0] != "Bearer token-v1" {
+		t.Errorf("first auth = %q, want %q", receivedAuths[0], "Bearer token-v1")
+	}
+
+	tokenSeq.Store(1)
+	_, err = r.Resolve(ctx, "proj1", "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatalf("Resolve (2nd): %v", err)
+	}
+	if receivedAuths[1] != "Bearer token-v2" {
+		t.Errorf("second auth = %q, want %q", receivedAuths[1], "Bearer token-v2")
+	}
+}
+
+func TestResolve_ByName_SendsCurrentToken(t *testing.T) {
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(agentSearchResult{
+			Items: []struct {
+				ID string `json:"id"`
+			}{{ID: "resolved-agent-id"}},
+			Total: 1,
+		})
+	}))
+	defer srv.Close()
+
+	r := NewResolver(srv.URL, func() string { return "name-lookup-token" })
+	agentID, err := r.Resolve(context.Background(), "proj1", "my-agent")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if agentID != "resolved-agent-id" {
+		t.Errorf("agentID = %q, want %q", agentID, "resolved-agent-id")
+	}
+	if receivedAuth != "Bearer name-lookup-token" {
+		t.Errorf("auth = %q, want %q", receivedAuth, "Bearer name-lookup-token")
+	}
+}
+
+func TestResolve_ByUUID_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	r := NewResolver(srv.URL, func() string { return "t" })
+	_, err := r.Resolve(context.Background(), "proj1", "550e8400-e29b-41d4-a716-446655440000")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestResolve_ByName_NoMatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(agentSearchResult{Total: 0})
+	}))
+	defer srv.Close()
+
+	r := NewResolver(srv.URL, func() string { return "t" })
+	_, err := r.Resolve(context.Background(), "proj1", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for no match")
+	}
+}
+
+func TestResolve_ByName_Ambiguous(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(agentSearchResult{
+			Items: []struct {
+				ID string `json:"id"`
+			}{{ID: "a"}, {ID: "b"}},
+			Total: 2,
+		})
+	}))
+	defer srv.Close()
+
+	r := NewResolver(srv.URL, func() string { return "t" })
+	_, err := r.Resolve(context.Background(), "proj1", "ambiguous")
+	if err == nil {
+		t.Fatal("expected error for ambiguous match")
+	}
+}
+
+func TestExtract(t *testing.T) {
+	matches := Extract("Hello @alice and @bob, also @alice again")
+	if len(matches) != 2 {
+		t.Fatalf("len(matches) = %d, want 2", len(matches))
+	}
+	if matches[0].Identifier != "alice" {
+		t.Errorf("matches[0].Identifier = %q, want %q", matches[0].Identifier, "alice")
+	}
+	if matches[1].Identifier != "bob" {
+		t.Errorf("matches[1].Identifier = %q, want %q", matches[1].Identifier, "bob")
+	}
+}
+
+func TestExtract_NoMentions(t *testing.T) {
+	matches := Extract("no mentions here")
+	if len(matches) != 0 {
+		t.Errorf("len(matches) = %d, want 0", len(matches))
+	}
+}
+
+func TestStripToken_RemovesMention(t *testing.T) {
+	result := StripToken("hello @alice do this", "@alice")
+	if result != "hello  do this" {
+		t.Errorf("StripToken = %q, want %q", result, "hello  do this")
+	}
+}

--- a/components/ambient-mcp/tokenexchange/tokenexchange.go
+++ b/components/ambient-mcp/tokenexchange/tokenexchange.go
@@ -1,0 +1,210 @@
+package tokenexchange
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	fetchAttempts  = 3
+	fetchTimeout   = 10 * time.Second
+	refreshPeriod  = 5 * time.Minute
+	initialBackoff = 1 * time.Second
+)
+
+type Exchanger struct {
+	tokenURL     string
+	publicKey    *rsa.PublicKey
+	sessionID    string
+	httpClient   *http.Client
+	mu           sync.RWMutex
+	currentToken string
+	onRefresh    func(string)
+	stopCh       chan struct{}
+	startOnce    sync.Once
+	stopOnce     sync.Once
+}
+
+type tokenResponse struct {
+	Token string `json:"token"`
+}
+
+func New(tokenURL, publicKeyPEM, sessionID string) (*Exchanger, error) {
+	if err := validateTokenURL(tokenURL); err != nil {
+		return nil, err
+	}
+
+	pubKey, err := parsePublicKey(publicKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+
+	return &Exchanger{
+		tokenURL:   tokenURL,
+		publicKey:  pubKey,
+		sessionID:  sessionID,
+		httpClient: &http.Client{Timeout: fetchTimeout},
+		stopCh:     make(chan struct{}),
+	}, nil
+}
+
+func (e *Exchanger) OnRefresh(fn func(string)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.onRefresh = fn
+}
+
+func (e *Exchanger) FetchToken() (string, error) {
+	bearer, err := encryptSessionID(e.publicKey, e.sessionID)
+	if err != nil {
+		return "", fmt.Errorf("encrypt session ID: %w", err)
+	}
+
+	var lastErr error
+	for attempt := range fetchAttempts {
+		if attempt > 0 {
+			time.Sleep(initialBackoff * time.Duration(1<<(attempt-1)))
+		}
+
+		token, err := e.doFetch(bearer)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		e.mu.Lock()
+		e.currentToken = token
+		callback := e.onRefresh
+		e.mu.Unlock()
+
+		if callback != nil {
+			callback(token)
+		}
+
+		return token, nil
+	}
+
+	return "", fmt.Errorf("token endpoint unreachable after %d attempts: %w", fetchAttempts, lastErr)
+}
+
+func (e *Exchanger) Token() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.currentToken
+}
+
+func (e *Exchanger) StartBackgroundRefresh() {
+	e.startOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(refreshPeriod)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if _, err := e.FetchToken(); err != nil {
+						fmt.Fprintf(os.Stderr, "background token refresh failed: %v\n", err)
+					}
+				case <-e.stopCh:
+					return
+				}
+			}
+		}()
+	})
+}
+
+func (e *Exchanger) Stop() {
+	e.stopOnce.Do(func() {
+		close(e.stopCh)
+	})
+}
+
+func (e *Exchanger) doFetch(bearer string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, e.tokenURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp tokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("unmarshal response: %w", err)
+	}
+	if tokenResp.Token == "" {
+		return "", fmt.Errorf("token response missing 'token' field")
+	}
+
+	return tokenResp.Token, nil
+}
+
+func encryptSessionID(pubKey *rsa.PublicKey, sessionID string) (string, error) {
+	ciphertext, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, []byte(sessionID), nil)
+	if err != nil {
+		return "", fmt.Errorf("RSA-OAEP encrypt: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+func parsePublicKey(pemStr string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in public key")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKIX public key: %w", err)
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is not RSA (got %T)", pub)
+	}
+
+	return rsaPub, nil
+}
+
+func validateTokenURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse token URL: %w", err)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("invalid token URL scheme %q (must be http or https)", scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("token URL has no host")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("token URL must not contain credentials")
+	}
+	return nil
+}

--- a/components/ambient-mcp/tokenexchange/tokenexchange_test.go
+++ b/components/ambient-mcp/tokenexchange/tokenexchange_test.go
@@ -1,0 +1,396 @@
+package tokenexchange
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func generateTestKeyPair(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	if err != nil {
+		t.Fatalf("marshaling public key: %v", err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	return privKey, string(pubPEM)
+}
+
+func decryptBearer(t *testing.T, privKey *rsa.PrivateKey, bearer string) string {
+	t.Helper()
+	ciphertext, err := base64.StdEncoding.DecodeString(bearer)
+	if err != nil {
+		t.Fatalf("decoding bearer base64: %v", err)
+	}
+	plaintext, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, privKey, ciphertext, nil)
+	if err != nil {
+		t.Fatalf("decrypting bearer: %v", err)
+	}
+	return string(plaintext)
+}
+
+func newTokenServer(t *testing.T, privKey *rsa.PrivateKey, apiToken string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if len(auth) < 8 || auth[:7] != "Bearer " {
+			http.Error(w, "missing bearer", http.StatusUnauthorized)
+			return
+		}
+		bearer := auth[7:]
+		sessionID := decryptBearer(t, privKey, bearer)
+		if len(sessionID) < 8 {
+			http.Error(w, "invalid session ID", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{Token: apiToken})
+	}))
+}
+
+func TestEncryptSessionID_Roundtrip(t *testing.T) {
+	privKey, pubPEM := generateTestKeyPair(t)
+	pubKey, err := parsePublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("parsePublicKey: %v", err)
+	}
+
+	sessionID := "test-session-abc123"
+	encrypted, err := encryptSessionID(pubKey, sessionID)
+	if err != nil {
+		t.Fatalf("encryptSessionID: %v", err)
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(encrypted)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	plaintext, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, privKey, ciphertext, nil)
+	if err != nil {
+		t.Fatalf("RSA decrypt: %v", err)
+	}
+	if string(plaintext) != sessionID {
+		t.Errorf("roundtrip got %q, want %q", string(plaintext), sessionID)
+	}
+}
+
+func TestParsePublicKey_Valid(t *testing.T) {
+	_, pubPEM := generateTestKeyPair(t)
+	key, err := parsePublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("parsePublicKey: %v", err)
+	}
+	if key == nil {
+		t.Fatal("parsePublicKey returned nil key")
+	}
+}
+
+func TestParsePublicKey_InvalidPEM(t *testing.T) {
+	_, err := parsePublicKey("not-a-pem-block")
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+func TestParsePublicKey_NotRSA(t *testing.T) {
+	_, err := parsePublicKey("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n-----END PUBLIC KEY-----\n")
+	if err == nil {
+		t.Fatal("expected error for non-RSA key")
+	}
+}
+
+func TestValidateTokenURL(t *testing.T) {
+	cases := []struct {
+		url   string
+		valid bool
+	}{
+		{"https://cp.example.com/token", true},
+		{"http://localhost:8080/token", true},
+		{"ftp://example.com/token", false},
+		{"://missing-scheme", false},
+		{"http://user:pass@example.com/token", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		err := validateTokenURL(tc.url)
+		if (err == nil) != tc.valid {
+			t.Errorf("validateTokenURL(%q): err=%v, wantValid=%v", tc.url, err, tc.valid)
+		}
+	}
+}
+
+func TestNew_ValidConfig(t *testing.T) {
+	_, pubPEM := generateTestKeyPair(t)
+	ex, err := New("https://cp.example.com/token", pubPEM, "test-session-12345678")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if ex == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+func TestNew_InvalidURL(t *testing.T) {
+	_, pubPEM := generateTestKeyPair(t)
+	_, err := New("ftp://bad.example.com", pubPEM, "test-session-12345678")
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestNew_InvalidPublicKey(t *testing.T) {
+	_, err := New("https://cp.example.com/token", "garbage", "test-session-12345678")
+	if err == nil {
+		t.Fatal("expected error for invalid public key")
+	}
+}
+
+func TestFetchToken_Success(t *testing.T) {
+	privKey, pubPEM := generateTestKeyPair(t)
+	srv := newTokenServer(t, privKey, "fresh-api-token-xyz")
+	defer srv.Close()
+
+	ex, err := New(srv.URL+"/token", pubPEM, "session-abcdef12")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	token, err := ex.FetchToken()
+	if err != nil {
+		t.Fatalf("FetchToken: %v", err)
+	}
+	if token != "fresh-api-token-xyz" {
+		t.Errorf("token = %q, want %q", token, "fresh-api-token-xyz")
+	}
+	if ex.Token() != "fresh-api-token-xyz" {
+		t.Errorf("Token() = %q, want %q", ex.Token(), "fresh-api-token-xyz")
+	}
+}
+
+func TestFetchToken_ServerError_Retries(t *testing.T) {
+	privKey, pubPEM := generateTestKeyPair(t)
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n < 3 {
+			http.Error(w, "temporary failure", http.StatusServiceUnavailable)
+			return
+		}
+		bearer := r.Header.Get("Authorization")[7:]
+		decryptBearer(t, privKey, bearer)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{Token: "recovered-token"})
+	}))
+	defer srv.Close()
+
+	ex, err := New(srv.URL+"/token", pubPEM, "session-retry-test1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	token, err := ex.FetchToken()
+	if err != nil {
+		t.Fatalf("FetchToken: %v", err)
+	}
+	if token != "recovered-token" {
+		t.Errorf("token = %q, want %q", token, "recovered-token")
+	}
+	if callCount.Load() != 3 {
+		t.Errorf("server called %d times, want 3", callCount.Load())
+	}
+}
+
+func TestFetchToken_AllRetriesFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "permanent failure", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, pubPEM := generateTestKeyPair(t)
+	ex, err := New(srv.URL+"/token", pubPEM, "session-fail-test1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = ex.FetchToken()
+	if err == nil {
+		t.Fatal("expected error after all retries fail")
+	}
+}
+
+func TestFetchToken_EmptyTokenResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{Token: ""})
+	}))
+	defer srv.Close()
+
+	_, pubPEM := generateTestKeyPair(t)
+	ex, err := New(srv.URL+"/token", pubPEM, "session-empty-test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = ex.FetchToken()
+	if err == nil {
+		t.Fatal("expected error for empty token response")
+	}
+}
+
+func TestFetchToken_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "not-json")
+	}))
+	defer srv.Close()
+
+	_, pubPEM := generateTestKeyPair(t)
+	ex, err := New(srv.URL+"/token", pubPEM, "session-badjson-x")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = ex.FetchToken()
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestFetchToken_OnRefreshCallback(t *testing.T) {
+	privKey, pubPEM := generateTestKeyPair(t)
+	srv := newTokenServer(t, privKey, "callback-token")
+	defer srv.Close()
+
+	ex, err := New(srv.URL+"/token", pubPEM, "session-callback1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var received string
+	ex.OnRefresh(func(token string) {
+		received = token
+	})
+
+	token, err := ex.FetchToken()
+	if err != nil {
+		t.Fatalf("FetchToken: %v", err)
+	}
+	if received != token {
+		t.Errorf("OnRefresh received %q, want %q", received, token)
+	}
+}
+
+func TestFetchToken_SendsCorrectBearer(t *testing.T) {
+	privKey, pubPEM := generateTestKeyPair(t)
+	sessionID := "session-bearer-check"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if len(auth) < 8 || auth[:7] != "Bearer " {
+			t.Errorf("missing Bearer prefix in Authorization header")
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		bearer := auth[7:]
+		decrypted := decryptBearer(t, privKey, bearer)
+		if decrypted != sessionID {
+			t.Errorf("decrypted session ID = %q, want %q", decrypted, sessionID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{Token: "verified-token"})
+	}))
+	defer srv.Close()
+
+	ex, err := New(srv.URL+"/token", pubPEM, sessionID)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = ex.FetchToken()
+	if err != nil {
+		t.Fatalf("FetchToken: %v", err)
+	}
+}
+
+func TestToken_ReturnsEmptyBeforeFetch(t *testing.T) {
+	_, pubPEM := generateTestKeyPair(t)
+	ex, err := New("https://example.com/token", pubPEM, "session-nofetch1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := ex.Token(); got != "" {
+		t.Errorf("Token() before fetch = %q, want empty", got)
+	}
+}
+
+func TestStopBackgroundRefresh(t *testing.T) {
+	privKey, pubPEM := generateTestKeyPair(t)
+	srv := newTokenServer(t, privKey, "bg-token")
+	defer srv.Close()
+
+	ex, err := New(srv.URL+"/token", pubPEM, "session-stop-test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ex.StartBackgroundRefresh()
+	ex.Stop()
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestFetchToken_WrongKey_ServerRejects(t *testing.T) {
+	wrongKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating wrong key: %v", err)
+	}
+	wrongPubDER, _ := x509.MarshalPKIXPublicKey(&wrongKey.PublicKey)
+	wrongPubPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: wrongPubDER}))
+
+	realKey, _ := generateTestKeyPair(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if len(auth) < 8 || auth[:7] != "Bearer " {
+			http.Error(w, "missing bearer", http.StatusUnauthorized)
+			return
+		}
+		bearer := auth[7:]
+		ciphertext, err := base64.StdEncoding.DecodeString(bearer)
+		if err != nil {
+			http.Error(w, "bad base64", http.StatusUnauthorized)
+			return
+		}
+		_, err = rsa.DecryptOAEP(sha256.New(), rand.Reader, realKey, ciphertext, nil)
+		if err != nil {
+			http.Error(w, "decryption failed", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{Token: "should-not-get-this"})
+	}))
+	defer srv.Close()
+
+	ex, err := New(srv.URL+"/token", wrongPubPEM, "session-wrongkey1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = ex.FetchToken()
+	if err == nil {
+		t.Fatal("expected error when encrypted with wrong key")
+	}
+}

--- a/components/ambient-mcp/tools/sessions.go
+++ b/components/ambient-mcp/tools/sessions.go
@@ -132,7 +132,7 @@ func CreateSession(c *client.Client) func(ctx context.Context, req mcp.CallToolR
 }
 
 func PushMessage(c *client.Client) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	resolver := mention.NewResolver(c.BaseURL(), c.Token())
+	resolver := mention.NewResolver(c.BaseURL(), c.Token)
 
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sessionID := mcp.ParseString(req, "session_id", "")

--- a/components/manifests/overlays/mpp-openshift/ambient-control-plane.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-control-plane.yaml
@@ -84,8 +84,6 @@ spec:
               value: "http://ambient-control-plane.ambient-code--ambient-s0.svc:8080/token"
             - name: MCP_IMAGE
               value: "quay.io/ambient_code/vteam_mcp:latest"
-            - name: MCP_API_SERVER_URL
-              value: "http://ambient-api-server.ambient-code--runtime-int.svc:8000"
           volumeMounts:
             - name: project-kube-token
               mountPath: /var/run/secrets/project-kube


### PR DESCRIPTION
## Summary

- Replace static `AMBIENT_TOKEN` injection with the same RSA-OAEP token exchange protocol the runner uses — the MCP sidecar now fetches and periodically refreshes its own API token from the CP token server
- Add `tokenexchange` package to `ambient-mcp` with RSA-OAEP encryption, retry/backoff, and background refresh (every 5 min)
- Make `client.Client` thread-safe (`sync.RWMutex` + `SetToken()`) so tokens can be hot-swapped on refresh
- Refactor `mention.Resolver` to use `TokenFunc` instead of a static string
- Inject `SESSION_ID` into MCP sidecar env vars in `buildMCPSidecar()`
- Default `MCP_API_SERVER_URL` to `AMBIENT_API_SERVER_URL` and remove the hardcoded `runtime-int` value from the mpp-openshift overlay

## Changes

 < /dev/null |  File | What |
|------|------|
| `components/ambient-mcp/tokenexchange/tokenexchange.go` | New: RSA-OAEP encrypt + fetch + background refresh |
| `components/ambient-mcp/client/client.go` | Thread-safe token with `SetToken()` |
| `components/ambient-mcp/main.go` | Bootstrap via CP token exchange, fallback to static `AMBIENT_TOKEN` |
| `components/ambient-mcp/mention/resolve.go` | `TokenFunc` instead of static token |
| `components/ambient-mcp/tools/sessions.go` | Pass `c.Token` as `TokenFunc` |
| `components/ambient-control-plane/internal/reconciler/kube_reconciler.go` | `buildMCPSidecar(sessionID)`, inject `SESSION_ID`, remove static token |
| `components/ambient-control-plane/internal/config/config.go` | `MCPAPIServerURL` defaults to `APIServerURL` |
| `components/manifests/overlays/mpp-openshift/ambient-control-plane.yaml` | Remove hardcoded `MCP_API_SERVER_URL` |

## Test plan

- [x] Unit tests for `tokenexchange` (18 tests): RSA-OAEP roundtrip, key parsing, URL validation, fetch success/retry/failure, callback, wrong-key rejection
- [x] Unit tests for `client` (7 tests): construction, `SetToken`, concurrent access, bearer header propagation
- [x] Unit tests for `mention` (9 tests): `TokenFunc` lazy eval, token rotation across requests, resolve by UUID/name, error cases
- [x] `go build ./...` and `go vet ./...` pass for both `ambient-mcp` and `ambient-control-plane`
- [ ] Deploy to cluster and verify MCP sidecar bootstraps token via exchange and refreshes on rotation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic token refresh with background updates and optional token-exchange support.
  * Session-aware sidecar injection that propagates session IDs to sidecars.
  * New token-exchange component to bootstrap and refresh MCP tokens.

* **Bug Fixes**
  * Token concurrency safety improved via synchronized access.
  * Resolver and mention lookups now use the current token per request.
  * Configuration now derives MCP API server URL from the primary API server when not set.

* **Tests**
  * Added comprehensive tests for client, resolver, and token-exchange logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->