### PR TITLE
fix(ci): drop review requirement from Mergify for single-maintainer workflow

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,18 +1,8 @@
 queue_rules:
-  - name: large-pr
-    autoqueue: true
-    merge_method: squash
-    queue_conditions:
-      - "#approved-reviews-by>=2"
-      - "#changes-requested-reviews-by=0"
-      - check-success=End-to-End Tests
-      - check-success=Local Dev CI Gate
-
   - name: default
     autoqueue: true
     merge_method: squash
     queue_conditions:
-      - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - check-success=End-to-End Tests
       - check-success=Local Dev CI Gate
@@ -32,21 +22,10 @@ pull_request_rules:
     actions:
       update: {}
 
-  - name: queue large PRs
+  - name: queue PRs when CI passes
     conditions:
-      - or:
-        - "#files>10"
-        - "#added-lines>500"
-        - "#deleted-lines>500"
-    actions:
-      queue:
-        name: large-pr
-
-  - name: queue normal PRs
-    conditions:
-      - "#files<=10"
-      - "#added-lines<=500"
-      - "#deleted-lines<=500"
+      - -draft
+      - -conflict
     actions:
       queue:
         name: default

--- a/components/runners/ambient-runner/ambient_runner/bridges/gemini_cli/session.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/gemini_cli/session.py
@@ -152,7 +152,9 @@ class GeminiSessionWorker:
             stderr=asyncio.subprocess.PIPE,
             cwd=self._cwd,
             env=env,
-            limit=10 * 1024 * 1024,  # 10 MB — default 64 KB is too small for large MCP tool responses
+            limit=10
+            * 1024
+            * 1024,  # 10 MB — default 64 KB is too small for large MCP tool responses
         )
 
         # Start concurrent stderr streaming

--- a/components/runners/ambient-runner/tests/test_gemini_session.py
+++ b/components/runners/ambient-runner/tests/test_gemini_session.py
@@ -106,7 +106,9 @@ class TestWorkerSubprocessConfig:
         """
         payload = "x" * 100_000  # 100 KB — well above the old 64 KB default
         proc = await asyncio.create_subprocess_exec(
-            "python3", "-c", f'print("{payload}")',
+            "python3",
+            "-c",
+            f'print("{payload}")',
             stdout=asyncio.subprocess.PIPE,
             limit=10 * 1024 * 1024,
         )


### PR DESCRIPTION
## Summary
- Remove approval gates from merge queue — PRs merge on green CI without human review
- Remove large-pr queue (no tiered review needed with one maintainer)
- Keep CI gates, changes-requested block, dependabot auto-approval, auto-rebase

This is the first PR that should auto-merge itself once CI passes.

## Test plan
- [ ] This PR auto-merges when CI passes (no approval needed)
- [ ] Requesting changes on a subsequent PR blocks the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified pull request queueing by consolidating rules and reducing extra approval gating for smoother merge flow.
  * Minor runtime invocation tweak to improve subprocess handling reliability.

* **Tests**
  * Adjusted a subprocess-related test invocation to more robustly exercise large-output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->