### PR TITLE
fix(skill): add frontend accessibility validation to dev-cluster

### DIFF
--- a/.claude/skills/dev-cluster/SKILL.md
+++ b/.claude/skills/dev-cluster/SKILL.md
@@ -252,15 +252,63 @@ kubectl get pods -n ambient-code
 kubectl get events -n ambient-code --sort-by='.lastTimestamp'
 ```
 
-### Step 6: Provide Access Info
+### Step 6: Validate Frontend Accessibility
 
-**Detect the actual URL** by checking the kind container's port mapping (see "Detecting the Access URL" above), then provide the correct URL to the user.
+After deployment, **always verify the frontend is reachable** before reporting success. Port forwarding dies on rollout restarts, context switches, and timeouts — silently.
+
+**Key distinction:**
+- **Connection refused (curl exit code 7)** → port forwarding is broken. Fix it and retry.
+- **HTTP error (4xx/5xx)** → port forwarding works but the app is unhealthy. Check pod logs.
+
+```bash
+# Validate frontend is reachable
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$KIND_FWD_FRONTEND_PORT 2>/dev/null)
+CURL_EXIT=$?
+```
+
+**If connection refused (exit code 7):**
+
+1. Kill stale port-forward processes: `pkill -f "port-forward.*ambient-code"`
+2. Verify kubectl context: `kubectl config current-context` should start with `kind-`
+3. If wrong context: `kubectl config use-context kind-$KIND_CLUSTER_NAME`
+4. Restart: `make kind-port-forward &`
+5. Wait and retry
+
+**Retry loop (use this pattern):**
+```bash
+for attempt in 1 2 3; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$KIND_FWD_FRONTEND_PORT 2>/dev/null)
+  CURL_EXIT=$?
+  if [ "$CURL_EXIT" -eq 0 ] && [ "$STATUS" = "200" ]; then
+    echo "Frontend accessible at http://localhost:$KIND_FWD_FRONTEND_PORT"
+    break
+  fi
+  if [ "$CURL_EXIT" -eq 7 ]; then
+    echo "Attempt $attempt: connection refused — restarting port-forward..."
+    pkill -f "port-forward.*ambient-code" 2>/dev/null
+    sleep 1
+    kubectl config use-context kind-$(make -s kind-cluster-name 2>/dev/null || echo "ambient-local") 2>/dev/null
+    make kind-port-forward &
+    sleep 3
+  else
+    echo "Attempt $attempt: frontend returned HTTP $STATUS — check pod logs"
+    kubectl logs -l app=frontend -n ambient-code --tail=20
+    break
+  fi
+done
+```
+
+**CRITICAL:** Never tell the user "the cluster is ready" or provide a URL without first confirming the frontend responds. A URL that doesn't load is worse than no URL.
+
+### Step 7: Provide Access Info
+
+Only after frontend validation passes:
 
 ```
-✓ Deployment complete!
+✓ Deployment complete! Frontend verified accessible.
 
 Access the platform at:
-- Frontend: <detected URL from port mapping>
+- Frontend: http://localhost:$KIND_FWD_FRONTEND_PORT (verified ✓)
 - Test credentials: Check .env.test for the token
 
 To view logs:


### PR DESCRIPTION
## Summary

- Adds Step 6 (validate frontend) to the dev-cluster skill before providing access URLs
- Distinguishes connection refused (curl exit 7 = port-forward broken) from HTTP errors (app unhealthy)
- Includes retry loop that auto-fixes port forwarding on connection refused
- Never reports "cluster is ready" without confirming the frontend actually responds

## Test plan

- [ ] Invoke dev-cluster skill — verify it validates frontend accessibility before reporting success
- [ ] Kill port forwarding mid-session — verify skill detects and recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Frontend accessibility is now verified before setup completion
  * Automatic recovery from port-forwarding failures with intelligent retry logic
  * Enhanced error diagnostics guide users to troubleshoot frontend health issues
  * Success message displays the verified local frontend URL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->