### PR TITLE
docs: move project conventions from local memory to repo docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Rules that apply across ALL components. Per-component details live in component 
 - **No `panic()` in production**: Return explicit `fmt.Errorf` with context
 - **No `any` types in frontend**: Use proper types, `unknown`, or generic constraints
 - **Feature flags strongly recommended**: Gate new features behind Unleash flags. Use `/unleash-flag` to set up
+- **No new CRDs**: Existing CRDs (AgenticSession, ProjectSettings) are grandfathered. For new persistent storage, confirm with the user whether to use repo files or PostgreSQL — do not default to K8s custom resources
 - **Conventional commits**: Squashed on merge to `main`
 
 Component-specific conventions:

--- a/components/backend/DEVELOPMENT.md
+++ b/components/backend/DEVELOPMENT.md
@@ -105,6 +105,15 @@ if !found || err != nil {
 4. **Update operator:** Handle new field in reconciliation
 5. **Test:** Create sample CR with new field
 
+## OOTB Workflows
+
+Workflows live in `github.com/ambient-code/workflows`. Each has `.ambient/ambient.json` with: `name`, `description`, `systemPrompt`, `startupPrompt`, `greeting`.
+
+- `greeting` = user-facing text displayed instantly with typewriter effect (no LLM call)
+- `startupPrompt` = instruction to Claude (reserved for future use, not currently sent)
+- Backend caches OOTB workflows for 5 min (`ootbCacheTTL`) — restart backend to force refresh
+- Backend parses `ambient.json` via GitHub API — invalid JSON silently fails (returns empty fields)
+
 ## Pre-Commit Checklist
 
 - [ ] All user operations use `GetK8sClientsForRequest`

--- a/components/frontend/DEVELOPMENT.md
+++ b/components/frontend/DEVELOPMENT.md
@@ -99,6 +99,26 @@ app/
         page.tsx           # Uses session-card
 ```
 
+## Feature Flags
+
+**FORBIDDEN:** `useFlag()` from `@unleash/proxy-client-react` — it doesn't work with workspace overrides.
+
+**REQUIRED:** `useWorkspaceFlag(projectName, flagName)` for workspace-scoped flags (shared hook, 15s staleTime). Evaluates: ConfigMap override > Unleash default.
+
+```typescript
+// ❌ BAD
+import { useFlag } from "@unleash/proxy-client-react"
+const enabled = useFlag("my-feature")
+
+// ✅ GOOD
+import { useWorkspaceFlag } from "@/services/queries/feature-flags"
+const enabled = useWorkspaceFlag(projectName, "my-feature")
+```
+
+If a specific page needs instant flag freshness, use `useQuery` with `evaluateFeatureFlag()` directly and set `staleTime: 0, refetchOnMount: 'always'` — don't modify the shared hook.
+
+New flags go in `components/manifests/base/core/flags.json` with `scope:workspace` tag. Use `/unleash-flag` to scaffold.
+
 ## Common Patterns
 
 ### Page Structure
@@ -156,6 +176,37 @@ export function useCreateSession(projectName: string) {
   })
 }
 ```
+
+## Session Creation: Adding Options to the + Menu
+
+The `+` button dropdown in `new-session-view.tsx` is the single entry point for all per-session configuration.
+
+**File:** `src/app/projects/[name]/sessions/[sessionName]/components/new-session-view.tsx`
+
+### Adding a Boolean Toggle
+
+1. Add state: `const [myToggle, setMyToggle] = useState(false)`
+2. Add `DropdownMenuCheckboxItem` after `<DropdownMenuSeparator />`
+3. Wire into `handleSubmit` → `onCreateSession({ ..., myToggle: myToggle || undefined })`
+4. Update `NewSessionViewProps.onCreateSession` config type
+5. Wire through `page.tsx` into the mutation payload
+6. Bump `MENU_VERSION` constant (triggers the discovery dot)
+
+### Adding a Form-Heavy Config
+
+1. Create form component (e.g., `components/my-config.tsx`) with save/preview/dirty-guard
+2. Add `DropdownMenuItem` that opens a `Dialog`
+3. Render the `Dialog` outside the dropdown (at component root level)
+4. Wire saved values into `handleSubmit` → `onCreateSession`
+5. Bump `MENU_VERSION` constant
+
+### Discovery Dot
+
+`MENU_VERSION` constant (date string) + `useLocalStorage` with key `acp-menu-seen-version`. Bump the version when adding new menu items — the dot appears until the user opens the menu.
+
+### Backend Wiring
+
+New options flow: `onCreateSession` config → `page.tsx` → `createSessionMutation.mutate()` → POST `/api/projects/{project}/agentic-sessions` → backend handler → CR spec. For booleans, add to `CreateAgenticSessionRequest` in `types/session.go`. For complex options, serialize to env var on the CR and parse in the runner.
 
 ## Pre-Commit Checklist
 

--- a/docs/security-standards.md
+++ b/docs/security-standards.md
@@ -50,6 +50,10 @@ func customRedactingFormatter(param gin.LogFormatterParams) string {
 }
 ```
 
+### Token Lifetime (K8s TokenRequest)
+
+K8s `TokenRequest` API does NOT support non-expiring tokens. If `ExpirationSeconds` is omitted, K8s silently applies a default (~1h). Maximum enforced lifetime: **1 year** (31536000 seconds), validated in backend `CreateProjectKey`. Frontend default: 90 days.
+
 ### RBAC Enforcement
 
 **1. Always Check Permissions Before Operations**


### PR DESCRIPTION
## Summary
- Surfaces non-obvious conventions that were trapped in personal Claude Code memory into checked-in docs where all contributors benefit
- Adds feature flag usage rules (`useWorkspaceFlag` not `useFlag`), session creation menu patterns, OOTB workflow architecture, K8s TokenRequest lifetime gotcha, and the no-new-CRDs constraint
- No code changes — docs only

## Changes
| File | What |
|------|------|
| `CLAUDE.md` | Added "No new CRDs" to Critical Conventions |
| `components/frontend/DEVELOPMENT.md` | Feature flags section + session creation + menu patterns |
| `components/backend/DEVELOPMENT.md` | OOTB workflow architecture (greeting vs startupPrompt, cache TTL, silent JSON failure) |
| `docs/security-standards.md` | K8s TokenRequest silent default lifetime gotcha |

## Test plan
- [ ] Docs render correctly in GitHub markdown preview
- [ ] No conflicts with PR #1307 (claude automation overhaul)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cross-cutting convention clarifying Kubernetes custom resource constraints for persistent storage.
  * Documented Out-of-the-Box Workflows configuration, caching behavior, and expected field specifications.
  * Added Feature Flags usage guidelines and session creation workflow documentation.
  * Documented token lifetime security standards, including constraints and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->