### PR TITLE
fix(e2e): wait for form input to be enabled before typing

### DIFF
--- a/e2e/cypress/e2e/scheduled-sessions.cy.ts
+++ b/e2e/cypress/e2e/scheduled-sessions.cy.ts
@@ -72,6 +72,13 @@ describe('Scheduled Sessions', () => {
     }
   })
 
+  function waitForFormReady() {
+    cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+      .should('not.be.disabled')
+    cy.get('[data-testid="schedule-preset-select"]', { timeout: 10000 })
+      .should('not.be.disabled')
+  }
+
   // Helper: create a scheduled session via API, return its name
   function createScheduledSessionViaApi(schedule: string, displayName?: string): Cypress.Chainable<string> {
     return cy.request({
@@ -99,9 +106,9 @@ describe('Scheduled Sessions', () => {
   describe('Schedule Creation', () => {
     it('should create a scheduled session with a preset schedule', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+      waitForFormReady()
 
-      // Fill display name
-      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+      cy.get('[data-testid="scheduled-session-name-input"]')
         .type('Preset Schedule Test')
 
       // Select "Daily at 9:00 AM" preset
@@ -133,9 +140,9 @@ describe('Scheduled Sessions', () => {
 
     it('should create a scheduled session with a custom cron expression', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+      waitForFormReady()
 
-      // Fill display name
-      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+      cy.get('[data-testid="scheduled-session-name-input"]')
         .type('Custom Cron Test')
 
       // Select "Custom" preset
@@ -171,9 +178,9 @@ describe('Scheduled Sessions', () => {
   describe('Cron Validation', () => {
     it('should show client-side validation error when custom cron is empty', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+      waitForFormReady()
 
-      // Select "Custom" preset
-      cy.get('[data-testid="schedule-preset-select"]', { timeout: 10000 }).click()
+      cy.get('[data-testid="schedule-preset-select"]').click()
       cy.get('[role="option"]').contains('Custom').click()
 
       // Leave custom cron input empty
@@ -197,9 +204,9 @@ describe('Scheduled Sessions', () => {
 
     it('should show server-side validation error for invalid cron syntax', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+      waitForFormReady()
 
-      // Select "Custom" preset
-      cy.get('[data-testid="schedule-preset-select"]', { timeout: 10000 }).click()
+      cy.get('[data-testid="schedule-preset-select"]').click()
       cy.get('[role="option"]').contains('Custom').click()
 
       // Enter invalid cron (3 fields instead of required 5)
@@ -272,9 +279,9 @@ describe('Scheduled Sessions', () => {
   describe('Custom Workflow', () => {
     it('should create a scheduled session with a custom workflow', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
+      waitForFormReady()
 
-      // Fill display name
-      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+      cy.get('[data-testid="scheduled-session-name-input"]')
         .type('Custom Workflow Test')
 
       // Leave default schedule preset (Every hour)

--- a/e2e/cypress/e2e/scheduled-sessions.cy.ts
+++ b/e2e/cypress/e2e/scheduled-sessions.cy.ts
@@ -108,7 +108,8 @@ describe('Scheduled Sessions', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
       waitForFormReady()
 
-      cy.get('[data-testid="scheduled-session-name-input"]')
+      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+        .should('not.be.disabled')
         .type('Preset Schedule Test')
 
       // Select "Daily at 9:00 AM" preset
@@ -142,7 +143,8 @@ describe('Scheduled Sessions', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
       waitForFormReady()
 
-      cy.get('[data-testid="scheduled-session-name-input"]')
+      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+        .should('not.be.disabled')
         .type('Custom Cron Test')
 
       // Select "Custom" preset
@@ -281,7 +283,8 @@ describe('Scheduled Sessions', () => {
       cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/new`)
       waitForFormReady()
 
-      cy.get('[data-testid="scheduled-session-name-input"]')
+      cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+        .should('not.be.disabled')
         .type('Custom Workflow Test')
 
       // Leave default schedule preset (Every hour)

--- a/e2e/cypress/e2e/scheduled-sessions.cy.ts
+++ b/e2e/cypress/e2e/scheduled-sessions.cy.ts
@@ -73,9 +73,11 @@ describe('Scheduled Sessions', () => {
   })
 
   function waitForFormReady() {
-    cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
+    cy.get('[data-testid="runner-type-select"]', { timeout: 15000 })
       .should('not.be.disabled')
-    cy.get('[data-testid="schedule-preset-select"]', { timeout: 10000 })
+    cy.get('[data-testid="model-select"]', { timeout: 15000 })
+      .should('not.be.disabled')
+    cy.get('[data-testid="scheduled-session-name-input"]', { timeout: 10000 })
       .should('not.be.disabled')
   }
 


### PR DESCRIPTION
## Summary
- Adds `should('not.be.disabled')` guard before `cy.type()` in the custom cron test
- Fixes race condition where the input was still disabled from the previous test's mutation

## Test plan
- [ ] E2E scheduled-sessions tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved scheduled-sessions end-to-end tests by adding a shared readiness check that waits for key form controls to appear and become enabled before interaction, removed redundant per-call timeouts for element waits, and added explicit enabled-state assertions to make tests more reliable and less flaky.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->