### PR TITLE
fix: use GitHub App token for model discovery PR approval

### DIFF
--- a/.github/workflows/model-discovery.yml
+++ b/.github/workflows/model-discovery.yml
@@ -89,10 +89,18 @@ jobs:
           labels: automated,models
           delete-branch: true
 
+      - name: Generate app token
+        if: steps.create-pr.outputs.pull-request-number
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AMBIENT_APP_ID }}
+          private-key: ${{ secrets.AMBIENT_APP_PRIVATE_KEY }}
+
       - name: Approve PR
         if: steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.AMBIENT_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr review "$PR_NUMBER" --approve --body "Manifest validation passed — auto-approved by model discovery workflow"
 

--- a/.github/workflows/model-discovery.yml
+++ b/.github/workflows/model-discovery.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Generate app token
         if: steps.create-pr.outputs.pull-request-number
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.AMBIENT_APP_ID }}
           private-key: ${{ secrets.AMBIENT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Replace `AMBIENT_BOT_TOKEN` (401 bad credentials) with `actions/create-github-app-token@v2`
- Uses the `ambient-code` GitHub App (ID 2057322) to generate fresh installation tokens at runtime
- No token rotation needed — tokens are ephemeral and scoped to the workflow run

## Prereqs
- `AMBIENT_APP_ID` and `AMBIENT_APP_PRIVATE_KEY` secrets must be set (confirmed done)

## Test plan
- [ ] Merge, then trigger `Model Discovery` workflow — verify approve + auto-merge succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal CI workflow authentication to use a generated app token for automated PR approval, improving security and reliability of automated processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->