### PR TITLE
fix(ci): add Mergify auto-update rule to keep PRs rebased on main

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,6 +27,13 @@ pull_request_rules:
       review:
         type: APPROVE
 
+  - name: keep PRs up to date with main
+    conditions:
+      - -conflict
+      - -draft
+    actions:
+      update: {}
+
   - name: queue large PRs
     conditions:
       - or:


### PR DESCRIPTION
## Summary

- Adds a `pull_request_rules` entry with the `update` action so Mergify automatically rebases non-draft, non-conflicting PRs onto `main` when they fall behind
- Without this, PRs that pass CI go stale as other PRs merge, accumulating conflicts that block the merge queue

## Why

Mergify's merge queue was configured but PRs were never actually merging through it because there was no auto-rebase. Every time a PR merged to `main`, the remaining queued PRs would fall behind and conflict — requiring manual rebases that never happened.

## Test plan

- [ ] Mergify validates config on push (check "Configuration changed" status)
- [ ] Observe that open PRs without conflicts get rebased automatically after the next merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request management automation to keep pull requests current with the base branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->