### PR TITLE
feat: add optional cluster-reader service account overlay

### DIFF
--- a/components/manifests/overlays/cluster-reader/README.md
+++ b/components/manifests/overlays/cluster-reader/README.md
@@ -22,13 +22,14 @@ oc apply -k components/manifests/overlays/cluster-reader/
 
 # Override namespace
 cd components/manifests/overlays/cluster-reader
-kustomize edit set namespace my-namespace
+NS=my-namespace
+kustomize edit set namespace "${NS}"
 oc apply -k .
 
 # Get a token (max 1 year)
-oc create token readonly-admin -n ambient-code --duration=8760h
+oc create token readonly-admin -n "${NS}" --duration=8760h
 
 # Verify read-only access
-oc auth can-i get pods --all-namespaces --as=system:serviceaccount:ambient-code:readonly-admin
-oc auth can-i delete pods -n ambient-code --as=system:serviceaccount:ambient-code:readonly-admin
+oc auth can-i get pods --all-namespaces --as=system:serviceaccount:${NS}:readonly-admin
+oc auth can-i delete pods -n "${NS}" --as=system:serviceaccount:${NS}:readonly-admin
 ```

--- a/components/manifests/overlays/cluster-reader/README.md
+++ b/components/manifests/overlays/cluster-reader/README.md
@@ -1,0 +1,34 @@
+# Cluster Reader Service Account
+
+Read-only service account using OpenShift's built-in `cluster-reader` ClusterRole.
+
+## Use cases
+
+- CI pipelines that observe cluster state (pod status, deployment health, events)
+- Development tooling and dashboards
+- Any automation that needs cluster-wide visibility without write access
+
+## Permissions
+
+- **Can read**: pods, deployments, nodes, namespaces, configmaps, events, and most other resources across all namespaces
+- **Cannot read**: secrets
+- **Cannot write**: anything (create, update, delete, patch all denied)
+
+## Usage
+
+```bash
+# Apply (OpenShift only — cluster-reader does not exist on vanilla K8s/kind)
+oc apply -k components/manifests/overlays/cluster-reader/
+
+# Override namespace
+cd components/manifests/overlays/cluster-reader
+kustomize edit set namespace my-namespace
+oc apply -k .
+
+# Get a token (max 1 year)
+oc create token readonly-admin -n ambient-code --duration=8760h
+
+# Verify read-only access
+oc auth can-i get pods --all-namespaces --as=system:serviceaccount:ambient-code:readonly-admin
+oc auth can-i delete pods -n ambient-code --as=system:serviceaccount:ambient-code:readonly-admin
+```

--- a/components/manifests/overlays/cluster-reader/cluster-role-binding.yaml
+++ b/components/manifests/overlays/cluster-reader/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: readonly-admin-cluster-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: readonly-admin
+    namespace: ambient-code

--- a/components/manifests/overlays/cluster-reader/kustomization.yaml
+++ b/components/manifests/overlays/cluster-reader/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ambient-code
+
+resources:
+  - service-account.yaml
+  - cluster-role-binding.yaml

--- a/components/manifests/overlays/cluster-reader/service-account.yaml
+++ b/components/manifests/overlays/cluster-reader/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: readonly-admin


### PR DESCRIPTION
## Summary

- Adds a standalone kustomize overlay at `components/manifests/overlays/cluster-reader/` that creates a read-only service account bound to OpenShift's built-in `cluster-reader` ClusterRole
- Not applied by default — must be explicitly applied with `oc apply -k`
- OpenShift only — `cluster-reader` does not exist on vanilla K8s/kind

## Use cases

- CI pipelines that need to observe cluster state without write access
- Dev tooling and dashboards for Ambient platform development
- Any automation that needs cluster-wide read visibility

## Permissions granted

- **Can read**: pods, deployments, nodes, namespaces, configmaps, events, and most resources cluster-wide
- **Cannot read**: secrets
- **Cannot write**: anything (create, update, delete, patch all denied)

## Test plan

- [x] `kustomize build components/manifests/overlays/cluster-reader/` renders valid YAML
- [x] Tested on CRC (OpenShift 4.21): SA created, reads succeed, writes return 403
- [x] Verified `cluster-reader` excludes secret read access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a read-only, cluster-wide service account that grants broad read access across namespaces while preventing secret reads and any write/delete operations.

* **Documentation**
  * Added a setup and usage guide for deploying the read-only overlay in OpenShift, including namespace configuration, token creation, and verification commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->