### PR TITLE
fix: correct PreToolUse hook format in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,12 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "command": "scripts/hooks/pr-review-gate.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "scripts/hooks/pr-review-gate.sh"
+          }
+        ]
       },
       {
         "matcher": "Edit|Write",


### PR DESCRIPTION
## Summary
- The first `PreToolUse` hook entry used a flat `command` property instead of the required `hooks: [{type, command}]` array wrapper
- This caused a settings validation error on every Claude Code startup, forcing manual dismissal

## Test plan
- [ ] Start Claude Code in the repo — no settings error dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration structure to use explicit nested format for tool hook definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->