### PR TITLE
fix: set API_SERVER_URL on frontend in kind overlay

### DIFF
--- a/components/manifests/overlays/kind/frontend-test-patch.yaml
+++ b/components/manifests/overlays/kind/frontend-test-patch.yaml
@@ -12,6 +12,9 @@ spec:
         # Backend API URL for server-side Next.js API routes
         - name: BACKEND_URL
           value: "http://backend-service.ambient-code.svc.cluster.local:8080/api"
+        # API Server URL for intelligence and other ambient-api-server proxy routes
+        - name: API_SERVER_URL
+          value: "http://ambient-api-server.ambient-code.svc.cluster.local:8000"
         # E2E testing: provide token for both server-side and client-side
         - name: OC_TOKEN
           valueFrom:


### PR DESCRIPTION
## Summary
- Frontend proxy routes for intelligence data call `API_SERVER_URL`, which defaults to `http://localhost:8000`
- Inside the kind cluster, this doesn't reach the `ambient-api-server` service
- Adds the env var to `frontend-test-patch.yaml` pointing at the in-cluster DNS name

## Test plan
- [x] Verified manually on kind cluster — intelligence proxy route returns data after setting this env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend deployment configuration to enable API server connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->