### PR TITLE
ci: reduce PR feedback loop with targeted caching

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install Vale
       run: |
-        curl -sfL https://github.com/errata-ai/vale/releases/download/v3.12.1/vale_3.12.1_Linux_64-bit.tar.gz | tar xz -C /usr/local/bin vale
+        curl -sfL https://github.com/errata-ai/vale/releases/download/v3.14.1/vale_3.14.1_Linux_64-bit.tar.gz | tar xz -C /usr/local/bin vale
 
     - name: Install npm tools
       run: npm install -g markdownlint-cli2 cspell

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  KIND_VERSION: "v0.27.0"
+
 concurrency:
   group: e2e-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -166,11 +169,23 @@ jobs:
     - name: Show built images
       run: docker images | grep e2e-test
 
+    - name: Cache kind binary
+      uses: actions/cache@v4
+      with:
+        path: ~/k8s-tools/kind
+        key: kind-${{ runner.os }}-${{ env.KIND_VERSION }}
+
     - name: Install kind
       run: |
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
-        chmod +x ./kind
-        sudo mv ./kind /usr/local/bin/kind
+        mkdir -p ~/k8s-tools
+        if [[ ! -f ~/k8s-tools/kind ]]; then
+          echo "Downloading kind $KIND_VERSION..."
+          curl -sLo ~/k8s-tools/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x ~/k8s-tools/kind
+        else
+          echo "Using cached kind"
+        fi
+        sudo cp ~/k8s-tools/kind /usr/local/bin/kind
         kind version
 
     - name: Setup kind cluster

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,10 @@ on:
 env:
   KIND_VERSION: "v0.27.0"
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: e2e-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -29,12 +33,12 @@ jobs:
       claude-runner: ${{ steps.filter.outputs.claude-runner }}
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check for component changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -57,12 +61,12 @@ jobs:
 
     steps:
     - name: Checkout PR code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Cleanup Diskspace
-      uses: kubeflow/pipelines/.github/actions/github-disk-cleanup@master
+      uses: kubeflow/pipelines/.github/actions/github-disk-cleanup@ab1231a5c32c688bcb62314e467011b586aee796 # master
       if: (!cancelled())
 
     - name: Validate AGENTS.md symlink
@@ -75,7 +79,7 @@ jobs:
         echo "✅ AGENTS.md symlink is valid"
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: '20'
         cache: 'npm'
@@ -86,13 +90,13 @@ jobs:
       run: npm ci
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       with:
         driver-opts: network=host
 
     - name: Build or pull frontend image
       if: needs.detect-changes.outputs.frontend == 'true'
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
       with:
         context: components/frontend
         file: components/frontend/Dockerfile
@@ -111,7 +115,7 @@ jobs:
 
     - name: Build or pull backend image
       if: needs.detect-changes.outputs.backend == 'true'
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
       with:
         context: components/backend
         file: components/backend/Dockerfile
@@ -130,7 +134,7 @@ jobs:
 
     - name: Build or pull operator image
       if: needs.detect-changes.outputs.operator == 'true'
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
       with:
         context: components/operator
         file: components/operator/Dockerfile
@@ -149,7 +153,7 @@ jobs:
 
     - name: Build or pull ambient-runner image
       if: needs.detect-changes.outputs.claude-runner == 'true'
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
       with:
         context: components/runners
         file: components/runners/ambient-runner/Dockerfile
@@ -170,7 +174,7 @@ jobs:
       run: docker images | grep e2e-test
 
     - name: Cache kind binary
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/k8s-tools/kind
         key: kind-${{ runner.os }}-${{ env.KIND_VERSION }}
@@ -229,7 +233,7 @@ jobs:
 
     - name: Upload test results
       if: failure()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: cypress-screenshots-pr-${{ github.event.pull_request.number }}
         path: e2e/cypress/screenshots
@@ -238,7 +242,7 @@ jobs:
 
     - name: Upload test videos
       if: failure()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: cypress-videos-pr-${{ github.event.pull_request.number }}
         path: e2e/cypress/videos

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,64 +87,84 @@ jobs:
       with:
         driver-opts: network=host
 
-    - name: Build component images from PR code
+    - name: Build or pull frontend image
+      if: needs.detect-changes.outputs.frontend == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/frontend
+        file: components/frontend/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_frontend:e2e-test
+        cache-from: |
+          type=gha,scope=frontend-amd64
+          type=gha,scope=e2e-frontend
+        cache-to: type=gha,mode=max,scope=e2e-frontend
+
+    - name: Pull frontend latest (unchanged)
+      if: needs.detect-changes.outputs.frontend != 'true'
       run: |
-        echo "======================================"
-        echo "Building images from PR code..."
-        echo "PR #${{ github.event.pull_request.number }}"
-        echo "SHA: ${{ github.event.pull_request.head.sha }}"
-        echo "======================================"
+        docker pull quay.io/ambient_code/vteam_frontend:latest
+        docker tag quay.io/ambient_code/vteam_frontend:latest quay.io/ambient_code/vteam_frontend:e2e-test
 
-        # Build frontend image (if changed or use latest)
-        if [ "${{ needs.detect-changes.outputs.frontend }}" == "true" ]; then
-          echo "Building frontend (changed)..."
-          docker build -t quay.io/ambient_code/vteam_frontend:e2e-test \
-            -f components/frontend/Dockerfile \
-            components/frontend
-        else
-          echo "Frontend unchanged, pulling latest..."
-          docker pull quay.io/ambient_code/vteam_frontend:latest
-          docker tag quay.io/ambient_code/vteam_frontend:latest quay.io/ambient_code/vteam_frontend:e2e-test
-        fi
+    - name: Build or pull backend image
+      if: needs.detect-changes.outputs.backend == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/backend
+        file: components/backend/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_backend:e2e-test
+        cache-from: |
+          type=gha,scope=backend-amd64
+          type=gha,scope=e2e-backend
+        cache-to: type=gha,mode=max,scope=e2e-backend
 
-        # Build backend image (if changed or use latest)
-        if [ "${{ needs.detect-changes.outputs.backend }}" == "true" ]; then
-          echo "Building backend (changed)..."
-          docker build -t quay.io/ambient_code/vteam_backend:e2e-test \
-            -f components/backend/Dockerfile \
-            components/backend
-        else
-          echo "Backend unchanged, pulling latest..."
-          docker pull quay.io/ambient_code/vteam_backend:latest
-          docker tag quay.io/ambient_code/vteam_backend:latest quay.io/ambient_code/vteam_backend:e2e-test
-        fi
+    - name: Pull backend latest (unchanged)
+      if: needs.detect-changes.outputs.backend != 'true'
+      run: |
+        docker pull quay.io/ambient_code/vteam_backend:latest
+        docker tag quay.io/ambient_code/vteam_backend:latest quay.io/ambient_code/vteam_backend:e2e-test
 
-        # Build operator image (if changed or use latest)
-        if [ "${{ needs.detect-changes.outputs.operator }}" == "true" ]; then
-          echo "Building operator (changed)..."
-          docker build -t quay.io/ambient_code/vteam_operator:e2e-test \
-            -f components/operator/Dockerfile \
-            components/operator
-        else
-          echo "Operator unchanged, pulling latest..."
-          docker pull quay.io/ambient_code/vteam_operator:latest
-          docker tag quay.io/ambient_code/vteam_operator:latest quay.io/ambient_code/vteam_operator:e2e-test
-        fi
+    - name: Build or pull operator image
+      if: needs.detect-changes.outputs.operator == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/operator
+        file: components/operator/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_operator:e2e-test
+        cache-from: |
+          type=gha,scope=operator-amd64
+          type=gha,scope=e2e-operator
+        cache-to: type=gha,mode=max,scope=e2e-operator
 
-        # Build ambient-runner image (if changed or use latest)
-        if [ "${{ needs.detect-changes.outputs.claude-runner }}" == "true" ]; then
-          echo "Building ambient-runner (changed)..."
-          docker build -t quay.io/ambient_code/vteam_claude_runner:e2e-test \
-            components/runners/ambient-runner
-        else
-          echo "Claude-runner unchanged, pulling latest..."
-          docker pull quay.io/ambient_code/vteam_claude_runner:latest
-          docker tag quay.io/ambient_code/vteam_claude_runner:latest quay.io/ambient_code/vteam_claude_runner:e2e-test
-        fi
+    - name: Pull operator latest (unchanged)
+      if: needs.detect-changes.outputs.operator != 'true'
+      run: |
+        docker pull quay.io/ambient_code/vteam_operator:latest
+        docker tag quay.io/ambient_code/vteam_operator:latest quay.io/ambient_code/vteam_operator:e2e-test
 
-        echo ""
-        echo "✅ All images ready"
-        docker images | grep e2e-test
+    - name: Build or pull ambient-runner image
+      if: needs.detect-changes.outputs.claude-runner == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/runners
+        file: components/runners/ambient-runner/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_claude_runner:e2e-test
+        cache-from: |
+          type=gha,scope=ambient-runner-amd64
+          type=gha,scope=e2e-ambient-runner
+        cache-to: type=gha,mode=max,scope=e2e-ambient-runner
+
+    - name: Pull ambient-runner latest (unchanged)
+      if: needs.detect-changes.outputs.claude-runner != 'true'
+      run: |
+        docker pull quay.io/ambient_code/vteam_claude_runner:latest
+        docker tag quay.io/ambient_code/vteam_claude_runner:latest quay.io/ambient_code/vteam_claude_runner:e2e-test
+
+    - name: Show built images
+      run: docker images | grep e2e-test
 
     - name: Install kind
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,10 +40,10 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect changed components
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -80,10 +80,10 @@ jobs:
     name: Frontend Lint and Type Check
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: 'components/frontend/package.json'
           cache: 'npm'
@@ -116,10 +116,10 @@ jobs:
     name: Go Lint - Backend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'components/backend/go.mod'
           cache-dependency-path: 'components/backend/go.sum'
@@ -142,7 +142,7 @@ jobs:
           go vet ./...
 
       - name: Run golangci-lint (all build tags)
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: latest
           working-directory: components/backend
@@ -155,10 +155,10 @@ jobs:
     name: Go Lint - Operator
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'components/operator/go.mod'
           cache-dependency-path: 'components/operator/go.sum'
@@ -181,7 +181,7 @@ jobs:
           go vet ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: latest
           working-directory: components/operator
@@ -194,10 +194,10 @@ jobs:
     name: Go Lint - API Server
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'components/ambient-api-server/go.mod'
           cache-dependency-path: 'components/ambient-api-server/go.sum'
@@ -220,7 +220,7 @@ jobs:
           go vet ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: latest
           working-directory: components/ambient-api-server
@@ -233,10 +233,10 @@ jobs:
     name: Go Lint - CLI
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'components/ambient-cli/go.mod'
           cache-dependency-path: 'components/ambient-cli/go.sum'
@@ -259,7 +259,7 @@ jobs:
           go vet ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: latest
           working-directory: components/ambient-cli

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -141,14 +141,7 @@ jobs:
           cd components/backend
           go vet ./...
 
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
-          working-directory: components/backend
-          args: --timeout=5m
-
-      - name: Run golangci-lint (test build tags)
+      - name: Run golangci-lint (all build tags)
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -128,12 +128,11 @@ jobs:
           go run github.com/onsi/ginkgo/v2/ginkgo -r -v --cover --keep-going --github-output=true --tags=test --label-filter=${{ steps.configure.outputs.TEST_LABEL }} --junit-report=${{ env.JUNIT_FILENAME }} --output-dir=reports -- -testNamespace=${{ steps.configure.outputs.DEFAULT_NAMESPACE }}
         continue-on-error: true
 
-      - name: Install Junit2Html plugin and generate report
+      - name: Generate HTML test report
         if: (!cancelled())
         shell: bash
         run: |
-          pip install junit2html
-          junit2html ${{ env.TESTS_DIR }}/reports/${{ env.JUNIT_FILENAME }} ${{ env.TESTS_DIR }}/reports/test-report.html
+          pipx run junit2html ${{ env.TESTS_DIR }}/reports/${{ env.JUNIT_FILENAME }} ${{ env.TESTS_DIR }}/reports/test-report.html
         continue-on-error: true
 
       - name: Configure report name

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,10 +57,10 @@ jobs:
       scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect changed components
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -91,10 +91,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'components/backend/go.mod'
           cache-dependency-path: 'components/backend/go.sum'
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload HTML Report
         id: upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: (!cancelled())
         with:
           name: ${{ steps.name_gen.outputs.REPORT_NAME }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Publish Test Summary With HTML Report
         id: publish
-        uses: kubeflow/pipelines/.github/actions/junit-summary@master
+        uses: kubeflow/pipelines/.github/actions/junit-summary@ab1231a5c32c688bcb62314e467011b586aee796 # master
         if: (!cancelled()) && steps.upload.outcome != 'failure'
         with:
           xml_files: '${{ env.TESTS_DIR }}/reports'
@@ -164,7 +164,7 @@ jobs:
 
       - name: Publish Test Summary
         id: summary
-        uses: kubeflow/pipelines/.github/actions/junit-summary@master
+        uses: kubeflow/pipelines/.github/actions/junit-summary@ab1231a5c32c688bcb62314e467011b586aee796 # master
         if: (!cancelled()) && steps.upload.outcome == 'failure'
         with:
           xml_files: '${{ env.TESTS_DIR }}/reports'
@@ -191,10 +191,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'components/ambient-api-server/go.mod'
           cache-dependency-path: 'components/ambient-api-server/go.sum'
@@ -222,10 +222,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -249,10 +249,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'components/ambient-cli/go.mod'
           cache-dependency-path: 'components/ambient-cli/go.sum'
@@ -274,7 +274,7 @@ jobs:
           go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: cli-coverage-${{ github.run_id }}
@@ -292,10 +292,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: 'components/frontend/package.json'
           cache: 'npm'
@@ -314,10 +314,10 @@ jobs:
     name: Script Tests (model-discovery)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 

--- a/docs/superpowers/plans/2026-04-11-ci-improvements.md
+++ b/docs/superpowers/plans/2026-04-11-ci-improvements.md
@@ -1,0 +1,313 @@
+# CI Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce PR feedback loop wall-clock time from ~10.4m P50 to ~5-7m through targeted caching and shared Docker layer reuse.
+
+**Architecture:** Replace plain `docker build` in E2E with BuildKit builds that read from the same GHA cache scopes written by components-build-deploy. Add kind binary caching. Consolidate redundant golangci-lint passes. Replace pip-installed junit2html with pipx.
+
+**Tech Stack:** GitHub Actions, Docker BuildKit, GHA cache, golangci-lint, pipx
+
+---
+
+### Task 1: Add Docker BuildKit Layer Caching to E2E Image Builds
+
+**Files:**
+- Modify: `.github/workflows/e2e.yml:86-148`
+
+This is the highest-impact change. The E2E workflow currently uses plain `docker build` for 4 component images with no layer caching. We replace the monolithic shell script with individual `docker/build-push-action@v7` steps that use `cache-from` to read layers from both the components-build-deploy workflow's cache and the E2E's own cache.
+
+The components-build-deploy workflow writes cache with scopes like `frontend-amd64`, `backend-amd64`, etc. E2E runs on `ubuntu-latest` (amd64), so it can read those layers directly.
+
+- [ ] **Step 1: Replace the monolithic build step with individual buildx build steps**
+
+Replace the single "Build component images from PR code" step (lines 90-148) with 4 individual conditional steps. Each uses `docker/build-push-action@v7` with `load: true` (loads into local Docker daemon instead of pushing to registry) and reads from the components-build cache scope.
+
+Replace this block (lines 90-148):
+
+```yaml
+    - name: Build component images from PR code
+      run: |
+        echo "======================================"
+        ...entire shell script...
+```
+
+With these 4 steps:
+
+```yaml
+    - name: Build or pull frontend image
+      if: needs.detect-changes.outputs.frontend == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/frontend
+        file: components/frontend/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_frontend:e2e-test
+        cache-from: |
+          type=gha,scope=frontend-amd64
+          type=gha,scope=e2e-frontend
+        cache-to: type=gha,mode=max,scope=e2e-frontend
+
+    - name: Pull frontend latest (unchanged)
+      if: needs.detect-changes.outputs.frontend != 'true'
+      run: |
+        docker pull quay.io/ambient_code/vteam_frontend:latest
+        docker tag quay.io/ambient_code/vteam_frontend:latest quay.io/ambient_code/vteam_frontend:e2e-test
+
+    - name: Build or pull backend image
+      if: needs.detect-changes.outputs.backend == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/backend
+        file: components/backend/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_backend:e2e-test
+        cache-from: |
+          type=gha,scope=backend-amd64
+          type=gha,scope=e2e-backend
+        cache-to: type=gha,mode=max,scope=e2e-backend
+
+    - name: Pull backend latest (unchanged)
+      if: needs.detect-changes.outputs.backend != 'true'
+      run: |
+        docker pull quay.io/ambient_code/vteam_backend:latest
+        docker tag quay.io/ambient_code/vteam_backend:latest quay.io/ambient_code/vteam_backend:e2e-test
+
+    - name: Build or pull operator image
+      if: needs.detect-changes.outputs.operator == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/operator
+        file: components/operator/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_operator:e2e-test
+        cache-from: |
+          type=gha,scope=operator-amd64
+          type=gha,scope=e2e-operator
+        cache-to: type=gha,mode=max,scope=e2e-operator
+
+    - name: Pull operator latest (unchanged)
+      if: needs.detect-changes.outputs.operator != 'true'
+      run: |
+        docker pull quay.io/ambient_code/vteam_operator:latest
+        docker tag quay.io/ambient_code/vteam_operator:latest quay.io/ambient_code/vteam_operator:e2e-test
+
+    - name: Build or pull ambient-runner image
+      if: needs.detect-changes.outputs.claude-runner == 'true'
+      uses: docker/build-push-action@v7
+      with:
+        context: components/runners
+        file: components/runners/ambient-runner/Dockerfile
+        load: true
+        tags: quay.io/ambient_code/vteam_claude_runner:e2e-test
+        cache-from: |
+          type=gha,scope=ambient-runner-amd64
+          type=gha,scope=e2e-ambient-runner
+        cache-to: type=gha,mode=max,scope=e2e-ambient-runner
+
+    - name: Pull ambient-runner latest (unchanged)
+      if: needs.detect-changes.outputs.claude-runner != 'true'
+      run: |
+        docker pull quay.io/ambient_code/vteam_claude_runner:latest
+        docker tag quay.io/ambient_code/vteam_claude_runner:latest quay.io/ambient_code/vteam_claude_runner:e2e-test
+
+    - name: Show built images
+      run: docker images | grep e2e-test
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"`
+Expected: No output (valid YAML)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/e2e.yml
+git commit -m "ci(e2e): add Docker BuildKit layer caching to image builds
+
+Read from components-build-deploy cache scopes (frontend-amd64, etc.)
+so E2E gets warm layers from the last main build. Falls back to
+building uncached if cache misses."
+```
+
+---
+
+### Task 2: Cache kind Binary in E2E
+
+**Files:**
+- Modify: `.github/workflows/e2e.yml:1-10` (add env block)
+- Modify: `.github/workflows/e2e.yml:150-155` (replace Install kind step)
+
+The E2E workflow downloads `kind v0.27.0` from the internet every run. Add an `actions/cache` step matching the pattern already used in `test-local-dev.yml`.
+
+- [ ] **Step 1: Add KIND_VERSION env var at the workflow level**
+
+After the `on:` block and before `concurrency:`, add:
+
+```yaml
+env:
+  KIND_VERSION: "v0.27.0"
+```
+
+- [ ] **Step 2: Replace the "Install kind" step with a cached version**
+
+Replace this step:
+
+```yaml
+    - name: Install kind
+      run: |
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+        chmod +x ./kind
+        sudo mv ./kind /usr/local/bin/kind
+        kind version
+```
+
+With:
+
+```yaml
+    - name: Cache kind binary
+      uses: actions/cache@v4
+      id: kind-cache
+      with:
+        path: ~/k8s-tools/kind
+        key: kind-${{ runner.os }}-${{ env.KIND_VERSION }}
+
+    - name: Install kind
+      run: |
+        mkdir -p ~/k8s-tools
+        if [[ ! -f ~/k8s-tools/kind ]]; then
+          echo "Downloading kind $KIND_VERSION..."
+          curl -sLo ~/k8s-tools/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x ~/k8s-tools/kind
+        else
+          echo "Using cached kind"
+        fi
+        sudo cp ~/k8s-tools/kind /usr/local/bin/kind
+        kind version
+```
+
+- [ ] **Step 3: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"`
+Expected: No output (valid YAML)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/e2e.yml
+git commit -m "ci(e2e): cache kind binary between runs
+
+Pin version in env var for cache key stability. Matches pattern
+used in test-local-dev.yml."
+```
+
+---
+
+### Task 3: Consolidate golangci-lint Passes in Lint Workflow
+
+**Files:**
+- Modify: `.github/workflows/lint.yml:144-156`
+
+The `go-backend` job runs `golangci-lint` twice — once with default tags and once with `--build-tags=test`. The test tag is a superset: files with `//go:build test` are only compiled when the tag is present, so linting with `--build-tags=test` covers all production files plus test-tagged files. Replace two passes with one.
+
+- [ ] **Step 1: Replace the two golangci-lint steps with one**
+
+Replace these two steps in the `go-backend` job:
+
+```yaml
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          working-directory: components/backend
+          args: --timeout=5m
+
+      - name: Run golangci-lint (test build tags)
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          working-directory: components/backend
+          args: --timeout=5m --build-tags=test
+```
+
+With a single step:
+
+```yaml
+      - name: Run golangci-lint (all build tags)
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          working-directory: components/backend
+          args: --timeout=5m --build-tags=test
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"`
+Expected: No output (valid YAML)
+
+- [ ] **Step 3: Verify locally that test-tagged lint catches everything**
+
+Run: `cd components/backend && golangci-lint run --timeout=5m --build-tags=test 2>&1 | tail -5`
+Expected: Same or superset of issues found by default tags.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/lint.yml
+git commit -m "ci(lint): consolidate golangci-lint to single pass with test tags
+
+The test build tag is a superset of default — files with
+//go:build test are only included when the tag is present. A single
+pass with --build-tags=test covers all code."
+```
+
+---
+
+### Task 4: Replace pip-installed junit2html with pipx in Unit Tests
+
+**Files:**
+- Modify: `.github/workflows/unit-tests.yml:131-137`
+
+The backend unit test job runs `pip install junit2html` without caching on every run. `pipx` is pre-installed on GitHub Actions runners and handles isolated installs. Using `pipx run` avoids the install step entirely — pipx downloads and caches the tool itself.
+
+- [ ] **Step 1: Replace pip install with pipx run**
+
+Replace this step:
+
+```yaml
+      - name: Install Junit2Html plugin and generate report
+        if: (!cancelled())
+        shell: bash
+        run: |
+          pip install junit2html
+          junit2html ${{ env.TESTS_DIR }}/reports/${{ env.JUNIT_FILENAME }} ${{ env.TESTS_DIR }}/reports/test-report.html
+        continue-on-error: true
+```
+
+With:
+
+```yaml
+      - name: Generate HTML test report
+        if: (!cancelled())
+        shell: bash
+        run: |
+          pipx run junit2html ${{ env.TESTS_DIR }}/reports/${{ env.JUNIT_FILENAME }} ${{ env.TESTS_DIR }}/reports/test-report.html
+        continue-on-error: true
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/unit-tests.yml'))"`
+Expected: No output (valid YAML)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/unit-tests.yml
+git commit -m "ci(unit-tests): use pipx for junit2html instead of pip install
+
+pipx is pre-installed on GHA runners and handles caching. Avoids
+uncached pip install on every run."
+```

--- a/docs/superpowers/specs/2026-04-11-ci-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-11-ci-improvements-design.md
@@ -1,0 +1,143 @@
+# CI Improvements: Reduce PR Feedback Loop
+
+## Problem
+
+PR wall-clock time is gated by the slowest workflow. Current P50 times:
+
+| Workflow | P50 | Primary Bottleneck |
+|----------|-----|--------------------|
+| E2E Tests | 10.4m | Docker builds from scratch, no layer cache |
+| Test Local Dev | 4.9m | Full kind cluster + image build |
+| Docker Builds | 3.5m | Already cached (GHA layer cache) |
+| Unit Tests | 3.3m | Well-parallelized |
+| Lint | 1.6m | golangci-lint runs twice per Go component |
+
+## Approach
+
+Two complementary strategies:
+
+### A: Targeted Caching + Quick Wins
+
+Incremental improvements across all PR workflows without structural changes.
+
+### B: E2E Image Reuse
+
+Restructure E2E to consume images already built by the `components-build-deploy` workflow instead of rebuilding them.
+
+## Changes
+
+### 1. E2E Docker Layer Caching (Approach A)
+
+**File:** `.github/workflows/e2e.yml`
+
+Replace plain `docker build` commands with `docker buildx build` using GHA cache:
+
+```yaml
+- name: Build frontend
+  if: needs.detect-changes.outputs.frontend == 'true'
+  uses: docker/build-push-action@v7
+  with:
+    context: components/frontend
+    file: components/frontend/Dockerfile
+    load: true
+    tags: quay.io/ambient_code/vteam_frontend:e2e-test
+    cache-from: type=gha,scope=e2e-frontend
+    cache-to: type=gha,mode=max,scope=e2e-frontend
+```
+
+Repeat for backend, operator, ambient-runner (4 images total).
+
+**Expected savings:** 3-5 min on rebuilds (layer cache hits for unchanged layers).
+
+### 2. Cache kind Binary in E2E (Approach A)
+
+**File:** `.github/workflows/e2e.yml`
+
+Currently downloads kind v0.27.0 every run. Add `actions/cache` for the binary, matching the pattern already used in `test-local-dev.yml`.
+
+Pin version in an env var for cache key stability.
+
+**Expected savings:** ~10-15s per run.
+
+### 3. Consolidate golangci-lint Passes (Approach A)
+
+**File:** `.github/workflows/lint.yml`
+
+The `go-backend` job runs `golangci-lint-action` twice:
+1. Default build tags
+2. `--build-tags=test`
+
+The test tag is a superset — files with `//go:build test` are only compiled when the tag is present, so linting with `--build-tags=test` covers all files. Consolidate to a single pass with `--build-tags=test`.
+
+This applies only to `go-backend` — the other Go components (operator, api-server, cli) only run golangci-lint once.
+
+**Expected savings:** ~30s on backend lint.
+
+### 4. Cache junit2html in Unit Tests (Approach A)
+
+**File:** `.github/workflows/unit-tests.yml`
+
+The backend job runs `pip install junit2html` without caching. Add pip caching to the Go job's post-test reporting step, or pre-install in a cached venv.
+
+Simpler: use `pipx run junit2html` which avoids install entirely (pipx is pre-installed on GitHub runners).
+
+**Expected savings:** ~10s.
+
+### 5. E2E Image Reuse from Components Build (Approach B)
+
+**File:** `.github/workflows/e2e.yml`
+
+The `components-build-deploy` workflow already builds all images on PR and tags them `pr-<number>`. Instead of E2E rebuilding images, it should:
+
+1. Add `needs` dependency or use `workflow_run` trigger to wait for components-build
+2. Pull pre-built `pr-<number>` images from Quay.io
+3. Fall back to local build only if components-build was skipped (no component changes)
+
+**Implementation options:**
+
+**Option 1: workflow_run trigger** — E2E triggers after components-build completes. Clean separation but adds latency waiting for the full build matrix (14 jobs).
+
+**Option 2: Direct pull in E2E job** — E2E attempts to pull `pr-<number>` tagged images. If pull fails (image not pushed yet or components-build skipped), falls back to local build. This is simpler and doesn't create a hard dependency.
+
+**Recommendation: Option 2 (direct pull with fallback).** The components-build workflow only pushes on non-PR events currently (`if: github.event_name != 'pull_request'`), so we need to either:
+- Enable PR image pushes in components-build (to a PR-specific tag), or
+- Use the GHA Docker layer cache directly (E2E reads from same cache scope as components-build)
+
+The cleanest path: **share GHA cache scopes.** E2E's `cache-from` references the same scope that components-build writes to. No image push/pull needed — just shared BuildKit cache layers.
+
+```yaml
+# In e2e.yml - reuse cache from components-build
+cache-from: |
+  type=gha,scope=frontend-amd64
+  type=gha,scope=e2e-frontend
+cache-to: type=gha,mode=max,scope=e2e-frontend
+```
+
+This way E2E gets warm cache from the last components-build run on main, plus its own cache from prior E2E runs.
+
+**Expected savings:** 3-5 min (near-instant builds when layers haven't changed).
+
+## What We're NOT Changing
+
+- **Test Local Dev workflow:** Already well-optimized with k8s tools caching. The ~5 min is inherent to kind cluster bootstrap + image build + deploy. No easy wins without fundamentally changing the approach.
+- **Workflow consolidation:** Not merging lint + unit-tests. The separation is clean and the overhead is marginal (~30s for detect-changes + summary).
+- **Components-build-deploy push behavior:** Not enabling image pushes on PRs — the shared cache approach achieves the same benefit without registry overhead.
+
+## Risk Assessment
+
+| Change | Risk | Mitigation |
+|--------|------|------------|
+| Docker layer caching in E2E | Low — additive, fallback is uncached build | GHA cache has 10GB limit; scope names prevent collision |
+| kind caching | None — identical pattern to test-local-dev | Pin version in env var |
+| golangci-lint consolidation | Low — test tag is superset | Verify locally that `--build-tags=test` finds all issues |
+| junit2html via pipx | None — pipx pre-installed on runners | Can fall back to pip install |
+| Shared cache scopes | Medium — cache eviction if 10GB limit hit | Use `mode=max` and scope naming to partition |
+
+## Expected Outcome
+
+| Workflow | Current P50 | Expected P50 | Savings |
+|----------|-------------|--------------|---------|
+| E2E Tests | 10.4m | ~5-7m | 3-5m |
+| Lint | 1.6m | ~1.2m | ~30s |
+| Unit Tests | 3.3m | ~3.1m | ~10s |
+| **PR wall clock** | **~10.4m** | **~5-7m** | **3-5m** |


### PR DESCRIPTION
## Summary

- **E2E Docker layer caching:** Replace plain `docker build` with `docker/build-push-action@v7` using GHA cache. Reads layers from the components-build-deploy workflow's cache scopes (`frontend-amd64`, etc.) so E2E gets warm layers from the last main build. Expected savings: 3-5 min.
- **E2E kind binary caching:** Cache the kind binary between runs with `actions/cache@v4`. Pin version in env var for cache key stability. ~15s saved per run.
- **Lint golangci-lint consolidation:** Replace two sequential golangci-lint passes (default + test tags) with a single pass using `--build-tags=test` (superset). ~30s saved.
- **Unit tests pipx:** Replace uncached `pip install junit2html` with `pipx run junit2html` (pre-installed on GHA runners). ~10s saved.

**Current PR wall-clock P50:** ~10.4m (E2E bottleneck)
**Expected PR wall-clock P50:** ~5-7m

## Test plan

- [ ] Verify E2E workflow runs successfully with cached builds on a PR that changes component code
- [ ] Verify E2E workflow still pulls `:latest` for unchanged components
- [ ] Verify lint workflow passes with single golangci-lint pass
- [ ] Verify unit-tests backend job generates HTML report via pipx
- [ ] Confirm GHA cache scopes don't conflict with components-build-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows tightened: actions pinned to specific commits, E2E image handling changed to conditional build-or-pull steps with cache-aware builds, added a step to show built images, and introduced caching for the cluster binary to speed E2E runs
  * Linting consolidated into a single, more efficient pass
  * Unit-test reporting updated to avoid repeated installs and speed up report generation

* **Documentation**
  * Added CI improvements plan and design specification detailing changes and validation steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->