### PR TITLE
feat(cli): alpha migration PR 5 — CLI enhancements

### DIFF
--- a/components/ambient-cli/README.md
+++ b/components/ambient-cli/README.md
@@ -21,91 +21,231 @@ This produces an `acpctl` binary in the current directory with embedded version 
 
 ```bash
 # With a token and API server URL
-./acpctl login --token <your-token> --url http://localhost:8000 --project myproject
+acpctl login <api-url> --token <your-token>
+
+# Skip TLS verification (e.g. local Kind cluster)
+acpctl login <api-url> --token <your-token> --insecure-skip-tls-verify
+
+# Use RH SSO
+acpctl login --use-auth-code --url https://ambient-api-server-ambient-code--ambient-s0.apps.int.spoke.dev.us-east-1.aws.paas.redhat.com
 
 # Verify
-./acpctl whoami
+acpctl whoami
+# User: service-account-bob
+# Project: myproject
 ```
 
 ### 2. Configure defaults
 
 ```bash
 # Set or change the default project
-./acpctl config set project myproject
+acpctl config set project myproject
+
+# Switch active project context (shorthand)
+acpctl project myproject
+
+# Show the currently active project
+acpctl project current
 
 # View current settings
-./acpctl config get api_url
-./acpctl config get project
+acpctl config get api_url
+acpctl config get project
 ```
 
 ### 3. List resources
 
 ```bash
-# List sessions (table format)
-./acpctl get sessions
+# Sessions
+acpctl get sessions
+acpctl get sessions -o json
 
-# List projects
-./acpctl get projects
+# Single session by ID
+acpctl get session <session-id>
+acpctl get session <session-id> -o json
 
-# JSON output
-./acpctl get sessions -o json
+# Projects
+acpctl get projects
 
-# Single resource by ID
-./acpctl get session <session-id>
+# Agents
+acpctl get agents
+acpctl get agents -o json
+
+# Credentials
+acpctl get credentials
+acpctl get credentials -o json
+
+# Roles
+acpctl get roles
+acpctl get roles -o json
 ```
 
 ### 4. Create resources
 
 ```bash
 # Create a project
-./acpctl create project --name my-project --display-name "My Project"
+acpctl create project --name my-project --display-name "My Project" --description "Demo project"
 
 # Create a session
-./acpctl create session --name fix-bug-123 \
+acpctl create session --name fix-bug-123 \
   --prompt "Fix the null pointer in handler.go" \
   --repo-url https://github.com/org/repo \
   --model sonnet
 
 # Create with all options
-./acpctl create session --name refactor-auth \
+acpctl create session --name refactor-auth \
   --prompt "Refactor the auth middleware" \
   --model sonnet \
   --max-tokens 4000 \
   --temperature 0.7 \
   --timeout 3600
+
+# Create an agent
+acpctl agent create \
+  --project-id my-project \
+  --name my-agent \
+  --prompt "You are a GitHub automation agent."
+
+# Create a role binding (bind a credential role to an agent)
+acpctl create role-binding \
+  --user-id <user-id> \
+  --role-id <role-id> \
+  --scope agent \
+  --scope-id <agent-id>
 ```
 
-### 5. Session lifecycle
+### 5. Apply declarative manifests
+
+`acpctl apply` creates or updates resources from YAML files. Token values can be
+injected via environment variables referenced in the manifest.
+
+```bash
+# Apply a credential manifest
+cat > credential.yaml <<'EOF'
+kind: Credential
+name: my-github-pat
+provider: github
+token: $GITHUB_TOKEN
+description: GitHub PAT for CI
+EOF
+
+GITHUB_TOKEN="ghp_..." acpctl apply -f credential.yaml
+```
+
+Supported `kind` values: `Credential` (additional kinds vary by deployment).
+
+### 6. Agent sessions
+
+```bash
+# Start a session for a named agent with an initial prompt
+acpctl agent start <agent-name> \
+  --project-id <project-name> \
+  --prompt "Open a test issue in org/repo"
+
+# Start and capture the session ID
+SESSION_JSON=$(acpctl agent start my-agent --project-id my-project --prompt "..." -o json)
+SESSION_ID=$(echo "$SESSION_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+```
+
+### 7. Session lifecycle
 
 ```bash
 # Start a session
-./acpctl start <session-id>
+acpctl start <session-id>
 
 # Stop a session
-./acpctl stop <session-id>
+acpctl stop <session-id>
 ```
 
-### 6. Inspect resources
+### 8. Session messages
 
 ```bash
-# Full JSON detail of a session
-./acpctl describe session <session-id>
+# List all messages for a session (table format)
+acpctl session messages <session-id>
 
-# Full JSON detail of a project
-./acpctl describe project <project-id>
+# JSON output
+acpctl session messages <session-id> -o json
+
+# Stream new messages live (follow mode)
+acpctl session messages <session-id> -f
+
+# Stream only messages after a known sequence number
+acpctl session messages <session-id> -f --after 42
+
+# Send a user message to a running session (multi-turn)
+acpctl session send <session-id> "Please also update the test file."
 ```
 
-### 7. Delete resources
+### 9. Inspect resources
 
 ```bash
-./acpctl delete project <project-id>
-./acpctl delete project-settings <id>
+# Full detail of a session
+acpctl describe session <session-id>
+
+# Full detail of a project
+acpctl describe project <project-id>
 ```
 
-### 8. Log out
+### 10. Delete resources
 
 ```bash
-./acpctl logout
+acpctl delete session <session-id> -y
+acpctl delete project <project-id> -y
+acpctl delete project-settings <id>
+acpctl credential delete <credential-id> --confirm
+```
+
+### 11. Log out
+
+```bash
+acpctl logout
+```
+
+## Credentials
+
+Credentials store secrets (e.g. GitHub PATs, API keys) that are injected into
+agent sessions at runtime. The runner retrieves the raw token via the
+credentials API, so the secret is never embedded in session configuration.
+
+```bash
+# List credentials
+acpctl get credentials
+
+# Create via apply (token injected from env var — never passed as a flag)
+GITHUB_TOKEN="ghp_..." acpctl apply -f credential.yaml
+
+# Delete
+acpctl credential delete <credential-id> --confirm
+```
+
+### Role bindings
+
+Access to credentials is controlled by role bindings. The relevant roles are:
+
+| Role | Permission |
+|---|---|
+| `credential:token-reader` | Retrieve the raw credential token via `GET /credentials/{id}/token` |
+| `credential:reader` | Read credential metadata (name, provider, description) |
+
+```bash
+# Look up a role ID
+ROLE_ID=$(acpctl get roles -o json | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+items = data.get('items', []) if isinstance(data, dict) else data
+for r in items:
+    if r.get('name') == 'credential:token-reader':
+        print(r['id']); break
+")
+
+# Get your user ID
+MY_USER_ID=$(acpctl whoami | awk '/^User:/{print $2}')
+
+# Bind the role to an agent (agent can now retrieve the token)
+acpctl create role-binding \
+  --user-id "${MY_USER_ID}" \
+  --role-id "${ROLE_ID}" \
+  --scope agent \
+  --scope-id <agent-id>
 ```
 
 ## Try It Now (No Server Required)
@@ -122,12 +262,12 @@ make build
 ./acpctl create --help
 
 # Login and config flow
-./acpctl login --token test-token --url http://localhost:8000 --project demo
+./acpctl login http://localhost:8000 --token test-token
 ./acpctl whoami
 ./acpctl config get api_url
 ./acpctl config get project
 ./acpctl config set project other-project
-./acpctl config get project
+./acpctl project current
 
 # Shell completion
 ./acpctl completion bash

--- a/components/ambient-cli/cmd/acpctl/agent/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/agent/cmd.go
@@ -1,18 +1,774 @@
-// Package agent implements subcommands for interacting with agents.
+// Package agent implements the agent subcommand for managing agents.
 package agent
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/output"
+	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
+	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
 	"github.com/spf13/cobra"
 )
 
+var activePhases = map[string]bool{"Pending": true, "Creating": true, "Running": true}
+
 var Cmd = &cobra.Command{
 	Use:   "agent",
-	Short: "Interact with agents",
-	Long: `Interact with agents.
+	Short: "Manage project-scoped agents",
+	Long: `Manage project-scoped agents.
 
-Examples:
-  acpctl agent <id>            # (coming soon)`,
+Subcommands:
+  list        List agents in a project
+  get         Get a specific agent
+  create      Create an agent in a project
+  update      Update an agent's name, prompt, labels, or annotations
+  delete      Delete an agent
+  start       Start a session for an agent (idempotent)
+  stop        Stop the running session for an agent (idempotent)
+  start-preview  Preview start context (dry run)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},
+}
+
+func resolveProject(projectID string) (string, error) {
+	if projectID != "" {
+		return projectID, nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return "", err
+	}
+	p := cfg.GetProject()
+	if p == "" {
+		return "", fmt.Errorf("no project set; use --project-id or run 'acpctl config set project <name>'")
+	}
+	return p, nil
+}
+
+func resolveAgent(ctx context.Context, client *sdkclient.Client, projectID, agentArg string) (string, error) {
+	if agentArg == "" {
+		return "", fmt.Errorf("agent name or ID is required")
+	}
+	pa, err := client.Agents().GetInProject(ctx, projectID, agentArg)
+	if err != nil {
+		pa2, err2 := client.Agents().GetByProject(ctx, projectID, agentArg)
+		if err2 != nil {
+			return "", fmt.Errorf("agent %q not found in project %q", agentArg, projectID)
+		}
+		return pa2.ID, nil
+	}
+	return pa.ID, nil
+}
+
+func resolveAgentFull(ctx context.Context, client *sdkclient.Client, projectID, agentArg string) (*sdktypes.Agent, error) {
+	if agentArg == "" {
+		return nil, fmt.Errorf("agent name or ID is required")
+	}
+	pa, err := client.Agents().GetInProject(ctx, projectID, agentArg)
+	if err != nil {
+		pa, err = client.Agents().GetByProject(ctx, projectID, agentArg)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q not found in project %q", agentArg, projectID)
+		}
+	}
+	return pa, nil
+}
+
+func allAgentsInProject(ctx context.Context, client *sdkclient.Client, projectID string) ([]sdktypes.Agent, error) {
+	opts := sdktypes.NewListOptions().Size(500).Build()
+	list, err := client.Agents().ListByProject(ctx, projectID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list agents: %w", err)
+	}
+	return list.Items, nil
+}
+
+var listArgs struct {
+	projectID    string
+	outputFormat string
+	limit        int
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List agents in a project",
+	Example: `  acpctl agent list
+  acpctl agent list --project-id <id> -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(listArgs.projectID)
+		if err != nil {
+			return err
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		format, err := output.ParseFormat(listArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		opts := sdktypes.NewListOptions().Size(listArgs.limit).Build()
+		list, err := client.Agents().ListByProject(ctx, projectID, opts)
+		if err != nil {
+			return fmt.Errorf("list agents: %w", err)
+		}
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(list)
+		}
+
+		return printAgentTable(printer, list.Items)
+	},
+}
+
+var getArgs struct {
+	projectID    string
+	outputFormat string
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <name-or-id>",
+	Short: "Get a specific agent",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl agent get api
+  acpctl agent get api -o json
+  acpctl agent get <id> --project-id <id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(getArgs.projectID)
+		if err != nil {
+			return err
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		pa, err := client.Agents().GetInProject(ctx, projectID, args[0])
+		if err != nil {
+			pa, err = client.Agents().GetByProject(ctx, projectID, args[0])
+			if err != nil {
+				return fmt.Errorf("get agent %q: %w", args[0], err)
+			}
+		}
+
+		format, err := output.ParseFormat(getArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(pa)
+		}
+		return printAgentTable(printer, []sdktypes.Agent{*pa})
+	},
+}
+
+var createArgs struct {
+	projectID    string
+	name         string
+	prompt       string
+	labels       string
+	annotations  string
+	outputFormat string
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an agent in a project",
+	Example: `  acpctl agent create --name my-agent
+  acpctl agent create --name my-agent --prompt "You are a code reviewer"
+  acpctl agent create --project-id <id> --name my-agent`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(createArgs.projectID)
+		if err != nil {
+			return err
+		}
+		if createArgs.name == "" {
+			return fmt.Errorf("--name is required")
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		builder := sdktypes.NewAgentBuilder().
+			ProjectID(projectID).
+			Name(createArgs.name)
+
+		if createArgs.prompt != "" {
+			builder = builder.Prompt(createArgs.prompt)
+		}
+		if createArgs.labels != "" {
+			builder = builder.Labels(createArgs.labels)
+		}
+		if createArgs.annotations != "" {
+			builder = builder.Annotations(createArgs.annotations)
+		}
+
+		agent, err := builder.Build()
+		if err != nil {
+			return fmt.Errorf("build agent: %w", err)
+		}
+
+		created, err := client.Agents().CreateInProject(ctx, projectID, agent)
+		if err != nil {
+			return fmt.Errorf("create agent: %w", err)
+		}
+
+		format, err := output.ParseFormat(createArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(created)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "agent/%s created\n", created.Name)
+		return nil
+	},
+}
+
+var updateArgs struct {
+	projectID   string
+	name        string
+	prompt      string
+	labels      string
+	annotations string
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update <name-or-id>",
+	Short: "Update an agent",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl agent update api --prompt "New instructions"
+  acpctl agent update api --name new-name
+  acpctl agent update <id> --project-id <id> --prompt "..."`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(updateArgs.projectID)
+		if err != nil {
+			return err
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		agentID, err := resolveAgent(ctx, client, projectID, args[0])
+		if err != nil {
+			return err
+		}
+
+		patch := sdktypes.NewAgentPatchBuilder()
+		if cmd.Flags().Changed("name") {
+			patch = patch.Name(updateArgs.name)
+		}
+		if cmd.Flags().Changed("prompt") {
+			patch = patch.Prompt(updateArgs.prompt)
+		}
+		if cmd.Flags().Changed("labels") {
+			patch = patch.Labels(updateArgs.labels)
+		}
+		if cmd.Flags().Changed("annotations") {
+			patch = patch.Annotations(updateArgs.annotations)
+		}
+
+		updated, err := client.Agents().UpdateInProject(ctx, projectID, agentID, patch.Build())
+		if err != nil {
+			return fmt.Errorf("update agent: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "agent/%s updated\n", updated.Name)
+		return nil
+	},
+}
+
+var deleteArgs struct {
+	projectID string
+	confirm   bool
+}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete <name-or-id>",
+	Short: "Delete an agent",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl agent delete api --confirm
+  acpctl agent delete <id> --project-id <id> --confirm`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(deleteArgs.projectID)
+		if err != nil {
+			return err
+		}
+		if !deleteArgs.confirm {
+			return fmt.Errorf("add --confirm to delete agent/%s", args[0])
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		agentID, err := resolveAgent(ctx, client, projectID, args[0])
+		if err != nil {
+			return err
+		}
+
+		if err := client.Agents().DeleteInProject(ctx, projectID, agentID); err != nil {
+			return fmt.Errorf("delete agent: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "agent/%s deleted\n", args[0])
+		return nil
+	},
+}
+
+var agentStartArgs struct {
+	projectID    string
+	prompt       string
+	outputFormat string
+	all          bool
+}
+
+var agentStartCmd = &cobra.Command{
+	Use:   "start [name-or-id]",
+	Short: "Start a session for an agent (idempotent)",
+	Long: `Start a session for an agent. If the agent already has an active
+session (Pending, Creating, or Running), returns it without creating a
+new one. Use --all / -A to start all agents in the project.
+
+This operation is idempotent — calling it multiple times is safe.`,
+	Args: cobra.MaximumNArgs(1),
+	Example: `  acpctl agent start api
+  acpctl agent start api --prompt "fix the bug"
+  acpctl agent start --all
+  acpctl agent start -A --prompt "run tests"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(agentStartArgs.projectID)
+		if err != nil {
+			return err
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		if agentStartArgs.all {
+			if len(args) > 0 {
+				return fmt.Errorf("cannot specify agent name with --all")
+			}
+			return startAllAgents(ctx, cmd, client, projectID)
+		}
+
+		if len(args) == 0 {
+			return fmt.Errorf("agent name or ID is required (or use --all)")
+		}
+
+		agentID, err := resolveAgent(ctx, client, projectID, args[0])
+		if err != nil {
+			return err
+		}
+
+		return startSingleAgent(ctx, cmd, client, projectID, agentID, args[0])
+	},
+}
+
+func startSingleAgent(ctx context.Context, cmd *cobra.Command, client *sdkclient.Client, projectID, agentID, displayName string) error {
+	resp, err := client.Agents().Start(ctx, projectID, agentID, agentStartArgs.prompt)
+	if err != nil {
+		return fmt.Errorf("start agent: %w", err)
+	}
+
+	if agentStartArgs.outputFormat == "json" {
+		printer := output.NewPrinter(output.FormatJSON, cmd.OutOrStdout())
+		if resp.Session != nil {
+			return printer.PrintJSON(resp.Session)
+		}
+		return printer.PrintJSON(resp)
+	}
+	if resp.Session != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "session/%s started (phase: %s)\n", resp.Session.ID, resp.Session.Phase)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "agent/%s started\n", displayName)
+	}
+	return nil
+}
+
+func startAllAgents(ctx context.Context, cmd *cobra.Command, client *sdkclient.Client, projectID string) error {
+	agents, err := allAgentsInProject(ctx, client, projectID)
+	if err != nil {
+		return err
+	}
+	if len(agents) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "no agents in project")
+		return nil
+	}
+	var failed int
+	for _, a := range agents {
+		if err := startSingleAgent(ctx, cmd, client, projectID, a.ID, a.Name); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "agent/%s: %v\n", a.Name, err)
+			failed++
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d of %d agents failed to start", failed, len(agents))
+	}
+	return nil
+}
+
+var startPreviewArgs struct {
+	projectID string
+}
+
+var startPreviewCmd = &cobra.Command{
+	Use:   "start-preview <name-or-id>",
+	Short: "Preview start context for an agent (dry run)",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl agent start-preview api
+  acpctl agent start-preview <id> --project-id <id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(startPreviewArgs.projectID)
+		if err != nil {
+			return err
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		agentID, err := resolveAgent(ctx, client, projectID, args[0])
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Agents().GetStartPreview(ctx, projectID, agentID)
+		if err != nil {
+			return fmt.Errorf("get start preview for agent %q: %w", args[0], err)
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), resp.StartingPrompt)
+		return nil
+	},
+}
+
+var sessionsArgs struct {
+	projectID    string
+	outputFormat string
+	limit        int
+}
+
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions <name-or-id>",
+	Short: "List session history for an agent",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl agent sessions api
+  acpctl agent sessions <id> --project-id <id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(sessionsArgs.projectID)
+		if err != nil {
+			return err
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		agentID, err := resolveAgent(ctx, client, projectID, args[0])
+		if err != nil {
+			return err
+		}
+
+		opts := sdktypes.NewListOptions().Size(sessionsArgs.limit).Build()
+		list, err := client.Agents().Sessions(ctx, projectID, agentID, opts)
+		if err != nil {
+			return fmt.Errorf("list sessions for agent %q: %w", args[0], err)
+		}
+
+		format, err := output.ParseFormat(sessionsArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(list)
+		}
+
+		return printSessionTable(printer, list.Items)
+	},
+}
+
+var agentStopArgs struct {
+	projectID string
+	all       bool
+}
+
+var agentStopCmd = &cobra.Command{
+	Use:   "stop [name-or-id]",
+	Short: "Stop the running session for an agent (idempotent)",
+	Long: `Stop the active session for an agent. If the agent has no active
+session, prints a message and succeeds. Use --all / -A to stop all
+agents in the project.
+
+This operation is idempotent — calling it multiple times is safe.`,
+	Args: cobra.MaximumNArgs(1),
+	Example: `  acpctl agent stop api
+  acpctl agent stop --all
+  acpctl agent stop -A`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, err := resolveProject(agentStopArgs.projectID)
+		if err != nil {
+			return err
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		if agentStopArgs.all {
+			if len(args) > 0 {
+				return fmt.Errorf("cannot specify agent name with --all")
+			}
+			return stopAllAgents(ctx, cmd, client, projectID)
+		}
+
+		if len(args) == 0 {
+			return fmt.Errorf("agent name or ID is required (or use --all)")
+		}
+
+		agent, err := resolveAgentFull(ctx, client, projectID, args[0])
+		if err != nil {
+			return err
+		}
+
+		return stopSingleAgent(ctx, cmd, client, agent)
+	},
+}
+
+func stopSingleAgent(ctx context.Context, cmd *cobra.Command, client *sdkclient.Client, agent *sdktypes.Agent) error {
+	if agent.CurrentSessionID == "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "agent/%s has no active session\n", agent.Name)
+		return nil
+	}
+
+	sess, err := client.Sessions().Get(ctx, agent.CurrentSessionID)
+	if err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "agent/%s session/%s not found — already cleaned up\n", agent.Name, agent.CurrentSessionID)
+		return nil
+	}
+
+	if !activePhases[sess.Phase] {
+		fmt.Fprintf(cmd.OutOrStdout(), "agent/%s session/%s already %s\n", agent.Name, sess.ID, sess.Phase)
+		return nil
+	}
+
+	stopped, err := client.Sessions().Stop(ctx, sess.ID)
+	if err != nil {
+		return fmt.Errorf("stop agent/%s session/%s: %w", agent.Name, sess.ID, err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "agent/%s session/%s stopped (phase: %s)\n", agent.Name, stopped.ID, stopped.Phase)
+	return nil
+}
+
+func stopAllAgents(ctx context.Context, cmd *cobra.Command, client *sdkclient.Client, projectID string) error {
+	agents, err := allAgentsInProject(ctx, client, projectID)
+	if err != nil {
+		return err
+	}
+	if len(agents) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "no agents in project")
+		return nil
+	}
+	var failed int
+	for i := range agents {
+		if err := stopSingleAgent(ctx, cmd, client, &agents[i]); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "agent/%s: %v\n", agents[i].Name, err)
+			failed++
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d of %d agents failed to stop", failed, len(agents))
+	}
+	return nil
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(getCmd)
+	Cmd.AddCommand(createCmd)
+	Cmd.AddCommand(updateCmd)
+	Cmd.AddCommand(deleteCmd)
+	Cmd.AddCommand(agentStartCmd)
+	Cmd.AddCommand(agentStopCmd)
+	Cmd.AddCommand(startPreviewCmd)
+	Cmd.AddCommand(sessionsCmd)
+
+	listCmd.Flags().StringVar(&listArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	listCmd.Flags().StringVarP(&listArgs.outputFormat, "output", "o", "", "Output format: json|wide")
+	listCmd.Flags().IntVar(&listArgs.limit, "limit", 100, "Maximum number of items to return")
+
+	getCmd.Flags().StringVar(&getArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	getCmd.Flags().StringVarP(&getArgs.outputFormat, "output", "o", "", "Output format: json")
+
+	createCmd.Flags().StringVar(&createArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	createCmd.Flags().StringVar(&createArgs.name, "name", "", "Agent name (required)")
+	createCmd.Flags().StringVar(&createArgs.prompt, "prompt", "", "Standing instructions prompt")
+	createCmd.Flags().StringVar(&createArgs.labels, "labels", "", "Labels (JSON string)")
+	createCmd.Flags().StringVar(&createArgs.annotations, "annotations", "", "Annotations (JSON string)")
+	createCmd.Flags().StringVarP(&createArgs.outputFormat, "output", "o", "", "Output format: json")
+
+	updateCmd.Flags().StringVar(&updateArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	updateCmd.Flags().StringVar(&updateArgs.name, "name", "", "New agent name")
+	updateCmd.Flags().StringVar(&updateArgs.prompt, "prompt", "", "New standing instructions prompt")
+	updateCmd.Flags().StringVar(&updateArgs.labels, "labels", "", "New labels (JSON string)")
+	updateCmd.Flags().StringVar(&updateArgs.annotations, "annotations", "", "New annotations (JSON string)")
+
+	deleteCmd.Flags().StringVar(&deleteArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	deleteCmd.Flags().BoolVar(&deleteArgs.confirm, "confirm", false, "Confirm deletion")
+
+	agentStartCmd.Flags().StringVar(&agentStartArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	agentStartCmd.Flags().StringVar(&agentStartArgs.prompt, "prompt", "", "Task prompt for this run")
+	agentStartCmd.Flags().StringVarP(&agentStartArgs.outputFormat, "output", "o", "", "Output format: json")
+	agentStartCmd.Flags().BoolVarP(&agentStartArgs.all, "all", "A", false, "Start all agents in the project")
+
+	agentStopCmd.Flags().StringVar(&agentStopArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	agentStopCmd.Flags().BoolVarP(&agentStopArgs.all, "all", "A", false, "Stop all agents in the project")
+
+	startPreviewCmd.Flags().StringVar(&startPreviewArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+
+	sessionsCmd.Flags().StringVar(&sessionsArgs.projectID, "project-id", "", "Project ID (defaults to configured project)")
+	sessionsCmd.Flags().StringVarP(&sessionsArgs.outputFormat, "output", "o", "", "Output format: json")
+	sessionsCmd.Flags().IntVar(&sessionsArgs.limit, "limit", 100, "Maximum number of items to return")
+}
+
+func printAgentTable(printer *output.Printer, agents []sdktypes.Agent) error {
+	columns := []output.Column{
+		{Name: "ID", Width: 27},
+		{Name: "NAME", Width: 24},
+		{Name: "PROJECT", Width: 27},
+		{Name: "SESSION", Width: 27},
+		{Name: "AGE", Width: 10},
+	}
+
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+
+	for _, a := range agents {
+		age := ""
+		if a.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*a.CreatedAt))
+		}
+		table.WriteRow(a.ID, a.Name, a.ProjectID, a.CurrentSessionID, age)
+	}
+	return nil
+}
+
+func printSessionTable(printer *output.Printer, sessions []sdktypes.Session) error {
+	columns := []output.Column{
+		{Name: "ID", Width: 27},
+		{Name: "NAME", Width: 32},
+		{Name: "PHASE", Width: 12},
+		{Name: "AGE", Width: 10},
+	}
+
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+
+	for _, s := range sessions {
+		age := ""
+		if s.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*s.CreatedAt))
+		}
+		table.WriteRow(s.ID, s.Name, s.Phase, age)
+	}
+	return nil
 }

--- a/components/ambient-cli/cmd/acpctl/ambient/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/cmd.go
@@ -38,12 +38,17 @@ Output streams line-by-line into the main panel.
 
 Data refreshes automatically every 10 seconds.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		factory, err := connection.NewClientFactory()
+		if err != nil {
+			return fmt.Errorf("connect: %w", err)
+		}
+
 		client, err := connection.NewClientFromConfig()
 		if err != nil {
 			return fmt.Errorf("connect: %w", err)
 		}
 
-		m := tui.NewModel(client)
+		m := tui.NewModel(client, factory)
 		p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 		if _, err := p.Run(); err != nil {
 			fmt.Fprintf(os.Stderr, "TUI error: %v\n", err)

--- a/components/ambient-cli/cmd/acpctl/ambient/tui/dashboard.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/tui/dashboard.go
@@ -3,6 +3,7 @@ package tui
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -10,9 +11,19 @@ import (
 	"sync"
 	"time"
 
+	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
 	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+)
+
+type sdkClientIface interface {
+	Sessions() *sdkclient.SessionAPI
+}
+
+var (
+	styleSelected       = lipgloss.NewStyle().Background(lipgloss.Color("236")).Foreground(lipgloss.Color("255"))
+	styleSelectedGutter = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("▌")
 )
 
 func (m *Model) rebuildMain() {
@@ -22,7 +33,15 @@ func (m *Model) rebuildMain() {
 	}
 	contentH := m.mainContentH()
 
+	if m.agentEditMode {
+		m.mainLines = m.renderAgentEditLines(mainW)
+		m.mainScroll = 0
+		return
+	}
+
 	switch m.nav {
+	case NavDashboard:
+		m.mainLines = m.buildDashboardLines()
 	case NavCluster:
 		m.mainLines = buildClusterLines(m.data)
 	case NavNamespaces:
@@ -33,10 +52,57 @@ func (m *Model) rebuildMain() {
 		m.mainLines = m.buildSessionTiles(mainW, contentH)
 	case NavAgents:
 		m.mainLines = buildAgentLines(m.data)
-	case NavStats:
-		m.mainLines = buildStatsLines(m.data)
 	}
+
+	if m.panelFocus && !m.detailMode {
+		m.applyPanelCursor()
+	}
+
 	m.mainScroll = 0
+}
+
+func navHeaderRows(nav NavSection) int {
+	switch nav {
+	case NavDashboard:
+		return 4
+	case NavCluster, NavNamespaces, NavProjects, NavAgents, NavSessions:
+		return 4
+	default:
+		return 2
+	}
+}
+
+func applyRowCursor(lines []string, row, mainW int) {
+	if row < 0 || row >= len(lines) {
+		return
+	}
+	line := lines[row]
+	if strings.HasPrefix(line, "  ") {
+		line = styleSelectedGutter + line[2:]
+	} else {
+		line = styleSelectedGutter + line
+	}
+	vis := lipgloss.Width(line)
+	if vis < mainW {
+		line = line + strings.Repeat(" ", mainW-vis)
+	}
+	lines[row] = styleSelected.Render(line)
+}
+
+func (m *Model) applyPanelCursor() {
+	row := m.panelRow + navHeaderRows(m.nav)
+	applyRowCursor(m.mainLines, row, m.width-navW-2)
+}
+
+func (m *Model) applyDetailCursor(headerLines int) {
+	row := m.detailRow + headerLines
+	if row < 0 || row >= len(m.detailLines) {
+		return
+	}
+	rebuilt := make([]string, len(m.detailLines))
+	copy(rebuilt, m.detailLines)
+	applyRowCursor(rebuilt, row, m.width-navW-2)
+	m.detailLines = rebuilt
 }
 
 func col(s string, w int) string {
@@ -45,6 +111,72 @@ func col(s string, w int) string {
 		return string(r[:w-1]) + " "
 	}
 	return s + strings.Repeat(" ", w-len(r))
+}
+
+func (m *Model) buildDashboardLines() []string {
+	lines := []string{
+		styleBold.Render("  System Controls"),
+		"",
+		styleBold.Render("  ── Port Forwards ───────────────────────"),
+		"",
+	}
+
+	for i, pf := range m.portForwards {
+		var statusIcon, statusLabel string
+		if pf.Running {
+			statusIcon = styleGreen.Render("●")
+			statusLabel = styleGreen.Render("running")
+		} else {
+			statusIcon = styleRed.Render("○")
+			statusLabel = styleDim.Render("stopped")
+		}
+		pidStr := ""
+		if pf.Running && pf.PID > 0 {
+			pidStr = styleDim.Render(fmt.Sprintf("  pid %d", pf.PID))
+		}
+		toggle := styleDim.Render("[Enter/Space to toggle]")
+		if m.panelFocus && m.panelRow == i {
+			if pf.Running {
+				toggle = styleRed.Render("[Enter/Space: stop]")
+			} else {
+				toggle = styleGreen.Render("[Enter/Space: start]")
+			}
+		}
+		line := "  " + statusIcon + "  " +
+			styleBlue.Render(col(pf.Label, 12)) +
+			styleDim.Render(fmt.Sprintf("localhost:%-6d → %s:%d", pf.LocalPort, pf.SvcName, pf.SvcPort)) +
+			"  " + statusLabel + pidStr + "  " + toggle
+		lines = append(lines, line)
+	}
+
+	lines = append(lines, "",
+		styleBold.Render("  ── Login ───────────────────────────────"),
+		"",
+	)
+
+	loginRow := len(m.portForwards)
+	if m.loginStatus.LoggedIn {
+		loginLine := "  " + styleGreen.Render("●") + "  " +
+			styleGreen.Render(col("Logged in", 12)) +
+			styleDim.Render("user: "+m.loginStatus.User+"  ctx: "+m.loginStatus.Server+"  ns: "+m.loginStatus.Namespace)
+		lines = append(lines, loginLine)
+	} else {
+		toggle := styleDim.Render("[Enter/Space: refresh login status]")
+		if m.panelFocus && m.panelRow == loginRow {
+			toggle = styleBlue.Render("[Enter/Space: check login]")
+		}
+		loginLine := "  " + styleRed.Render("○") + "  " +
+			styleDim.Render(col("Not logged in", 14)) + "  " + toggle
+		lines = append(lines, loginLine)
+	}
+
+	lines = append(lines, "",
+		styleBold.Render("  ── Platform Stats ──────────────────────"),
+		"",
+	)
+	lines = append(lines, buildStatsLines(m.data)[1:]...)
+
+	return lines
 }
 
 func buildClusterLines(d DashData) []string {
@@ -72,7 +204,7 @@ func buildClusterLines(d DashData) []string {
 		case p.Status == "Terminating":
 			statusStyle = styleOrange
 		}
-		line := styleCyan.Render(col(p.Name, 42)) +
+		line := styleBlue.Render(col(p.Name, 42)) +
 			col(p.Ready, 8) +
 			statusStyle.Render(col(p.Status, 14)) +
 			styleDim.Render(col(p.Restarts, 10)) +
@@ -99,7 +231,7 @@ func buildNamespaceLines(d DashData) []string {
 	for _, ns := range d.Namespaces {
 		highlight := styleWhite
 		if strings.HasPrefix(ns.Name, "fleet-") || strings.HasPrefix(ns.Name, "ambient") {
-			highlight = styleCyan
+			highlight = styleBlue
 		}
 		statusStyle := styleGreen
 		if ns.Status != "Active" {
@@ -129,15 +261,12 @@ func buildProjectLines(d DashData) []string {
 		if p.CreatedAt != nil {
 			age = fmtAge(time.Since(*p.CreatedAt))
 		}
-		display := p.DisplayName
-		if display == "" {
-			display = p.Name
-		}
+		display := p.Name
 		statusStyle := styleGreen
 		if p.Status != "" && p.Status != "active" {
 			statusStyle = styleDim
 		}
-		line := styleCyan.Render(col(p.Name, 32)) +
+		line := styleBlue.Render(col(p.Name, 32)) +
 			col(display, 30) +
 			statusStyle.Render(col(p.Status, 12)) +
 			styleDim.Render(age)
@@ -157,19 +286,66 @@ func (m *Model) buildSessionTiles(w, totalH int) []string {
 		}
 	}
 
+	nameW := 38
+	header := []string{
+		"",
+		styleBold.Render(col("  PROJECT/SESSION", nameW)) + styleBold.Render("MESSAGE"),
+		styleDim.Render(strings.Repeat("─", w-2)),
+	}
+
+	msgColW := w - nameW - 4
+	if msgColW < 10 {
+		msgColW = 10
+	}
+
+	for _, sess := range sessions {
+		name := styleBlue.Render(sess.ProjectID) + styleDim.Render("/") + styleWhite.Render(sess.Name)
+		var msgCol string
+		if m.composeMode && m.composeSessionID == sess.ID {
+			msgCol = styleOrange.Render("▶ ") + m.composeInput.render()
+			if m.composeStatus != "" {
+				msgCol += "  " + m.composeStatus
+			}
+		} else {
+			msgs := m.sessionMsgs[sess.ID]
+			last := lastMessageSnippet(msgs, msgColW)
+			msgCol = styleDim.Render(last)
+		}
+		row := "  " + padStyled(name, nameW-2) + msgCol
+		header = append(header, row)
+	}
+	header = append(header, "", styleDim.Render("  ▼ live messages"), "")
+
 	n := len(sessions)
-	tileH := totalH / n
-	if tileH < 6 {
-		tileH = 6
+	tableRows := len(header)
+	remaining := totalH - tableRows
+	if remaining < 0 {
+		remaining = 0
+	}
+	tileH := remaining / n
+	const minTileH = 8
+	const maxTileH = 16
+	if tileH < minTileH {
+		tileH = minTileH
+	}
+	if tileH > maxTileH {
+		tileH = maxTileH
 	}
 	msgLines := tileH - 4
 
-	var lines []string
-	for _, sess := range sessions {
-		lines = append(lines, m.renderSessionTile(sess, w, msgLines)...)
-		lines = append(lines, "")
+	if m.sessionTileContent == nil {
+		m.sessionTileContent = make(map[string][2]int)
 	}
-	return lines
+	for _, sess := range sessions {
+		tile := m.renderSessionTile(sess, w, msgLines)
+		tileStart := len(header)
+		header = append(header, tile...)
+		header = append(header, "")
+		contentStart := tileStart + 3
+		contentEnd := tileStart + len(tile) - 1
+		m.sessionTileContent[sess.ID] = [2]int{contentStart, contentEnd}
+	}
+	return header
 }
 
 func (m *Model) renderSessionTile(sess sdktypes.Session, w, msgLines int) []string {
@@ -191,7 +367,7 @@ func (m *Model) renderSessionTile(sess sdktypes.Session, w, msgLines int) []stri
 	case "Failed", "failed", "Error":
 		phaseStyle = styleRed
 	case "Completed", "completed":
-		phaseStyle = styleCyan
+		phaseStyle = styleGreen
 	}
 
 	age := ""
@@ -204,7 +380,7 @@ func (m *Model) renderSessionTile(sess sdktypes.Session, w, msgLines int) []stri
 		idShort = idShort[:20] + "…"
 	}
 
-	titleParts := styleCyan.Render(sess.ProjectID) +
+	titleParts := styleBlue.Render(sess.ProjectID) +
 		styleDim.Render("/") +
 		styleWhite.Render(sess.Name) +
 		"  " + phaseStyle.Render(phase) +
@@ -236,7 +412,10 @@ func renderTileMessages(msgs []sdktypes.SessionMessage, w, maxLines int) []strin
 		if display == "" {
 			continue
 		}
-		ts := styleDim.Render(msg.CreatedAt.Format("15:04:05"))
+		ts := styleDim.Render("--:--:--")
+		if msg.CreatedAt != nil {
+			ts = styleDim.Render(msg.CreatedAt.Format("15:04:05"))
+		}
 		evStyle := eventTypeStyle(msg.EventType)
 		evShort := truncate(msg.EventType, 24)
 		line := ts + "  " + evStyle.Render(col(evShort, 26)) + truncate(display, w-42)
@@ -250,6 +429,16 @@ func renderTileMessages(msgs []sdktypes.SessionMessage, w, maxLines int) []strin
 	padded := make([]string, maxLines)
 	copy(padded[maxLines-len(rendered):], rendered)
 	return padded
+}
+
+func lastMessageSnippet(msgs []sdktypes.SessionMessage, maxW int) string {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		d := tileDisplayPayload(msgs[i])
+		if d != "" {
+			return truncate(d, maxW)
+		}
+	}
+	return ""
 }
 
 func tileDisplayPayload(msg sdktypes.SessionMessage) string {
@@ -312,7 +501,7 @@ func extractKVField(payload, field string) string {
 func eventTypeStyle(et string) lipgloss.Style {
 	switch {
 	case strings.HasPrefix(et, "TEXT_MESSAGE"):
-		return styleCyan
+		return styleBlue
 	case strings.HasPrefix(et, "TOOL_CALL"):
 		return styleOrange
 	case et == "RUN_FINISHED":
@@ -330,7 +519,7 @@ func buildAgentLines(d DashData) []string {
 	lines := []string{
 		styleBold.Render("  Agents") + styleDim.Render(fmt.Sprintf("  total: %d", len(d.Agents))),
 		"",
-		styleBold.Render(col("NAME", 24) + col("DISPLAY NAME", 24) + col("PROJECT", 22) + col("MODEL", 16) + "SESSION"),
+		styleBold.Render(col("NAME", 24) + col("OWNER", 27) + col("VERSION", 10) + "PROMPT"),
 		styleDim.Render(strings.Repeat("─", 100)),
 	}
 	if len(d.Agents) == 0 {
@@ -338,27 +527,13 @@ func buildAgentLines(d DashData) []string {
 		return lines
 	}
 	for _, a := range d.Agents {
-		display := a.DisplayName
-		if display == "" {
-			display = a.Name
+		prompt := a.Prompt
+		if len(prompt) > 30 {
+			prompt = prompt[:27] + "…"
 		}
-		model := a.LlmModel
-		if model == "" {
-			model = "—"
-		}
-		sess := styleDim.Render("—")
-		if a.CurrentSessionID != "" {
-			short := a.CurrentSessionID
-			if len(short) > 16 {
-				short = short[:16] + "…"
-			}
-			sess = styleGreen.Render(short)
-		}
-		line := styleCyan.Render(col(a.Name, 24)) +
-			col(display, 24) +
-			col(a.ProjectID, 22) +
-			styleDim.Render(col(model, 16)) +
-			sess
+		line := styleBlue.Render(col(a.Name, 24)) +
+			col(a.OwnerUserID, 27) +
+			styleDim.Render(prompt)
 		lines = append(lines, "  "+line)
 	}
 	return lines
@@ -396,8 +571,8 @@ func buildStatsLines(d DashData) []string {
 		styleDim.Render("  last refresh: " + age),
 		"",
 		styleBold.Render("  ── Cluster ─────────────────────────────"),
-		fmt.Sprintf("  Pods (ambient-code):  %s", styleCyan.Render(fmt.Sprintf("%d", len(d.Pods)))),
-		fmt.Sprintf("  Fleet namespaces:     %s", styleCyan.Render(fmt.Sprintf("%d", fleetNS))),
+		fmt.Sprintf("  Pods (ambient-code):  %s", styleBlue.Render(fmt.Sprintf("%d", len(d.Pods)))),
+		fmt.Sprintf("  Fleet namespaces:     %s", styleBlue.Render(fmt.Sprintf("%d", fleetNS))),
 		fmt.Sprintf("  Total namespaces:     %s", styleDim.Render(fmt.Sprintf("%d", len(d.Namespaces)))),
 	}
 
@@ -417,9 +592,9 @@ func buildStatsLines(d DashData) []string {
 
 	lines = append(lines, "",
 		styleBold.Render("  ── Platform Objects ────────────────────"),
-		fmt.Sprintf("  Projects:  %s", styleCyan.Render(fmt.Sprintf("%d", len(d.Projects)))),
-		fmt.Sprintf("  Sessions:  %s", styleCyan.Render(fmt.Sprintf("%d", len(d.Sessions)))),
-		fmt.Sprintf("  Agents:    %s", styleCyan.Render(fmt.Sprintf("%d", len(d.Agents)))),
+		fmt.Sprintf("  Projects:  %s", styleBlue.Render(fmt.Sprintf("%d", len(d.Projects)))),
+		fmt.Sprintf("  Sessions:  %s", styleBlue.Render(fmt.Sprintf("%d", len(d.Sessions)))),
+		fmt.Sprintf("  Agents:    %s", styleBlue.Render(fmt.Sprintf("%d", len(d.Agents)))),
 	)
 
 	if len(sessionsByPhase) > 0 {
@@ -435,7 +610,7 @@ func buildStatsLines(d DashData) []string {
 			case "Failed", "failed":
 				phaseStyle = styleRed
 			case "Completed", "completed":
-				phaseStyle = styleCyan
+				phaseStyle = styleGreen
 			}
 			lines = append(lines, fmt.Sprintf("  %-20s %s", phase, phaseStyle.Render(fmt.Sprintf("%d", count))))
 		}
@@ -445,6 +620,279 @@ func buildStatsLines(d DashData) []string {
 		lines = append(lines, "", styleRed.Render("  ⚠ fetch errors: "+d.Err))
 	}
 
+	return lines
+}
+
+func fetchPodLogs(namespace, podName string) []string {
+	out, err := exec.Command("kubectl", "logs", "--namespace", namespace, podName, "--tail=200", "--all-containers=true").Output()
+	if err != nil {
+		out2, _ := exec.Command("kubectl", "logs", "--namespace", namespace, podName, "--tail=200").Output()
+		if len(out2) == 0 {
+			return []string{styleRed.Render("error fetching logs: " + err.Error())}
+		}
+		out = out2
+	}
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	return append([]string(nil), lines...)
+}
+
+func fetchNamespacePodsDetail(namespace string) detailReadyMsg {
+	out, err := exec.Command("kubectl", "get", "pods", "--namespace", namespace,
+		"--no-headers", "-o", "custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,AGE:.metadata.creationTimestamp").Output()
+	title := "Pods in namespace: " + namespace
+	header := styleBold.Render(col("NAME", 52) + col("READY", 8) + col("STATUS", 14) + col("RESTARTS", 10) + "AGE")
+	const headerLines = 2
+	lines := []string{header, styleDim.Render(strings.Repeat("─", 110))}
+	var items []detailItem
+	if err != nil {
+		lines = append(lines, styleRed.Render("  error: "+err.Error()))
+		return detailReadyMsg{title: title, lines: lines}
+	}
+	for _, l := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if l == "" {
+			continue
+		}
+		fields := strings.Fields(l)
+		if len(fields) > 0 {
+			items = append(items, detailItem{namespace: namespace, name: fields[0]})
+		}
+		lines = append(lines, "  "+l)
+	}
+	if len(items) == 0 {
+		lines = append(lines, styleDim.Render("  no pods"))
+		return detailReadyMsg{title: title, lines: lines}
+	}
+	return detailReadyMsg{
+		title:       title,
+		lines:       lines,
+		selectable:  true,
+		items:       items,
+		headerLines: headerLines,
+	}
+}
+
+func resolveSessionPod(sess sdktypes.Session) (namespace, podName string) {
+	ns := sess.KubeNamespace
+	if ns == "" {
+		ns = sess.ProjectID
+	}
+	if ns == "" {
+		return "", ""
+	}
+
+	if sess.KubeCrName != "" {
+		candidate := sess.KubeCrName + "-runner"
+		out, err := exec.Command("kubectl", "get", "pod", candidate, "--namespace", ns, "--no-headers", "-o", "name").Output()
+		if err == nil && strings.TrimSpace(string(out)) != "" {
+			return ns, candidate
+		}
+		out, err = exec.Command("kubectl", "get", "pod", sess.KubeCrName, "--namespace", ns, "--no-headers", "-o", "name").Output()
+		if err == nil && strings.TrimSpace(string(out)) != "" {
+			return ns, sess.KubeCrName
+		}
+	}
+
+	if sess.ID != "" {
+		labelSel := "ambient-code.io/session-id=" + sess.ID
+		out, err := exec.Command("kubectl", "get", "pods", "--namespace", ns, "-l", labelSel, "--no-headers", "-o", "custom-columns=NAME:.metadata.name").Output()
+		if err == nil {
+			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				line = strings.TrimSpace(line)
+				if line != "" {
+					return ns, line
+				}
+			}
+		}
+	}
+
+	return "", ""
+}
+
+func fetchSessionSplitDetail(sess sdktypes.Session, msgs []sdktypes.SessionMessage) splitDetailReadyMsg {
+	title := "Session: " + sess.ProjectID + "/" + sess.Name
+
+	phase := sess.Phase
+	if phase == "" {
+		phase = "unknown"
+	}
+	age := "—"
+	if sess.CreatedAt != nil {
+		age = fmtAge(time.Since(*sess.CreatedAt))
+	}
+
+	topLines := []string{
+		styleBold.Render("  Session Detail"),
+		"",
+		"  " + col("ID:", 16) + styleBlue.Render(sess.ID),
+		"  " + col("Name:", 16) + styleWhite.Render(sess.Name),
+		"  " + col("Project:", 16) + sess.ProjectID,
+		"  " + col("Phase:", 16) + phase,
+		"  " + col("Age:", 16) + age,
+		"  " + col("Model:", 16) + sess.LlmModel,
+		"",
+		styleBold.Render("  ── Messages ────────────────────────────────"),
+		"",
+	}
+	if len(msgs) == 0 {
+		topLines = append(topLines, styleDim.Render("  no messages"))
+	}
+	for _, msg := range msgs {
+		display := tileDisplayPayload(msg)
+		if display == "" {
+			continue
+		}
+		ts := styleDim.Render("--:--:--")
+		if msg.CreatedAt != nil {
+			ts = styleDim.Render(msg.CreatedAt.Format("15:04:05"))
+		}
+		evStyle := eventTypeStyle(msg.EventType)
+		seqStr := styleDim.Render(fmt.Sprintf("#%-4d", msg.Seq))
+		topLines = append(topLines, "  "+seqStr+"  "+ts+"  "+evStyle.Render(col(msg.EventType, 22))+"  "+display)
+	}
+
+	var bottomLines []string
+	podNS, podName := resolveSessionPod(sess)
+	if podNS != "" && podName != "" {
+		bottomLines = append(bottomLines,
+			styleBold.Render("  ── Pod Logs: "+podNS+"/"+podName+" ────────────────"),
+			"",
+		)
+		bottomLines = append(bottomLines, fetchPodLogs(podNS, podName)...)
+	} else {
+		bottomLines = []string{
+			styleBold.Render("  ── Pod Logs ────────────────────────────────"),
+			"",
+			styleDim.Render("  no pod info available"),
+		}
+	}
+
+	return splitDetailReadyMsg{
+		title:       title,
+		topLines:    topLines,
+		bottomLines: bottomLines,
+	}
+}
+
+func fetchProjectSessionsDetail(ctx context.Context, client sdkClientIface, proj sdktypes.Project) detailReadyMsg {
+	title := "Project: " + proj.Name
+	const headerLines = 2
+	lines := []string{
+		styleBold.Render(col("NAME", 30) + col("PHASE", 14) + col("MODEL", 22) + "AGE"),
+		styleDim.Render(strings.Repeat("─", 100)),
+	}
+	sessionList, err := client.Sessions().List(ctx, nil)
+	if err != nil {
+		return detailReadyMsg{title: title, lines: append(lines, styleRed.Render("  error: "+err.Error()))}
+	}
+	var items []detailItem
+	for _, sess := range sessionList.Items {
+		if sess.ProjectID != proj.ID {
+			continue
+		}
+		phase := sess.Phase
+		if phase == "" {
+			phase = "unknown"
+		}
+		phaseStyle := styleDim
+		switch phase {
+		case "Running", "running":
+			phaseStyle = styleGreen
+		case "Pending", "Creating":
+			phaseStyle = styleYellow
+		case "Failed", "Error":
+			phaseStyle = styleRed
+		case "Completed":
+			phaseStyle = styleGreen
+		}
+		age := "—"
+		if sess.CreatedAt != nil {
+			age = fmtAge(time.Since(*sess.CreatedAt))
+		}
+		line := styleBlue.Render(col(sess.Name, 30)) +
+			phaseStyle.Render(col(phase, 14)) +
+			styleDim.Render(col(sess.LlmModel, 22)) +
+			styleDim.Render(age)
+		lines = append(lines, "  "+line)
+		items = append(items, detailItem{kind: "session", id: sess.ID, name: sess.Name, namespace: proj.ID})
+	}
+	if len(items) == 0 {
+		lines = append(lines, styleDim.Render("  no sessions"))
+		return detailReadyMsg{title: title, lines: lines}
+	}
+	return detailReadyMsg{
+		title:       title,
+		lines:       lines,
+		selectable:  true,
+		items:       items,
+		headerLines: headerLines,
+	}
+}
+
+func renderAgentDetail(agent sdktypes.Agent) []string {
+	return []string{
+		styleBold.Render("  Agent Detail"),
+		"",
+		"  " + col("ID:", 20) + styleBlue.Render(agent.ID),
+		"  " + col("Name:", 20) + styleWhite.Render(agent.Name),
+		"  " + col("Owner:", 20) + agent.OwnerUserID,
+		"",
+		styleBold.Render("  ── Prompt ──────────────────────────────────"),
+		"",
+		"  " + styleDim.Render(agent.Prompt),
+	}
+}
+
+func (m *Model) renderAgentEditLines(mainW int) []string {
+	agent := m.agentEditAgent
+	runes := []rune(m.agentEditPrompt)
+	cur := m.agentEditCursor
+	if cur > len(runes) {
+		cur = len(runes)
+	}
+
+	before := string(runes[:cur])
+	cursorCh := "█"
+	after := ""
+	if cur < len(runes) {
+		cursorCh = string(runes[cur : cur+1])
+		after = string(runes[cur+1:])
+	}
+
+	dirtyMark := ""
+	if m.agentEditDirty {
+		dirtyMark = " " + styleOrange.Render("●")
+	}
+
+	lines := []string{
+		styleBold.Render("  ✎ Edit Agent") + dirtyMark,
+		"",
+		"  " + col("ID:", 20) + styleBlue.Render(agent.ID),
+		"  " + col("Name:", 20) + styleWhite.Render(agent.Name),
+		"  " + col("Owner:", 20) + agent.OwnerUserID,
+		"",
+		styleOrange.Render("  ── Prompt (editing) ────────────────────────"),
+		"",
+	}
+
+	promptW := mainW - 4
+	if promptW < 20 {
+		promptW = 20
+	}
+	fullPrompt := before + styleBold.Render(cursorCh) + after
+	var promptLines []string
+	remaining := fullPrompt
+	for len([]rune(remaining)) > 0 {
+		if lipgloss.Width(remaining) <= promptW {
+			promptLines = append(promptLines, "  "+remaining)
+			break
+		}
+		promptLines = append(promptLines, "  "+string([]rune(remaining)[:promptW]))
+		remaining = string([]rune(remaining)[promptW:])
+	}
+	if len(promptLines) == 0 {
+		promptLines = []string{"  " + styleBold.Render("█")}
+	}
+	lines = append(lines, promptLines...)
 	return lines
 }
 

--- a/components/ambient-cli/cmd/acpctl/ambient/tui/dashboard_test.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/tui/dashboard_test.go
@@ -1,0 +1,112 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
+)
+
+func msg(eventType, payload string, createdAt *time.Time) sdktypes.SessionMessage {
+	m := sdktypes.SessionMessage{}
+	m.EventType = eventType
+	m.Payload = payload
+	m.CreatedAt = createdAt
+	return m
+}
+
+func ptr(t time.Time) *time.Time { return &t }
+
+func TestRenderTileMessages_NilCreatedAt(t *testing.T) {
+	msgs := []sdktypes.SessionMessage{
+		msg("user", "hello from user", nil),
+	}
+	lines := renderTileMessages(msgs, 100, 10)
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "hello from user") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'hello from user' in rendered lines, got: %v", lines)
+	}
+}
+
+func TestRenderTileMessages_WithCreatedAt(t *testing.T) {
+	ts := time.Date(2026, 1, 1, 13, 45, 0, 0, time.UTC)
+	msgs := []sdktypes.SessionMessage{
+		msg("user", "timestamped message", ptr(ts)),
+	}
+	lines := renderTileMessages(msgs, 100, 10)
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "13:45:00") && strings.Contains(l, "timestamped message") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected timestamp and payload in rendered lines, got: %v", lines)
+	}
+}
+
+func TestRenderTileMessages_FilteredEventTypes(t *testing.T) {
+	msgs := []sdktypes.SessionMessage{
+		msg("TEXT_MESSAGE_END", "should be hidden", nil),
+		msg("TOOL_CALL_ARGS", "also hidden", nil),
+		msg("user", "visible", nil),
+	}
+	lines := renderTileMessages(msgs, 100, 10)
+	for _, l := range lines {
+		if strings.Contains(l, "should be hidden") || strings.Contains(l, "also hidden") {
+			t.Errorf("filtered event type appeared in output: %q", l)
+		}
+	}
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "visible") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'visible' in rendered lines, got: %v", lines)
+	}
+}
+
+func TestRenderTileMessages_MaxLines(t *testing.T) {
+	var msgs []sdktypes.SessionMessage
+	for i := 0; i < 20; i++ {
+		msgs = append(msgs, msg("user", "msg", nil))
+	}
+	lines := renderTileMessages(msgs, 100, 5)
+	if len(lines) != 5 {
+		t.Errorf("expected 5 lines (maxLines), got %d", len(lines))
+	}
+}
+
+func TestTileDisplayPayload_UserEvent(t *testing.T) {
+	m := msg("user", "hello", nil)
+	got := tileDisplayPayload(m)
+	if got != "hello" {
+		t.Errorf("expected 'hello', got %q", got)
+	}
+}
+
+func TestTileDisplayPayload_RunFinished(t *testing.T) {
+	m := msg("RUN_FINISHED", "", nil)
+	got := tileDisplayPayload(m)
+	if got != "[done]" {
+		t.Errorf("expected '[done]', got %q", got)
+	}
+}
+
+func TestTileDisplayPayload_EmptyFiltered(t *testing.T) {
+	for _, et := range []string{"TEXT_MESSAGE_END", "TOOL_CALL_ARGS", "TOOL_CALL_END"} {
+		m := msg(et, "anything", nil)
+		got := tileDisplayPayload(m)
+		if got != "" {
+			t.Errorf("event type %q should return empty, got %q", et, got)
+		}
+	}
+}

--- a/components/ambient-cli/cmd/acpctl/ambient/tui/fetch.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/tui/fetch.go
@@ -9,12 +9,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
 	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
 	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func fetchAll(client *sdkclient.Client, msgCh chan tea.Msg) tea.Cmd {
+func fetchAll(client *sdkclient.Client, factory *connection.ClientFactory, msgCh chan tea.Msg) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
@@ -45,30 +46,83 @@ func fetchAll(client *sdkclient.Client, msgCh chan tea.Msg) tea.Cmd {
 			mu.Unlock()
 		}()
 
+		var projects []sdktypes.Project
+		var projectErr string
+
+		projectsDone := make(chan struct{})
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer close(projectsDone)
 			list, err := client.Projects().List(ctx, &sdktypes.ListOptions{Page: 1, Size: 200})
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
-				appendErr(&data, "projects: "+err.Error())
+				projectErr = "projects: " + err.Error()
 				return
 			}
 			data.Projects = list.Items
+			projects = list.Items
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			list, err := client.Sessions().List(ctx, &sdktypes.ListOptions{Page: 1, Size: 200})
+			<-projectsDone
 			mu.Lock()
-			defer mu.Unlock()
-			if err != nil {
-				appendErr(&data, "sessions: "+err.Error())
+			if projectErr != "" {
+				appendErr(&data, projectErr)
+				mu.Unlock()
 				return
 			}
-			data.Sessions = list.Items
+			projs := make([]sdktypes.Project, len(projects))
+			copy(projs, projects)
+			mu.Unlock()
+
+			var allSessions []sdktypes.Session
+			var sessWg sync.WaitGroup
+			var sessMu sync.Mutex
+			var sessErr string
+
+			for _, proj := range projs {
+				proj := proj
+				sessWg.Add(1)
+				go func() {
+					defer sessWg.Done()
+					if factory == nil {
+						return
+					}
+					projClient, err := factory.ForProject(proj.Name)
+					if err != nil {
+						sessMu.Lock()
+						if sessErr == "" {
+							sessErr = "session client for " + proj.Name + ": " + err.Error()
+						}
+						sessMu.Unlock()
+						return
+					}
+					list, err := projClient.Sessions().List(ctx, &sdktypes.ListOptions{Page: 1, Size: 200})
+					if err != nil {
+						sessMu.Lock()
+						if sessErr == "" {
+							sessErr = "sessions[" + proj.Name + "]: " + err.Error()
+						}
+						sessMu.Unlock()
+						return
+					}
+					sessMu.Lock()
+					allSessions = append(allSessions, list.Items...)
+					sessMu.Unlock()
+				}()
+			}
+			sessWg.Wait()
+
+			mu.Lock()
+			defer mu.Unlock()
+			if sessErr != "" {
+				appendErr(&data, sessErr)
+			}
+			data.Sessions = allSessions
 		}()
 
 		wg.Add(1)

--- a/components/ambient-cli/cmd/acpctl/ambient/tui/model.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/tui/model.go
@@ -2,9 +2,14 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
 	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
 	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,21 +18,21 @@ import (
 type NavSection int
 
 const (
-	NavCluster    NavSection = iota // system pods in ambient-code namespace
+	NavDashboard  NavSection = iota // system controls, port-forwards, login
+	NavCluster                      // system pods in ambient-code namespace
 	NavNamespaces                   // fleet-* namespaces
 	NavProjects                     // SDK projects list
 	NavSessions                     // SDK sessions list
 	NavAgents                       // SDK agents list
-	NavStats                        // summary counts
 )
 
 var navLabels = []string{
+	"Dashboard",
 	"Cluster Pods",
 	"Namespaces",
 	"Projects",
 	"Sessions",
 	"Agents",
-	"Stats",
 }
 
 type PodRow struct {
@@ -43,6 +48,22 @@ type NamespaceRow struct {
 	Name   string
 	Status string
 	Age    string
+}
+
+type PortForwardEntry struct {
+	Label     string
+	SvcName   string
+	LocalPort int
+	SvcPort   int
+	PID       int
+	Running   bool
+}
+
+type LoginStatus struct {
+	LoggedIn  bool
+	User      string
+	Server    string
+	Namespace string
 }
 
 type DashData struct {
@@ -102,40 +123,86 @@ func (c *cmdInputModel) render() string {
 	runes := []rune(c.value)
 	cur := c.cursor
 	if cur >= len(runes) {
-		return styleGreen.Render("$ ") + string(runes) + styleBold.Render("█")
+		return styleBlue.Render("$ ") + string(runes) + styleBold.Render("█")
 	}
 	before := string(runes[:cur])
 	cursorChar := string(runes[cur : cur+1])
 	after := string(runes[cur+1:])
-	return styleGreen.Render("$ ") + before + styleBold.Render(cursorChar) + after
+	return styleBlue.Render("$ ") + before + styleBold.Render(cursorChar) + after
 }
 
 type Model struct {
-	client          *sdkclient.Client
-	width           int
-	height          int
-	nav             NavSection
-	data            DashData
-	mainLines       []string
-	mainScroll      int
-	input           cmdInputModel
-	history         []string
-	histIdx         int
-	cmdRunning      bool
-	refreshing      bool
-	lastFetch       time.Time
-	msgCh           chan tea.Msg
-	cmdFocus        bool
-	sessionMsgs     map[string][]sdktypes.SessionMessage
-	sessionWatching map[string]context.CancelFunc
+	client             *sdkclient.Client
+	clientFactory      *connection.ClientFactory
+	width              int
+	height             int
+	nav                NavSection
+	data               DashData
+	mainLines          []string
+	mainScroll         int
+	input              cmdInputModel
+	history            []string
+	histIdx            int
+	cmdRunning         bool
+	refreshing         bool
+	lastFetch          time.Time
+	msgCh              chan tea.Msg
+	cmdFocus           bool
+	sessionMsgs        map[string][]sdktypes.SessionMessage
+	sessionWatching    map[string]context.CancelFunc
+	sessionTileContent map[string][2]int
+
+	portForwards []PortForwardEntry
+	loginStatus  LoginStatus
+
+	panelFocus        bool
+	panelRow          int
+	detailMode        bool
+	detailLines       []string
+	detailTitle       string
+	detailScroll      int
+	detailSelectable  bool
+	detailRow         int
+	detailItems       []detailItem
+	detailHeaderLines int
+
+	detailSplit        bool
+	detailTopLines     []string
+	detailBottomLines  []string
+	detailTopScroll    int
+	detailBottomScroll int
+	detailSplitFocus   int
+
+	composeMode      bool
+	composeSessionID string
+	composeInput     cmdInputModel
+	composeStatus    string
+
+	agentEditMode    bool
+	agentEditAgent   sdktypes.Agent
+	agentEditPrompt  string
+	agentEditDirty   bool
+	agentEditCursor  int
+	agentEditStatus  string
+	agentEditEscOnce bool
+
+	agentConfirmDelete bool
+	agentDeleteID      string
+	agentDeleteName    string
 }
 
-func NewModel(client *sdkclient.Client) *Model {
+func NewModel(client *sdkclient.Client, factory *connection.ClientFactory) *Model {
 	return &Model{
-		client:  client,
-		msgCh:   make(chan tea.Msg, 256),
-		histIdx: -1,
-		nav:     NavCluster,
+		client:        client,
+		clientFactory: factory,
+		msgCh:         make(chan tea.Msg, 256),
+		histIdx:       -1,
+		nav:           NavDashboard,
+		portForwards: []PortForwardEntry{
+			{Label: "REST API", SvcName: "ambient-api-server", LocalPort: 18000, SvcPort: 8000},
+			{Label: "gRPC", SvcName: "ambient-api-server", LocalPort: 19000, SvcPort: 9000},
+			{Label: "Frontend", SvcName: "frontend-service", LocalPort: 18080, SvcPort: 3000},
+		},
 	}
 }
 
@@ -145,6 +212,7 @@ func (m *Model) Init() tea.Cmd {
 		m.listenForMsgs(),
 		func() tea.Msg { return refreshMsg{} },
 		m.tickCmd(),
+		m.checkPortForwards(),
 	)
 }
 
@@ -185,6 +253,42 @@ const (
 	lkHeader
 )
 
+type detailItem struct {
+	namespace string
+	name      string
+	id        string
+	kind      string
+}
+
+type detailReadyMsg struct {
+	title       string
+	lines       []string
+	selectable  bool
+	items       []detailItem
+	headerLines int
+}
+
+type composeSentMsg struct{ sessionID string }
+type composeErrMsg struct{ err string }
+
+type splitDetailReadyMsg struct {
+	title       string
+	topLines    []string
+	bottomLines []string
+}
+
+type agentSavedMsg struct{ agent sdktypes.Agent }
+type agentSaveErrMsg struct{ err string }
+type agentDeletedMsg struct{ id string }
+type agentDeleteErrMsg struct{ err string }
+
+type pfStatusMsg struct {
+	idx     int
+	running bool
+	pid     int
+}
+type loginStatusMsg struct{ status LoginStatus }
+
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
@@ -193,19 +297,125 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.rebuildMain()
 
+	case splitDetailReadyMsg:
+		m.detailTitle = msg.title
+		m.detailSplit = true
+		m.detailTopLines = msg.topLines
+		m.detailBottomLines = msg.bottomLines
+		m.detailTopScroll = 0
+		m.detailBottomScroll = 0
+		m.detailSplitFocus = 0
+		m.detailMode = true
+		m.detailSelectable = false
+		m.detailLines = nil
+		return m, m.listenForMsgs()
+
+	case detailReadyMsg:
+		m.detailTitle = msg.title
+		m.detailLines = msg.lines
+		m.detailScroll = 0
+		m.detailRow = 0
+		m.detailSelectable = msg.selectable
+		m.detailItems = msg.items
+		m.detailHeaderLines = msg.headerLines
+		m.detailMode = true
+		if msg.selectable {
+			m.applyDetailCursor(msg.headerLines)
+		}
+		return m, m.listenForMsgs()
+
+	case agentSavedMsg:
+		m.agentEditStatus = styleGreen.Render("✓ saved")
+		m.agentEditDirty = false
+		for i, a := range m.data.Agents {
+			if a.ID == msg.agent.ID {
+				m.data.Agents[i] = msg.agent
+				m.agentEditAgent = msg.agent
+			}
+		}
+		m.rebuildMain()
+		return m, m.listenForMsgs()
+
+	case agentSaveErrMsg:
+		m.agentEditStatus = styleRed.Render("✗ " + msg.err)
+		return m, m.listenForMsgs()
+
+	case agentDeletedMsg:
+		m.agentConfirmDelete = false
+		m.agentDeleteID = ""
+		m.agentDeleteName = ""
+		var updated []sdktypes.Agent
+		for _, a := range m.data.Agents {
+			if a.ID != msg.id {
+				updated = append(updated, a)
+			}
+		}
+		m.data.Agents = updated
+		m.panelFocus = false
+		m.panelRow = 0
+		m.rebuildMain()
+		return m, m.listenForMsgs()
+
+	case agentDeleteErrMsg:
+		m.agentConfirmDelete = false
+		m.agentEditStatus = styleRed.Render("✗ delete failed: " + msg.err)
+		return m, m.listenForMsgs()
+
 	case tea.KeyMsg:
+		if m.agentEditMode {
+			return m.updateAgentEdit(msg)
+		}
+		if m.agentConfirmDelete {
+			return m.updateAgentDeleteConfirm(msg)
+		}
+		if m.composeMode {
+			return m.updateComposeFocused(msg)
+		}
 		if m.cmdFocus {
 			return m.updateInputFocused(msg)
 		}
+		if m.detailMode {
+			return m.updateDetailMode(msg)
+		}
+		if m.panelFocus {
+			return m.updatePanelFocused(msg)
+		}
 		return m.updateNavFocused(msg)
+
+	case composeSentMsg:
+		m.composeStatus = styleGreen.Render("✓ sent")
+		m.rebuildMain()
+		return m, m.listenForMsgs()
+
+	case composeErrMsg:
+		m.composeStatus = styleRed.Render("✗ " + msg.err)
+		m.rebuildMain()
+		return m, m.listenForMsgs()
 
 	case refreshMsg:
 		m.refreshing = true
-		return m, tea.Batch(m.listenForMsgs(), fetchAll(m.client, m.msgCh))
+		return m, tea.Batch(m.listenForMsgs(), fetchAll(m.client, m.clientFactory, m.msgCh))
 
 	case tickMsg:
 		m.refreshing = true
-		return m, tea.Batch(m.listenForMsgs(), fetchAll(m.client, m.msgCh), m.tickCmd())
+		return m, tea.Batch(m.listenForMsgs(), fetchAll(m.client, m.clientFactory, m.msgCh), m.tickCmd())
+
+	case pfStatusMsg:
+		if msg.idx >= 0 && msg.idx < len(m.portForwards) {
+			m.portForwards[msg.idx].Running = msg.running
+			m.portForwards[msg.idx].PID = msg.pid
+		}
+		if m.nav == NavDashboard {
+			m.rebuildMain()
+		}
+		return m, m.listenForMsgs()
+
+	case loginStatusMsg:
+		m.loginStatus = msg.status
+		if m.nav == NavDashboard {
+			m.rebuildMain()
+		}
+		return m, m.listenForMsgs()
 
 	case dataMsg:
 		m.data = msg.data
@@ -246,6 +456,8 @@ func (m *Model) updateNavFocused(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC:
 		return m, tea.Quit
+	case tea.KeyEsc:
+		return m, tea.Quit
 	case tea.KeyUp:
 		if m.nav > 0 {
 			m.nav--
@@ -258,10 +470,16 @@ func (m *Model) updateNavFocused(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.mainScroll = 0
 			m.rebuildMain()
 		}
+	case tea.KeyRight, tea.KeyEnter:
+		m.panelFocus = true
+		m.panelRow = 0
+		m.rebuildMain()
 	case tea.KeyPgUp:
 		m.mainScroll = max(0, m.mainScroll-m.mainContentH())
 	case tea.KeyPgDown:
 		m.mainScroll = min(max(0, len(m.mainLines)-m.mainContentH()), m.mainScroll+m.mainContentH())
+	case tea.KeyTab:
+		m.cmdFocus = true
 	case tea.KeyRunes:
 		switch msg.String() {
 		case "q":
@@ -281,10 +499,6 @@ func (m *Model) updateNavFocused(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.rebuildMain()
 			}
 		}
-	case tea.KeyTab:
-		m.cmdFocus = true
-	case tea.KeyEnter:
-		m.cmdFocus = true
 	}
 	return m, nil
 }
@@ -353,6 +567,607 @@ func (m *Model) updateInputFocused(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m *Model) panelRowCount() int {
+	switch m.nav {
+	case NavDashboard:
+		return len(m.portForwards) + 1
+	case NavCluster:
+		return len(m.data.Pods)
+	case NavNamespaces:
+		return len(m.data.Namespaces)
+	case NavProjects:
+		return len(m.data.Projects)
+	case NavSessions:
+		return len(m.data.Sessions)
+	case NavAgents:
+		return len(m.data.Agents)
+	}
+	return 0
+}
+
+func (m *Model) updatePanelFocused(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	n := m.panelRowCount()
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc, tea.KeyLeft:
+		m.panelFocus = false
+		m.panelRow = 0
+		m.rebuildMain()
+		return m, nil
+	case tea.KeyUp:
+		if m.panelRow > 0 {
+			m.panelRow--
+			m.rebuildMain()
+		}
+	case tea.KeyDown:
+		if n > 0 && m.panelRow < n-1 {
+			m.panelRow++
+			m.rebuildMain()
+		}
+	case tea.KeyPgUp:
+		m.panelRow = max(0, m.panelRow-m.mainContentH())
+		m.rebuildMain()
+	case tea.KeyPgDown:
+		if n > 0 {
+			m.panelRow = min(n-1, m.panelRow+m.mainContentH())
+		}
+		m.rebuildMain()
+	case tea.KeyEnter, tea.KeyRight:
+		if m.nav == NavDashboard {
+			return m, m.dashboardActivate(m.panelRow)
+		}
+		if m.nav == NavSessions && m.panelRow < len(m.data.Sessions) {
+			sess := m.data.Sessions[m.panelRow]
+			m.composeMode = true
+			m.composeSessionID = sess.ID
+			m.composeStatus = ""
+			m.composeInput.clear()
+			m.rebuildMain()
+			return m, nil
+		}
+		if m.nav == NavAgents && m.panelRow < len(m.data.Agents) {
+			agent := m.data.Agents[m.panelRow]
+			m.agentEditMode = true
+			m.agentEditAgent = agent
+			m.agentEditPrompt = agent.Prompt
+			m.agentEditDirty = false
+			m.agentEditCursor = len([]rune(agent.Prompt))
+			m.agentEditStatus = ""
+			return m, nil
+		}
+		return m, m.drillIntoSelected()
+	case tea.KeyRunes:
+		switch msg.String() {
+		case "d", "D":
+			if m.nav == NavAgents && m.panelRow < len(m.data.Agents) {
+				agent := m.data.Agents[m.panelRow]
+				m.agentConfirmDelete = true
+				m.agentDeleteID = agent.ID
+				m.agentDeleteName = agent.Name
+				return m, nil
+			}
+		case "j":
+			if n > 0 && m.panelRow < n-1 {
+				m.panelRow++
+				m.rebuildMain()
+			}
+		case "k":
+			if m.panelRow > 0 {
+				m.panelRow--
+				m.rebuildMain()
+			}
+		case "r":
+			return m, func() tea.Msg { return refreshMsg{} }
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) updateAgentDeleteConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		m.agentConfirmDelete = false
+		return m, nil
+	case tea.KeyRunes:
+		switch msg.String() {
+		case "y", "Y":
+			id := m.agentDeleteID
+			client := m.client
+			m.agentConfirmDelete = false
+			return m, tea.Batch(m.listenForMsgs(), func() tea.Msg {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if err := client.Agents().Delete(ctx, id); err != nil {
+					return agentDeleteErrMsg{err: err.Error()}
+				}
+				return agentDeletedMsg{id: id}
+			})
+		case "n", "N":
+			m.agentConfirmDelete = false
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) updateAgentEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	runes := []rune(m.agentEditPrompt)
+	cur := m.agentEditCursor
+
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		if m.agentEditDirty {
+			m.agentConfirmDelete = false
+			m.agentEditEscOnce = true
+			m.agentEditStatus = styleYellow.Render("unsaved changes — y abandon  ·  n keep editing")
+		} else {
+			m.agentEditMode = false
+			m.agentEditEscOnce = false
+			m.agentEditStatus = ""
+		}
+		return m, nil
+	case tea.KeyEnter:
+		if !m.agentEditDirty {
+			m.agentEditMode = false
+			m.rebuildMain()
+			return m, nil
+		}
+		prompt := m.agentEditPrompt
+		agent := m.agentEditAgent
+		client := m.client
+		m.agentEditStatus = styleDim.Render("saving…")
+		m.rebuildMain()
+		return m, tea.Batch(m.listenForMsgs(), func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			updated, err := client.Agents().Update(ctx, agent.ID, map[string]any{"prompt": prompt})
+			if err != nil {
+				return agentSaveErrMsg{err: err.Error()}
+			}
+			return agentSavedMsg{agent: *updated}
+		})
+	case tea.KeyBackspace:
+		m.agentEditEscOnce = false
+		if cur > 0 {
+			runes = append(runes[:cur-1], runes[cur:]...)
+			m.agentEditPrompt = string(runes)
+			m.agentEditCursor--
+			m.agentEditDirty = true
+		}
+	case tea.KeyDelete:
+		if cur < len(runes) {
+			runes = append(runes[:cur], runes[cur+1:]...)
+			m.agentEditPrompt = string(runes)
+			m.agentEditDirty = true
+		}
+	case tea.KeyLeft:
+		if cur > 0 {
+			m.agentEditCursor--
+		}
+	case tea.KeyRight:
+		if cur < len(runes) {
+			m.agentEditCursor++
+		}
+	case tea.KeyHome, tea.KeyCtrlA:
+		m.agentEditCursor = 0
+	case tea.KeyEnd, tea.KeyCtrlE:
+		m.agentEditCursor = len(runes)
+	case tea.KeyCtrlK:
+		m.agentEditPrompt = string(runes[:cur])
+		m.agentEditDirty = true
+	case tea.KeyCtrlU:
+		m.agentEditPrompt = string(runes[cur:])
+		m.agentEditCursor = 0
+		m.agentEditDirty = true
+	case tea.KeySpace:
+		runes = append(runes[:cur], append([]rune{' '}, runes[cur:]...)...)
+		m.agentEditPrompt = string(runes)
+		m.agentEditCursor++
+		m.agentEditDirty = true
+	case tea.KeyRunes:
+		if m.agentEditEscOnce {
+			switch msg.String() {
+			case "y", "Y":
+				m.agentEditPrompt = m.agentEditAgent.Prompt
+				m.agentEditDirty = false
+				m.agentEditMode = false
+				m.agentEditEscOnce = false
+				m.agentEditStatus = ""
+			case "n", "N":
+				m.agentEditEscOnce = false
+				m.agentEditStatus = ""
+			}
+			m.rebuildMain()
+			return m, nil
+		}
+		for _, r := range msg.Runes {
+			runes = append(runes[:cur], append([]rune{r}, runes[cur:]...)...)
+			cur++
+		}
+		m.agentEditPrompt = string(runes)
+		m.agentEditCursor = cur
+		m.agentEditDirty = true
+	}
+	m.rebuildMain()
+	return m, nil
+}
+
+func (m *Model) updateComposeFocused(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		m.composeMode = false
+		m.composeInput.clear()
+		m.composeStatus = ""
+		m.rebuildMain()
+		return m, nil
+	case tea.KeyEnter:
+		text := strings.TrimSpace(m.composeInput.value)
+		if text == "" {
+			return m, nil
+		}
+		sessID := m.composeSessionID
+		client := m.client
+		factory := m.clientFactory
+		sessions := m.data.Sessions
+		m.composeInput.clear()
+		m.composeStatus = styleDim.Render("sending…")
+		m.rebuildMain()
+		return m, tea.Batch(m.listenForMsgs(), func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			c := client
+			if factory != nil {
+				for _, sess := range sessions {
+					if sess.ID == sessID && sess.ProjectID != "" {
+						if pc, err := factory.ForProject(sess.ProjectID); err == nil {
+							c = pc
+						}
+					}
+				}
+			}
+			_, err := c.Sessions().PushMessage(ctx, sessID, text)
+			if err != nil {
+				return composeErrMsg{err: err.Error()}
+			}
+			return composeSentMsg{sessionID: sessID}
+		})
+	case tea.KeyBackspace:
+		m.composeInput.backspace()
+	case tea.KeyDelete:
+		m.composeInput.deleteForward()
+	case tea.KeyLeft:
+		m.composeInput.moveLeft()
+	case tea.KeyRight:
+		m.composeInput.moveRight()
+	case tea.KeyHome, tea.KeyCtrlA:
+		m.composeInput.moveHome()
+	case tea.KeyEnd, tea.KeyCtrlE:
+		m.composeInput.moveEnd()
+	case tea.KeyCtrlK:
+		m.composeInput.value = string([]rune(m.composeInput.value)[:m.composeInput.cursor])
+	case tea.KeyCtrlU:
+		m.composeInput.value = string([]rune(m.composeInput.value)[m.composeInput.cursor:])
+		m.composeInput.cursor = 0
+	case tea.KeySpace:
+		m.composeInput.insert(' ')
+	case tea.KeyRunes:
+		for _, r := range msg.Runes {
+			m.composeInput.insert(r)
+		}
+	}
+	m.rebuildMain()
+	return m, nil
+}
+
+func (m *Model) popDetailMode() {
+	m.detailMode = false
+	m.detailLines = nil
+	m.detailTitle = ""
+	m.detailScroll = 0
+	m.detailRow = 0
+	m.detailSelectable = false
+	m.detailItems = nil
+	m.detailHeaderLines = 0
+	m.detailSplit = false
+	m.detailTopLines = nil
+	m.detailBottomLines = nil
+	m.detailTopScroll = 0
+	m.detailBottomScroll = 0
+	m.detailSplitFocus = 0
+	m.rebuildMain()
+}
+
+func (m *Model) updateDetailMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	contentH := m.mainContentH()
+	n := len(m.detailItems)
+	headerLines := m.detailHeaderLines
+
+	if m.detailSplit {
+		halfH := contentH/2 - 1
+		if halfH < 1 {
+			halfH = 1
+		}
+		active := &m.detailTopScroll
+		activeLines := m.detailTopLines
+		if m.detailSplitFocus == 1 {
+			active = &m.detailBottomScroll
+			activeLines = m.detailBottomLines
+		}
+		maxScroll := len(activeLines) - halfH
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		case tea.KeyEsc:
+			m.popDetailMode()
+			return m, nil
+		case tea.KeyLeft:
+			if m.detailSplitFocus == 1 {
+				m.detailSplitFocus = 0
+			} else {
+				m.popDetailMode()
+				return m, nil
+			}
+		case tea.KeyRight:
+			m.detailSplitFocus = 1
+		case tea.KeyUp:
+			if *active > 0 {
+				*active--
+			}
+		case tea.KeyDown:
+			if *active < maxScroll {
+				*active++
+			}
+		case tea.KeyPgUp:
+			*active = max(0, *active-halfH)
+		case tea.KeyPgDown:
+			*active = min(maxScroll, *active+halfH)
+		case tea.KeyTab:
+			m.detailSplitFocus = 1 - m.detailSplitFocus
+		case tea.KeyRunes:
+			switch msg.String() {
+			case "j":
+				if *active < maxScroll {
+					*active++
+				}
+			case "k":
+				if *active > 0 {
+					*active--
+				}
+			}
+		}
+		return m, nil
+	}
+
+	if m.detailSelectable {
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		case tea.KeyEsc, tea.KeyLeft:
+			m.popDetailMode()
+			return m, nil
+		case tea.KeyEnter, tea.KeyRight:
+			if m.detailRow < n {
+				item := m.detailItems[m.detailRow]
+				sessionMsgs := m.sessionMsgs
+				return m, func() tea.Msg {
+					switch item.kind {
+					case "session":
+						var msgs []sdktypes.SessionMessage
+						if sessionMsgs != nil {
+							msgs = sessionMsgs[item.id]
+						}
+						sess := sdktypes.Session{}
+						sess.Name = item.name
+						sess.ProjectID = item.namespace
+						sess.ID = item.id
+						return fetchSessionSplitDetail(sess, msgs)
+					default:
+						lines := fetchPodLogs(item.namespace, item.name)
+						return detailReadyMsg{title: "Pod Logs: " + item.namespace + "/" + item.name, lines: lines}
+					}
+				}
+			}
+		case tea.KeyUp:
+			if m.detailRow > 0 {
+				m.detailRow--
+				m.applyDetailCursor(headerLines)
+			}
+		case tea.KeyDown:
+			if n > 0 && m.detailRow < n-1 {
+				m.detailRow++
+				m.applyDetailCursor(headerLines)
+			}
+		case tea.KeyRunes:
+			switch msg.String() {
+			case "j":
+				if n > 0 && m.detailRow < n-1 {
+					m.detailRow++
+					m.applyDetailCursor(headerLines)
+				}
+			case "k":
+				if m.detailRow > 0 {
+					m.detailRow--
+					m.applyDetailCursor(headerLines)
+				}
+			}
+		}
+		return m, nil
+	}
+
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc, tea.KeyLeft:
+		m.popDetailMode()
+		return m, nil
+	case tea.KeyUp:
+		if m.detailScroll > 0 {
+			m.detailScroll--
+		}
+	case tea.KeyDown:
+		if m.detailScroll < len(m.detailLines)-contentH {
+			m.detailScroll++
+		}
+	case tea.KeyPgUp:
+		m.detailScroll = max(0, m.detailScroll-contentH)
+	case tea.KeyPgDown:
+		m.detailScroll = min(max(0, len(m.detailLines)-contentH), m.detailScroll+contentH)
+	case tea.KeyRunes:
+		switch msg.String() {
+		case "j":
+			if m.detailScroll < len(m.detailLines)-contentH {
+				m.detailScroll++
+			}
+		case "k":
+			if m.detailScroll > 0 {
+				m.detailScroll--
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) dashboardActivate(row int) tea.Cmd {
+	pfCount := len(m.portForwards)
+	if row < pfCount {
+		idx := row
+		entry := m.portForwards[idx]
+		return func() tea.Msg {
+			if entry.Running && entry.PID > 0 {
+				_ = exec.Command("kill", strconv.Itoa(entry.PID)).Run()
+				return pfStatusMsg{idx: idx, running: false, pid: 0}
+			}
+			namespace := "ambient-code"
+			cmd := exec.Command("kubectl", "port-forward",
+				fmt.Sprintf("svc/%s", entry.SvcName),
+				fmt.Sprintf("%d:%d", entry.LocalPort, entry.SvcPort),
+				"-n", namespace)
+			if err := cmd.Start(); err != nil {
+				return pfStatusMsg{idx: idx, running: false, pid: 0}
+			}
+			time.Sleep(500 * time.Millisecond)
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", entry.LocalPort), 2*time.Second)
+			if err == nil {
+				conn.Close()
+				return pfStatusMsg{idx: idx, running: true, pid: cmd.Process.Pid}
+			}
+			return pfStatusMsg{idx: idx, running: false, pid: 0}
+		}
+	}
+	return func() tea.Msg {
+		out, err := exec.Command("kubectl", "config", "current-context").Output()
+		if err != nil {
+			return loginStatusMsg{status: LoginStatus{}}
+		}
+		ctx := strings.TrimSpace(string(out))
+		whoami, _ := exec.Command("kubectl", "auth", "whoami", "-o", "jsonpath={.status.userInfo.username}").Output()
+		user := strings.TrimSpace(string(whoami))
+		if user == "" {
+			user = "unknown"
+		}
+		ns, _ := exec.Command("kubectl", "config", "view", "--minify", "-o", "jsonpath={..namespace}").Output()
+		namespace := strings.TrimSpace(string(ns))
+		if namespace == "" {
+			namespace = "default"
+		}
+		return loginStatusMsg{status: LoginStatus{
+			LoggedIn:  true,
+			User:      user,
+			Server:    ctx,
+			Namespace: namespace,
+		}}
+	}
+}
+
+func (m *Model) checkPortForwards() tea.Cmd {
+	entries := make([]PortForwardEntry, len(m.portForwards))
+	copy(entries, m.portForwards)
+	return func() tea.Msg {
+		for i, entry := range entries {
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", entry.LocalPort), 300*time.Millisecond)
+			if err == nil {
+				conn.Close()
+				if !entry.Running {
+					m.msgCh <- pfStatusMsg{idx: i, running: true, pid: entry.PID}
+				}
+			} else {
+				if entry.Running {
+					m.msgCh <- pfStatusMsg{idx: i, running: false, pid: 0}
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func (m *Model) drillIntoSelected() tea.Cmd {
+	row := m.panelRow
+	client := m.client
+	factory := m.clientFactory
+	data := m.data
+	sessionMsgs := m.sessionMsgs
+	return func() tea.Msg {
+		switch m.nav {
+		case NavCluster:
+			if row >= len(data.Pods) {
+				break
+			}
+			pod := data.Pods[row]
+			lines := fetchPodLogs(pod.Namespace, pod.Name)
+			return detailReadyMsg{title: "Pod Logs: " + pod.Namespace + "/" + pod.Name, lines: lines}
+
+		case NavNamespaces:
+			if row >= len(data.Namespaces) {
+				break
+			}
+			ns := data.Namespaces[row]
+			return fetchNamespacePodsDetail(ns.Name)
+
+		case NavSessions:
+			if row >= len(data.Sessions) {
+				break
+			}
+			sess := data.Sessions[row]
+			msgs := sessionMsgs[sess.ID]
+			return fetchSessionSplitDetail(sess, msgs)
+
+		case NavProjects:
+			if row >= len(data.Projects) {
+				break
+			}
+			proj := data.Projects[row]
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			projClient := client
+			if factory != nil {
+				if pc, err := factory.ForProject(proj.Name); err == nil {
+					projClient = pc
+				}
+			}
+			return fetchProjectSessionsDetail(ctx, projClient, proj)
+
+		case NavAgents:
+			if row >= len(data.Agents) {
+				break
+			}
+			agent := data.Agents[row]
+			lines := renderAgentDetail(agent)
+			return detailReadyMsg{title: "Agent: " + agent.Name, lines: lines}
+		}
+		return nil
+	}
 }
 
 func (m *Model) mainContentH() int {
@@ -428,7 +1243,8 @@ func (m *Model) restartSessionPoll() {
 		}
 	}
 
-	client := m.client
+	defaultClient := m.client
+	factory := m.clientFactory
 	msgCh := m.msgCh
 
 	for _, sess := range m.data.Sessions {
@@ -438,21 +1254,50 @@ func (m *Model) restartSessionPoll() {
 		ctx, cancel := context.WithCancel(context.Background())
 		m.sessionWatching[sess.ID] = cancel
 		sessID := sess.ID
-		go func() {
-			msgs, stop, err := client.Sessions().WatchMessages(ctx, sessID, 0)
-			if err != nil {
-				return
+		projID := sess.ProjectID
+
+		watchClient := defaultClient
+		if factory != nil && projID != "" {
+			if pc, err := factory.ForProject(projID); err == nil {
+				watchClient = pc
 			}
-			defer stop()
+		}
+
+		go func() {
 			for {
 				select {
 				case <-ctx.Done():
 					return
-				case msg, ok := <-msgs:
-					if !ok {
+				default:
+				}
+				msgs, stop, err := watchClient.Sessions().WatchMessages(ctx, sessID, 0)
+				if err != nil {
+					select {
+					case <-ctx.Done():
 						return
+					case <-time.After(3 * time.Second):
+						continue
 					}
-					msgCh <- sessionMsgsMsg{sessionID: sessID, msg: *msg}
+				}
+				done := false
+				for !done {
+					select {
+					case <-ctx.Done():
+						stop()
+						return
+					case msg, ok := <-msgs:
+						if !ok {
+							done = true
+							break
+						}
+						msgCh <- sessionMsgsMsg{sessionID: sessID, msg: *msg}
+					}
+				}
+				stop()
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(2 * time.Second):
 				}
 			}
 		}()

--- a/components/ambient-cli/cmd/acpctl/ambient/tui/view.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/tui/view.go
@@ -11,7 +11,7 @@ import (
 var (
 	colorOrange = lipgloss.Color("214")
 	colorCyan   = lipgloss.Color("36")
-	colorGreen  = lipgloss.Color("32")
+	colorGreen  = lipgloss.Color("28")
 	colorRed    = lipgloss.Color("31")
 	colorYellow = lipgloss.Color("33")
 	colorDim    = lipgloss.Color("240")
@@ -58,29 +58,75 @@ func (m *Model) renderHeader() string {
 	if m.refreshing {
 		spin = styleYellow.Render("  ⟳")
 	}
-	title := styleBold.Render("Ambient") +
-		styleCyan.Render(" Dashboard") +
-		age + spin +
-		styleDim.Render("  ↑↓/jk nav  ·  Tab cmd  ·  r refresh  ·  q quit")
+	title := styleOrange.Render(styleBold.Render("Ambient")) +
+		styleBlue.Render(" Dashboard") +
+		age + spin
 	return " " + title
 }
 
+func (m *Model) renderBreadcrumb() string {
+	sep := styleDim.Render(" › ")
+	crumb := styleOrange.Render(navLabels[m.nav])
+	if m.panelFocus && !m.detailMode {
+		enterHint := "Enter/→ open"
+		extra := ""
+		if m.nav == NavSessions {
+			enterHint = "Enter/→ send message"
+		}
+		if m.nav == NavAgents {
+			enterHint = "Enter/→ edit"
+			extra = "  ·  D delete"
+		}
+		return crumb + sep + styleOrange.Render("panel") + styleDim.Render("  ↑↓/jk navigate  ·  "+enterHint+extra+"  ·  Esc/← back")
+	}
+	if m.detailMode && m.detailSelectable {
+		return crumb + sep + styleDim.Render("panel") + sep + styleOrange.Render(m.detailTitle) + styleDim.Render("  ↑↓/jk navigate  ·  Enter/→ open  ·  Esc/← back")
+	}
+	if m.detailMode && m.detailSplit {
+		panel := "messages"
+		if m.detailSplitFocus == 1 {
+			panel = "pod logs"
+		}
+		return crumb + sep + styleDim.Render("panel") + sep + styleOrange.Render(m.detailTitle) + styleDim.Render("  ["+panel+"]  ↑↓/jk scroll  ·  ←/→ switch  ·  Esc back")
+	}
+	if m.detailMode {
+		return crumb + sep + styleDim.Render("panel") + sep + styleOrange.Render(m.detailTitle) + styleDim.Render("  ↑↓/jk scroll  ·  Esc/← back")
+	}
+	return styleOrange.Render(navLabels[m.nav]) + styleDim.Render("  ↑↓/jk nav  ·  Enter/→ panel  ·  Tab cmd  ·  r refresh  ·  q quit")
+}
+
 func (m *Model) renderFooter() string {
+	if m.agentConfirmDelete {
+		return styleRed.Render("⚠") + " " + styleBold.Render("Delete agent "+m.agentDeleteName+"?") + styleDim.Render("  y yes  ·  n/Esc cancel")
+	}
+	if m.agentEditMode {
+		dirty := ""
+		if m.agentEditDirty {
+			dirty = styleOrange.Render("  ●")
+		}
+		status := ""
+		if m.agentEditStatus != "" {
+			status = "  " + m.agentEditStatus
+		}
+		return styleOrange.Render("✎") + " " + styleBold.Render("Editing: "+m.agentEditAgent.Name) + dirty + styleDim.Render("  Enter save  ·  Esc cancel") + status
+	}
+	if m.composeMode {
+		return styleOrange.Render("▶") + " " + styleDim.Render("Enter send  ·  Esc cancel")
+	}
 	if m.cmdFocus {
 		return styleBlue.Render("▶") + " " + m.input.render()
 	}
 	if m.cmdRunning {
 		return styleYellow.Render("⏳") + " " + styleDim.Render("running…  (Tab to focus cmd bar)")
 	}
-	hint := styleDim.Render("Tab to focus command bar  ·  Esc to unfocus")
-	return "  " + hint
+	return " " + m.renderBreadcrumb()
 }
 
 func (m *Model) renderSidebar() []string {
 	lines := make([]string, 0, len(navLabels)+4)
-	lines = append(lines, styleBlue.Render("┌"+strings.Repeat("─", navW-2)+"┐"))
-	lines = append(lines, styleBlue.Render("│")+styleBold.Render(" Navigation")+styleBlue.Render(padTo(" ", navW-13))+"│")
-	lines = append(lines, styleBlue.Render("├"+strings.Repeat("─", navW-2)+"┤"))
+	lines = append(lines, styleOrange.Render("┌"+strings.Repeat("─", navW-2)+"┐"))
+	lines = append(lines, styleOrange.Render("│")+styleBold.Render(" Navigation")+styleOrange.Render(padTo(" ", navW-13))+"│")
+	lines = append(lines, styleOrange.Render("├"+strings.Repeat("─", navW-2)+"┤"))
 	for i, label := range navLabels {
 		nav := NavSection(i)
 		count := m.navCount(nav)
@@ -89,19 +135,21 @@ func (m *Model) renderSidebar() []string {
 			countStr = styleDim.Render(fmt.Sprintf(" (%d)", count))
 		}
 		if m.nav == nav {
-			text := styleGreen.Render("▶ "+label) + countStr
-			lines = append(lines, styleBlue.Render("│")+" "+padStyled(text, navW-3)+styleBlue.Render("│"))
+			text := styleOrange.Render("▶ "+label) + countStr
+			lines = append(lines, styleOrange.Render("│")+" "+padStyled(text, navW-3)+styleOrange.Render("│"))
 		} else {
 			text := styleDim.Render("  "+label) + countStr
-			lines = append(lines, styleBlue.Render("│")+" "+padStyled(text, navW-3)+styleBlue.Render("│"))
+			lines = append(lines, styleOrange.Render("│")+" "+padStyled(text, navW-3)+styleOrange.Render("│"))
 		}
 	}
-	lines = append(lines, styleBlue.Render("└"+strings.Repeat("─", navW-2)+"┘"))
+	lines = append(lines, styleOrange.Render("└"+strings.Repeat("─", navW-2)+"┘"))
 	return lines
 }
 
 func (m *Model) navCount(nav NavSection) int {
 	switch nav {
+	case NavDashboard:
+		return -1
 	case NavCluster:
 		return len(m.data.Pods)
 	case NavNamespaces:
@@ -120,9 +168,77 @@ func (m *Model) renderMain() []string {
 	mainW := m.width - navW - 1
 	contentH := m.mainContentH()
 
-	visible := m.mainLines
-	if m.mainScroll < len(visible) {
-		visible = visible[m.mainScroll:]
+	if m.detailMode && m.detailSplit {
+		halfH := contentH / 2
+		if halfH < 2 {
+			halfH = 2
+		}
+		bottomH := contentH - halfH - 1
+
+		renderPanel := func(src []string, scroll, h int, focused bool) []string {
+			visible := src
+			if scroll < len(visible) {
+				visible = visible[scroll:]
+			}
+			if len(visible) > h {
+				visible = visible[:h]
+			}
+			out := make([]string, h)
+			for i, l := range visible {
+				out[i] = truncateLine(l, mainW)
+			}
+			return out
+		}
+
+		topFocused := m.detailSplitFocus == 0
+		botFocused := m.detailSplitFocus == 1
+
+		sepChar := "─"
+		sepStyle := styleDim
+		if topFocused {
+			sepStyle = styleOrange
+		}
+		topIndicator := styleDim.Render(" ↑↓/jk  Tab switch")
+		if topFocused {
+			topIndicator = styleOrange.Render(" ↑↓/jk") + styleDim.Render("  Tab switch")
+		}
+
+		botSepStyle := styleDim
+		if botFocused {
+			botSepStyle = styleOrange
+		}
+		botIndicator := styleDim.Render(" ↑↓/jk")
+		if botFocused {
+			botIndicator = styleOrange.Render(" ↑↓/jk") + styleDim.Render("  Tab switch")
+		}
+		_ = botIndicator
+
+		sep := sepStyle.Render(strings.Repeat(sepChar, mainW/2)) + topIndicator
+
+		var lines []string
+		lines = append(lines, renderPanel(m.detailTopLines, m.detailTopScroll, halfH, topFocused)...)
+		lines = append(lines, sep)
+		botLines := renderPanel(m.detailBottomLines, m.detailBottomScroll, bottomH, botFocused)
+		if botFocused && len(botLines) > 0 {
+			botLines[0] = botSepStyle.Render(botLines[0])
+		}
+		lines = append(lines, botLines...)
+		return lines
+	}
+
+	var source []string
+	var scroll int
+	if m.detailMode {
+		source = m.detailLines
+		scroll = m.detailScroll
+	} else {
+		source = m.mainLines
+		scroll = m.mainScroll
+	}
+
+	visible := source
+	if scroll < len(visible) {
+		visible = visible[scroll:]
 	}
 	if len(visible) > contentH {
 		visible = visible[:contentH]
@@ -132,20 +248,6 @@ func (m *Model) renderMain() []string {
 	for i, l := range visible {
 		lines[i] = truncateLine(l, mainW)
 	}
-
-	scrollInfo := ""
-	if len(m.mainLines) > contentH {
-		pct := 0
-		if len(m.mainLines) > 0 {
-			pct = (m.mainScroll + contentH) * 100 / len(m.mainLines)
-			if pct > 100 {
-				pct = 100
-			}
-		}
-		scrollInfo = styleDim.Render(fmt.Sprintf("  %d%%  PgUp/PgDn to scroll", pct))
-	}
-	_ = scrollInfo
-
 	return lines
 }
 

--- a/components/ambient-cli/cmd/acpctl/apply/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/apply/cmd.go
@@ -1,0 +1,711 @@
+// Package apply implements acpctl apply -f / -k for declarative fleet management.
+package apply
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
+	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
+	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply declarative Project, Agent, and Credential manifests",
+	Long: `Apply Projects, Agents, and Credentials from YAML files or a Kustomize directory.
+
+Mirrors kubectl apply semantics: resources are created if they do not exist,
+or patched if they do. Output reports created / configured / unchanged per resource.
+
+Supported kinds: Project, Agent, Credential
+
+File format (one or more documents separated by ---):
+
+  kind: Project
+  name: my-project
+  description: "..."
+  prompt: |
+    Workspace context injected into every agent start.
+  labels:
+    env: dev
+  annotations:
+    ambient.io/summary: ""
+
+  ---
+
+  kind: Agent
+  name: lead
+  prompt: |
+    You are the Lead...
+  labels:
+    ambient.io/ready: "true"
+  annotations:
+    work.ambient.io/current-task: ""
+  inbox:
+    - from_name: platform-bootstrap
+      body: |
+        First start. Bootstrap: read project annotations...
+
+Examples:
+
+  acpctl apply -f .ambient/teams/base/
+  acpctl apply -f .ambient/teams/base/lead.yaml
+  acpctl apply -k .ambient/teams/overlays/dev/
+  acpctl apply -k .ambient/teams/overlays/prod/ --dry-run
+  cat lead.yaml | acpctl apply -f -
+
+Credential example:
+
+  kind: Credential
+  name: my-gitlab-pat
+  provider: gitlab
+  token: $GITLAB_PAT
+  url: https://gitlab.myco.com
+  labels:
+    team: platform
+`,
+	RunE: run,
+}
+
+var applyArgs struct {
+	file         string
+	kustomize    string
+	dryRun       bool
+	outputFormat string
+	project      string
+}
+
+func init() {
+	Cmd.Flags().StringVarP(&applyArgs.file, "filename", "f", "", "File, directory, or - for stdin")
+	Cmd.Flags().StringVarP(&applyArgs.kustomize, "kustomize", "k", "", "Kustomize directory")
+	Cmd.Flags().BoolVar(&applyArgs.dryRun, "dry-run", false, "Print what would be applied without making API calls")
+	Cmd.Flags().StringVarP(&applyArgs.outputFormat, "output", "o", "", "Output format: json")
+	Cmd.Flags().StringVar(&applyArgs.project, "project", "", "Override project context for Agent resources")
+}
+
+// resource is a parsed YAML document from a manifest file.
+type resource struct {
+	Kind        string            `yaml:"kind"`
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description"`
+	Prompt      string            `yaml:"prompt"`
+	Labels      map[string]string `yaml:"labels"`
+	Annotations map[string]string `yaml:"annotations"`
+	Inbox       []inboxSeed       `yaml:"inbox"`
+	Provider    string            `yaml:"provider"`
+	Token       string            `yaml:"token"`
+	URL         string            `yaml:"url"`
+	Email       string            `yaml:"email"`
+}
+
+type inboxSeed struct {
+	FromName string `yaml:"from_name"`
+	Body     string `yaml:"body"`
+}
+
+type applyResult struct {
+	Kind   string `json:"kind"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+func run(cmd *cobra.Command, _ []string) error {
+	if applyArgs.file == "" && applyArgs.kustomize == "" {
+		return fmt.Errorf("one of -f or -k is required")
+	}
+	if applyArgs.file != "" && applyArgs.kustomize != "" {
+		return fmt.Errorf("-f and -k are mutually exclusive")
+	}
+
+	var docs []resource
+	var err error
+
+	if applyArgs.kustomize != "" {
+		docs, err = loadKustomize(applyArgs.kustomize)
+	} else {
+		docs, err = loadFile(applyArgs.file)
+	}
+	if err != nil {
+		return err
+	}
+
+	if applyArgs.dryRun {
+		return printDryRun(cmd, docs)
+	}
+
+	factory, err := connection.NewClientFactory()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	projectName := applyArgs.project
+	if projectName == "" {
+		projectName = cfg.GetProject()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+	defer cancel()
+
+	client, err := factory.ForProject(projectName)
+	if err != nil {
+		return err
+	}
+
+	var results []applyResult
+	for _, doc := range docs {
+		var result applyResult
+		switch strings.ToLower(doc.Kind) {
+		case "project":
+			result, err = applyProject(ctx, client, doc)
+		case "agent":
+			result, err = applyAgent(ctx, client, doc, projectName, factory)
+		case "credential":
+			result, err = applyCredential(ctx, client, doc)
+		default:
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: unknown kind %q — skipping\n", doc.Kind)
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("apply %s/%s: %w", strings.ToLower(doc.Kind), doc.Name, err)
+		}
+		results = append(results, result)
+
+		if applyArgs.outputFormat != "json" {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s %s\n",
+				strings.ToLower(result.Kind), result.Name, result.Status)
+		}
+	}
+
+	if applyArgs.outputFormat == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+	return nil
+}
+
+func applyProject(ctx context.Context, client *sdkclient.Client, doc resource) (applyResult, error) {
+	existing, err := client.Projects().Get(ctx, doc.Name)
+	if err != nil {
+		builder := sdktypes.NewProjectBuilder().Name(doc.Name)
+		if doc.Description != "" {
+			builder = builder.Description(doc.Description)
+		}
+		if doc.Prompt != "" {
+			builder = builder.Prompt(doc.Prompt)
+		}
+		proj, buildErr := builder.Build()
+		if buildErr != nil {
+			return applyResult{}, buildErr
+		}
+		if _, createErr := client.Projects().Create(ctx, proj); createErr != nil {
+			return applyResult{}, createErr
+		}
+		if len(doc.Labels) > 0 || len(doc.Annotations) > 0 {
+			patch := map[string]any{}
+			if len(doc.Labels) > 0 {
+				patch["labels"] = marshalStringMap(doc.Labels)
+			}
+			if len(doc.Annotations) > 0 {
+				patch["annotations"] = marshalStringMap(doc.Annotations)
+			}
+			if _, patchErr := client.Projects().Update(ctx, doc.Name, patch); patchErr != nil {
+				return applyResult{}, patchErr
+			}
+		}
+		return applyResult{Kind: "Project", Name: doc.Name, Status: "created"}, nil
+	}
+
+	patch := buildProjectPatch(existing, doc)
+	if len(patch) == 0 {
+		return applyResult{Kind: "Project", Name: doc.Name, Status: "unchanged"}, nil
+	}
+	if _, err = client.Projects().Update(ctx, doc.Name, patch); err != nil {
+		return applyResult{}, err
+	}
+	return applyResult{Kind: "Project", Name: doc.Name, Status: "configured"}, nil
+}
+
+func applyCredential(ctx context.Context, client *sdkclient.Client, doc resource) (applyResult, error) {
+	existing, err := client.Credentials().Get(ctx, doc.Name)
+	if err != nil {
+		token := os.ExpandEnv(doc.Token)
+		builder := sdktypes.NewCredentialBuilder().
+			Name(doc.Name).
+			Provider(doc.Provider)
+		if token != "" {
+			builder = builder.Token(token)
+		}
+		if doc.Description != "" {
+			builder = builder.Description(doc.Description)
+		}
+		if doc.URL != "" {
+			builder = builder.URL(doc.URL)
+		}
+		if doc.Email != "" {
+			builder = builder.Email(doc.Email)
+		}
+		if len(doc.Labels) > 0 {
+			builder = builder.Labels(marshalStringMap(doc.Labels))
+		}
+		if len(doc.Annotations) > 0 {
+			builder = builder.Annotations(marshalStringMap(doc.Annotations))
+		}
+		cred, buildErr := builder.Build()
+		if buildErr != nil {
+			return applyResult{}, buildErr
+		}
+		if _, createErr := client.Credentials().Create(ctx, cred); createErr != nil {
+			return applyResult{}, createErr
+		}
+		return applyResult{Kind: "Credential", Name: doc.Name, Status: "created"}, nil
+	}
+
+	patch, changed := buildCredentialPatch(existing, doc)
+	if !changed {
+		return applyResult{Kind: "Credential", Name: doc.Name, Status: "unchanged"}, nil
+	}
+	if _, err = client.Credentials().Update(ctx, existing.ID, patch); err != nil {
+		return applyResult{}, err
+	}
+	return applyResult{Kind: "Credential", Name: doc.Name, Status: "configured"}, nil
+}
+
+func buildCredentialPatch(existing *sdktypes.Credential, doc resource) (map[string]any, bool) {
+	changed := false
+	patch := sdktypes.NewCredentialPatchBuilder()
+	if doc.Description != "" && doc.Description != existing.Description {
+		patch = patch.Description(doc.Description)
+		changed = true
+	}
+	if doc.URL != "" && doc.URL != existing.URL {
+		patch = patch.URL(doc.URL)
+		changed = true
+	}
+	if doc.Email != "" && doc.Email != existing.Email {
+		patch = patch.Email(doc.Email)
+		changed = true
+	}
+	token := os.ExpandEnv(doc.Token)
+	if token != "" && token != existing.Token {
+		patch = patch.Token(token)
+		changed = true
+	}
+	if len(doc.Labels) > 0 && marshalStringMap(doc.Labels) != existing.Labels {
+		patch = patch.Labels(marshalStringMap(doc.Labels))
+		changed = true
+	}
+	if len(doc.Annotations) > 0 && marshalStringMap(doc.Annotations) != existing.Annotations {
+		patch = patch.Annotations(marshalStringMap(doc.Annotations))
+		changed = true
+	}
+	return patch.Build(), changed
+}
+
+func marshalStringMap(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+func buildProjectPatch(existing *sdktypes.Project, doc resource) map[string]any {
+	patch := map[string]any{}
+	if doc.Description != "" && doc.Description != existing.Description {
+		patch["description"] = doc.Description
+	}
+	if doc.Prompt != "" && doc.Prompt != existing.Prompt {
+		patch["prompt"] = doc.Prompt
+	}
+	if len(doc.Labels) > 0 {
+		patch["labels"] = marshalStringMap(doc.Labels)
+	}
+	if len(doc.Annotations) > 0 {
+		patch["annotations"] = marshalStringMap(doc.Annotations)
+	}
+	return patch
+}
+
+func applyAgent(ctx context.Context, client *sdkclient.Client, doc resource, projectName string, factory *connection.ClientFactory) (applyResult, error) {
+	projClient := client
+	if factory != nil {
+		if pc, err := factory.ForProject(projectName); err == nil {
+			projClient = pc
+		}
+	}
+
+	project, err := projClient.Projects().Get(ctx, projectName)
+	if err != nil {
+		return applyResult{}, fmt.Errorf("project %q not found: %w", projectName, err)
+	}
+
+	existing, err := projClient.Agents().GetInProject(ctx, project.ID, doc.Name)
+	if err != nil {
+		builder := sdktypes.NewAgentBuilder().
+			ProjectID(project.ID).
+			Name(doc.Name)
+		if doc.Prompt != "" {
+			builder = builder.Prompt(doc.Prompt)
+		}
+		pa, buildErr := builder.Build()
+		if buildErr != nil {
+			return applyResult{}, buildErr
+		}
+		created, createErr := projClient.Agents().CreateInProject(ctx, project.ID, pa)
+		if createErr != nil {
+			return applyResult{}, createErr
+		}
+		if len(doc.Labels) > 0 || len(doc.Annotations) > 0 {
+			patch := map[string]any{}
+			if len(doc.Labels) > 0 {
+				patch["labels"] = marshalStringMap(doc.Labels)
+			}
+			if len(doc.Annotations) > 0 {
+				patch["annotations"] = marshalStringMap(doc.Annotations)
+			}
+			if _, patchErr := projClient.Agents().UpdateInProject(ctx, project.ID, created.ID, patch); patchErr != nil {
+				return applyResult{}, patchErr
+			}
+		}
+		if seedErr := seedInbox(ctx, projClient, project.ID, created.ID, doc.Inbox); seedErr != nil {
+			return applyResult{}, seedErr
+		}
+		return applyResult{Kind: "Agent", Name: doc.Name, Status: "created"}, nil
+	}
+
+	patch := buildAgentPatch(existing, doc)
+	status := "unchanged"
+	if len(patch) > 0 {
+		if _, err = projClient.Agents().UpdateInProject(ctx, project.ID, existing.ID, patch); err != nil {
+			return applyResult{}, err
+		}
+		status = "configured"
+	}
+	if seedErr := seedInbox(ctx, projClient, project.ID, existing.ID, doc.Inbox); seedErr != nil {
+		return applyResult{}, seedErr
+	}
+	return applyResult{Kind: "Agent", Name: doc.Name, Status: status}, nil
+}
+
+func buildAgentPatch(existing *sdktypes.Agent, doc resource) map[string]any {
+	patch := map[string]any{}
+	if doc.Prompt != "" && doc.Prompt != existing.Prompt {
+		patch["prompt"] = doc.Prompt
+	}
+	if len(doc.Labels) > 0 {
+		patch["labels"] = marshalStringMap(doc.Labels)
+	}
+	if len(doc.Annotations) > 0 {
+		patch["annotations"] = marshalStringMap(doc.Annotations)
+	}
+	return patch
+}
+
+func seedInbox(ctx context.Context, client *sdkclient.Client, projectID, agentID string, seeds []inboxSeed) error {
+	if len(seeds) == 0 {
+		return nil
+	}
+	existing, err := client.Agents().ListInboxInProject(ctx, projectID, agentID)
+	if err != nil {
+		return nil
+	}
+	existingSet := make(map[string]bool, len(existing))
+	for _, msg := range existing {
+		existingSet[msg.FromName+"\x00"+msg.Body] = true
+	}
+	for _, seed := range seeds {
+		key := seed.FromName + "\x00" + seed.Body
+		if existingSet[key] {
+			continue
+		}
+		if err := client.Agents().SendInboxInProject(ctx, projectID, agentID, seed.FromName, seed.Body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ── YAML loading ──────────────────────────────────────────────────────────────
+
+func loadFile(path string) ([]resource, error) {
+	if path == "-" {
+		return parseManifests(os.Stdin)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return loadDir(path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return parseManifests(f)
+}
+
+func loadDir(dir string) ([]resource, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var all []resource
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		if name == "kustomization.yaml" || name == "kustomization.yml" {
+			continue
+		}
+		docs, err := loadFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		all = append(all, docs...)
+	}
+	return all, nil
+}
+
+func parseManifests(r io.Reader) ([]resource, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var docs []resource
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var doc resource
+		if err := dec.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("parse YAML: %w", err)
+		}
+		if doc.Kind == "" {
+			continue
+		}
+		docs = append(docs, doc)
+	}
+	return docs, nil
+}
+
+// ── Kustomize ─────────────────────────────────────────────────────────────────
+
+type kustomization struct {
+	Kind      string      `yaml:"kind"`
+	Resources []string    `yaml:"resources"`
+	Bases     []string    `yaml:"bases"`
+	Patches   []kustPatch `yaml:"patches"`
+}
+
+type kustPatch struct {
+	Path   string     `yaml:"path"`
+	Target kustTarget `yaml:"target"`
+}
+
+type kustTarget struct {
+	Kind string `yaml:"kind"`
+	Name string `yaml:"name"`
+}
+
+func loadKustomize(dir string) ([]resource, error) {
+	kustFile := ""
+	for _, name := range []string{"kustomization.yaml", "kustomization.yml"} {
+		p := filepath.Join(dir, name)
+		if _, err := os.Stat(p); err == nil {
+			kustFile = p
+			break
+		}
+	}
+	if kustFile == "" {
+		return nil, fmt.Errorf("no kustomization.yaml found in %s", dir)
+	}
+
+	data, err := os.ReadFile(kustFile)
+	if err != nil {
+		return nil, err
+	}
+	var kust kustomization
+	if err := yaml.Unmarshal(data, &kust); err != nil {
+		return nil, fmt.Errorf("parse kustomization: %w", err)
+	}
+
+	var docs []resource
+
+	for _, base := range kust.Bases {
+		basePath := filepath.Join(dir, base)
+		baseDocs, err := loadKustomize(basePath)
+		if err != nil {
+			return nil, fmt.Errorf("base %s: %w", base, err)
+		}
+		docs = append(docs, baseDocs...)
+	}
+
+	for _, res := range kust.Resources {
+		resPath := filepath.Join(dir, res)
+		info, err := os.Stat(resPath)
+		if err != nil {
+			return nil, fmt.Errorf("resource %s: %w", res, err)
+		}
+		var resDocs []resource
+		if info.IsDir() {
+			resDocs, err = loadKustomize(resPath)
+		} else {
+			resDocs, err = loadFile(resPath)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("resource %s: %w", res, err)
+		}
+		docs = mergeResources(docs, resDocs)
+	}
+
+	for _, patch := range kust.Patches {
+		patchDocs, err := loadFile(filepath.Join(dir, patch.Path))
+		if err != nil {
+			return nil, fmt.Errorf("patch %s: %w", patch.Path, err)
+		}
+		for _, p := range patchDocs {
+			docs = applyPatch(docs, p, patch.Target)
+		}
+	}
+
+	return docs, nil
+}
+
+// mergeResources adds resDocs into docs, deduplicating by kind+name (later wins).
+func mergeResources(docs, incoming []resource) []resource {
+	idx := make(map[string]int, len(docs))
+	for i, d := range docs {
+		idx[resourceKey(d)] = i
+	}
+	for _, inc := range incoming {
+		key := resourceKey(inc)
+		if i, exists := idx[key]; exists {
+			docs[i] = inc
+		} else {
+			idx[key] = len(docs)
+			docs = append(docs, inc)
+		}
+	}
+	return docs
+}
+
+func resourceKey(r resource) string {
+	return strings.ToLower(r.Kind) + "/" + r.Name
+}
+
+// applyPatch merges patch into all matching resources (strategic merge).
+func applyPatch(docs []resource, patch resource, target kustTarget) []resource {
+	for i := range docs {
+		if !matchesTarget(docs[i], target) {
+			continue
+		}
+		docs[i] = strategicMerge(docs[i], patch)
+	}
+	return docs
+}
+
+func matchesTarget(doc resource, target kustTarget) bool {
+	if target.Kind != "" && !strings.EqualFold(doc.Kind, target.Kind) {
+		return false
+	}
+	if target.Name != "" && doc.Name != target.Name {
+		return false
+	}
+	return true
+}
+
+// strategicMerge applies patch onto base: scalars overwrite, maps merge.
+func strategicMerge(base, patch resource) resource {
+	if patch.Name != "" {
+		base.Name = patch.Name
+	}
+	if patch.Description != "" {
+		base.Description = patch.Description
+	}
+	if patch.Prompt != "" {
+		base.Prompt = patch.Prompt
+	}
+	if patch.Provider != "" {
+		base.Provider = patch.Provider
+	}
+	if patch.Token != "" {
+		base.Token = patch.Token
+	}
+	if patch.URL != "" {
+		base.URL = patch.URL
+	}
+	if patch.Email != "" {
+		base.Email = patch.Email
+	}
+	for k, v := range patch.Labels {
+		if base.Labels == nil {
+			base.Labels = make(map[string]string)
+		}
+		base.Labels[k] = v
+	}
+	for k, v := range patch.Annotations {
+		if base.Annotations == nil {
+			base.Annotations = make(map[string]string)
+		}
+		base.Annotations[k] = v
+	}
+	return base
+}
+
+// ── Dry-run ───────────────────────────────────────────────────────────────────
+
+func printDryRun(cmd *cobra.Command, docs []resource) error {
+	if applyArgs.outputFormat == "json" {
+		results := make([]applyResult, 0, len(docs))
+		for _, d := range docs {
+			results = append(results, applyResult{Kind: d.Kind, Name: d.Name, Status: "dry-run"})
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, "dry-run: would apply:")
+	for _, d := range docs {
+		fmt.Fprintf(w, "  %s/%s\n", strings.ToLower(d.Kind), d.Name)
+	}
+	return nil
+}
+
+// ── stdin helper ──────────────────────────────────────────────────────────────
+
+func readStdin() ([]byte, error) {
+	var buf bytes.Buffer
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		buf.WriteString(scanner.Text())
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes(), scanner.Err()
+}
+
+var _ = readStdin

--- a/components/ambient-cli/cmd/acpctl/create/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/create/cmd.go
@@ -23,6 +23,7 @@ var Cmd = &cobra.Command{
 Valid resource types:
   session         Create an agentic session
   project         Create a project
+  project-agent   Assign an agent to a project
   agent           Create an agent
   role            Create a role
   role-binding    Create a role binding
@@ -43,6 +44,8 @@ var createArgs struct {
 	description  string
 	outputFormat string
 	projectID    string
+	agentID      string
+	agentVersion int
 	ownerUserID  string
 	permissions  string
 	userID       string
@@ -63,6 +66,8 @@ func init() {
 	Cmd.Flags().StringVar(&createArgs.description, "description", "", "Description")
 	Cmd.Flags().StringVarP(&createArgs.outputFormat, "output", "o", "", "Output format: json")
 	Cmd.Flags().StringVar(&createArgs.projectID, "project-id", "", "Project ID")
+	Cmd.Flags().StringVar(&createArgs.agentID, "agent-id", "", "Agent ID (project-agent)")
+	Cmd.Flags().IntVar(&createArgs.agentVersion, "agent-version", 0, "Agent version to pin (project-agent)")
 	Cmd.Flags().StringVar(&createArgs.ownerUserID, "owner-user-id", "", "Owner user ID (agent)")
 	Cmd.Flags().StringVar(&createArgs.permissions, "permissions", "", "Role permissions (JSON)")
 	Cmd.Flags().StringVar(&createArgs.userID, "user-id", "", "User ID (role-binding)")
@@ -92,6 +97,8 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		return createSession(cmd, ctx, client)
 	case "project", "proj":
 		return createProject(cmd, ctx, client)
+	case "project-agent", "pa":
+		return createAgent(cmd, ctx, client)
 	case "agent":
 		return createAgent(cmd, ctx, client)
 	case "role":
@@ -99,7 +106,7 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 	case "role-binding", "rolebinding", "rb":
 		return createRoleBinding(cmd, ctx, client)
 	default:
-		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, agent, role, role-binding", cmdArgs[0])
+		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-agent, agent, role, role-binding", cmdArgs[0])
 	}
 }
 
@@ -185,9 +192,6 @@ func createProject(cmd *cobra.Command, ctx context.Context, client *sdkclient.Cl
 
 	builder := sdktypes.NewProjectBuilder().Name(createArgs.name)
 
-	if createArgs.displayName != "" {
-		builder = builder.DisplayName(createArgs.displayName)
-	}
 	if createArgs.description != "" {
 		builder = builder.Description(createArgs.description)
 	}
@@ -214,45 +218,29 @@ func createProject(cmd *cobra.Command, ctx context.Context, client *sdkclient.Cl
 }
 
 func createAgent(cmd *cobra.Command, ctx context.Context, client *sdkclient.Client) error {
-	warnUnusedFlags(cmd, "timeout", "user-id", "role-id", "scope", "scope-id", "recipient-agent-id", "body")
+	warnUnusedFlags(cmd, "repo-url", "model", "max-tokens", "temperature", "timeout", "display-name", "description", "owner-user-id", "permissions", "user-id", "role-id", "scope", "scope-id")
 
-	if createArgs.name == "" {
-		return fmt.Errorf("--name is required")
-	}
 	if createArgs.projectID == "" {
 		return fmt.Errorf("--project-id is required")
 	}
-	if createArgs.ownerUserID == "" {
-		return fmt.Errorf("--owner-user-id is required")
+	if createArgs.name == "" {
+		return fmt.Errorf("--name is required")
 	}
 
 	builder := sdktypes.NewAgentBuilder().
-		Name(createArgs.name).
 		ProjectID(createArgs.projectID).
-		OwnerUserID(createArgs.ownerUserID)
+		Name(createArgs.name)
 
 	if createArgs.prompt != "" {
 		builder = builder.Prompt(createArgs.prompt)
 	}
-	if createArgs.repoURL != "" {
-		builder = builder.RepoURL(createArgs.repoURL)
-	}
-	if createArgs.model != "" {
-		builder = builder.LlmModel(createArgs.model)
-	}
-	if createArgs.displayName != "" {
-		builder = builder.DisplayName(createArgs.displayName)
-	}
-	if createArgs.description != "" {
-		builder = builder.Description(createArgs.description)
-	}
 
-	agent, err := builder.Build()
+	pa, err := builder.Build()
 	if err != nil {
 		return fmt.Errorf("build agent: %w", err)
 	}
 
-	created, err := client.Agents().Create(ctx, agent)
+	created, err := client.Agents().CreateInProject(ctx, createArgs.projectID, pa)
 	if err != nil {
 		return fmt.Errorf("create agent: %w", err)
 	}

--- a/components/ambient-cli/cmd/acpctl/create/cmd_test.go
+++ b/components/ambient-cli/cmd/acpctl/create/cmd_test.go
@@ -18,7 +18,6 @@ func TestCreateProject_Success(t *testing.T) {
 		srv.RespondJSON(t, w, http.StatusCreated, &types.Project{
 			ObjectReference: types.ObjectReference{ID: "p-new"},
 			Name:            "my-project",
-			DisplayName:     "My Project",
 		})
 	})
 
@@ -65,7 +64,7 @@ func TestCreateProject_JSON(t *testing.T) {
 
 func TestCreateAgent_Success(t *testing.T) {
 	srv := testhelper.NewServer(t)
-	srv.Handle("/api/ambient/v1/projects/"+testhelper.TestProject+"/agents", func(w http.ResponseWriter, r *http.Request) {
+	srv.Handle("/api/ambient/v1/projects/my-project/agents", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
@@ -80,10 +79,7 @@ func TestCreateAgent_Success(t *testing.T) {
 	result := testhelper.Run(t, Cmd, "agent",
 		"--name", "overlord",
 		"--project-id", "my-project",
-		"--owner-user-id", "user-1",
 		"--prompt", "You coordinate the fleet",
-		"--repo-url", "https://github.com/org/repo",
-		"--model", "sonnet",
 	)
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v\nstdout: %s\nstderr: %s", result.Err, result.Stdout, result.Stderr)
@@ -96,7 +92,7 @@ func TestCreateAgent_Success(t *testing.T) {
 func TestCreateAgent_MissingName(t *testing.T) {
 	srv := testhelper.NewServer(t)
 	testhelper.Configure(t, srv.URL)
-	result := testhelper.Run(t, Cmd, "agent", "--project-id", "p1", "--owner-user-id", "u1")
+	result := testhelper.Run(t, Cmd, "agent", "--project-id", "p1")
 	if result.Err == nil {
 		t.Fatal("expected error for missing --name")
 	}
@@ -105,27 +101,15 @@ func TestCreateAgent_MissingName(t *testing.T) {
 	}
 }
 
-func TestCreateAgent_MissingProjectID(t *testing.T) {
+func TestCreateAgent_ProjectIDRequired(t *testing.T) {
 	srv := testhelper.NewServer(t)
 	testhelper.Configure(t, srv.URL)
-	result := testhelper.Run(t, Cmd, "agent", "--name", "x", "--owner-user-id", "u1")
+	result := testhelper.Run(t, Cmd, "agent", "--name", "x")
 	if result.Err == nil {
 		t.Fatal("expected error for missing --project-id")
 	}
 	if !strings.Contains(result.Err.Error(), "--project-id is required") {
 		t.Errorf("expected '--project-id is required', got: %v", result.Err)
-	}
-}
-
-func TestCreateAgent_MissingOwnerUserID(t *testing.T) {
-	srv := testhelper.NewServer(t)
-	testhelper.Configure(t, srv.URL)
-	result := testhelper.Run(t, Cmd, "agent", "--name", "x", "--project-id", "p1")
-	if result.Err == nil {
-		t.Fatal("expected error for missing --owner-user-id")
-	}
-	if !strings.Contains(result.Err.Error(), "--owner-user-id is required") {
-		t.Errorf("expected '--owner-user-id is required', got: %v", result.Err)
 	}
 }
 
@@ -178,7 +162,6 @@ func TestCreateRole_Success(t *testing.T) {
 		srv.RespondJSON(t, w, http.StatusCreated, &types.Role{
 			ObjectReference: types.ObjectReference{ID: "r-new"},
 			Name:            "agent:runner",
-			DisplayName:     "Agent Runner",
 		})
 	})
 

--- a/components/ambient-cli/cmd/acpctl/credential/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/credential/cmd.go
@@ -1,0 +1,407 @@
+// Package credential implements the credential subcommand for managing credentials.
+package credential
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/output"
+	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "credential",
+	Short: "Manage credentials",
+	Long: `Manage credentials for external service integrations.
+
+Subcommands:
+  list        List credentials
+  get         Get a specific credential
+  create      Create a credential
+  update      Update a credential's fields
+  delete      Delete a credential
+  token       Retrieve the token for a credential`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var listArgs struct {
+	outputFormat string
+	limit        int
+	provider     string
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List credentials",
+	Example: `  acpctl credential list
+  acpctl credential list --provider github -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		format, err := output.ParseFormat(listArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		opts := sdktypes.NewListOptions().Size(listArgs.limit).Build()
+		if listArgs.provider != "" {
+			opts.Search = fmt.Sprintf("provider='%s'", listArgs.provider)
+		}
+		list, err := client.Credentials().List(ctx, opts)
+		if err != nil {
+			return fmt.Errorf("list credentials: %w", err)
+		}
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(list)
+		}
+
+		return printCredentialTable(printer, list.Items)
+	},
+}
+
+var getArgs struct {
+	outputFormat string
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get a specific credential",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl credential get <id>
+  acpctl credential get <id> -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		credential, err := client.Credentials().Get(ctx, args[0])
+		if err != nil {
+			return fmt.Errorf("get credential %q: %w", args[0], err)
+		}
+
+		format, err := output.ParseFormat(getArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(credential)
+		}
+		return printCredentialTable(printer, []sdktypes.Credential{*credential})
+	},
+}
+
+var createArgs struct {
+	name         string
+	provider     string
+	token        string
+	description  string
+	url          string
+	email        string
+	labels       string
+	annotations  string
+	outputFormat string
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a credential",
+	Example: `  acpctl credential create --name github-main --provider github --token ghp_xxx
+  acpctl credential create --name jira-corp --provider jira --url https://corp.atlassian.net --token xxx`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if createArgs.name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		if createArgs.provider == "" {
+			return fmt.Errorf("--provider is required")
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		builder := sdktypes.NewCredentialBuilder().
+			Name(createArgs.name).
+			Provider(createArgs.provider)
+
+		if createArgs.token != "" {
+			builder = builder.Token(createArgs.token)
+		}
+		if createArgs.description != "" {
+			builder = builder.Description(createArgs.description)
+		}
+		if createArgs.url != "" {
+			builder = builder.URL(createArgs.url)
+		}
+		if createArgs.email != "" {
+			builder = builder.Email(createArgs.email)
+		}
+		if createArgs.labels != "" {
+			builder = builder.Labels(createArgs.labels)
+		}
+		if createArgs.annotations != "" {
+			builder = builder.Annotations(createArgs.annotations)
+		}
+
+		cred, err := builder.Build()
+		if err != nil {
+			return fmt.Errorf("build credential: %w", err)
+		}
+
+		created, err := client.Credentials().Create(ctx, cred)
+		if err != nil {
+			return fmt.Errorf("create credential: %w", err)
+		}
+
+		format, err := output.ParseFormat(createArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(created)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "credential/%s created\n", created.Name)
+		return nil
+	},
+}
+
+var updateArgs struct {
+	name        string
+	token       string
+	description string
+	url         string
+	email       string
+	labels      string
+	annotations string
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update a credential",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl credential update <id> --token ghp_newtoken
+  acpctl credential update <id> --description "updated description"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		patch := sdktypes.NewCredentialPatchBuilder()
+		if cmd.Flags().Changed("name") {
+			patch = patch.Name(updateArgs.name)
+		}
+		if cmd.Flags().Changed("token") {
+			patch = patch.Token(updateArgs.token)
+		}
+		if cmd.Flags().Changed("description") {
+			patch = patch.Description(updateArgs.description)
+		}
+		if cmd.Flags().Changed("url") {
+			patch = patch.URL(updateArgs.url)
+		}
+		if cmd.Flags().Changed("email") {
+			patch = patch.Email(updateArgs.email)
+		}
+		if cmd.Flags().Changed("labels") {
+			patch = patch.Labels(updateArgs.labels)
+		}
+		if cmd.Flags().Changed("annotations") {
+			patch = patch.Annotations(updateArgs.annotations)
+		}
+
+		updated, err := client.Credentials().Update(ctx, args[0], patch.Build())
+		if err != nil {
+			return fmt.Errorf("update credential: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "credential/%s updated\n", updated.Name)
+		return nil
+	},
+}
+
+var deleteArgs struct {
+	confirm bool
+}
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete <id>",
+	Short:   "Delete a credential",
+	Args:    cobra.ExactArgs(1),
+	Example: `  acpctl credential delete <id> --confirm`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !deleteArgs.confirm {
+			return fmt.Errorf("add --confirm to delete credential/%s", args[0])
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		if err := client.Credentials().Delete(ctx, args[0]); err != nil {
+			return fmt.Errorf("delete credential: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "credential/%s deleted\n", args[0])
+		return nil
+	},
+}
+
+var tokenArgs struct {
+	outputFormat string
+}
+
+var tokenCmd = &cobra.Command{
+	Use:   "token <id>",
+	Short: "Retrieve the token for a credential",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl credential token <id>
+  acpctl credential token <id> -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		resp, err := client.Credentials().GetToken(ctx, args[0])
+		if err != nil {
+			return fmt.Errorf("get token for credential %q: %w", args[0], err)
+		}
+
+		format, err := output.ParseFormat(tokenArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(resp)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", resp.Token)
+		return nil
+	},
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(getCmd)
+	Cmd.AddCommand(createCmd)
+	Cmd.AddCommand(updateCmd)
+	Cmd.AddCommand(deleteCmd)
+	Cmd.AddCommand(tokenCmd)
+
+	listCmd.Flags().StringVarP(&listArgs.outputFormat, "output", "o", "", "Output format: json")
+	listCmd.Flags().IntVar(&listArgs.limit, "limit", 100, "Maximum number of items to return")
+	listCmd.Flags().StringVar(&listArgs.provider, "provider", "", "Filter by provider (github|gitlab|jira|google|kubeconfig)")
+
+	getCmd.Flags().StringVarP(&getArgs.outputFormat, "output", "o", "", "Output format: json")
+
+	createCmd.Flags().StringVar(&createArgs.name, "name", "", "Credential name (required)")
+	createCmd.Flags().StringVar(&createArgs.provider, "provider", "", "Provider (github|gitlab|jira|google|kubeconfig) (required)")
+	createCmd.Flags().StringVar(&createArgs.token, "token", "", "Secret token or API key")
+	createCmd.Flags().StringVar(&createArgs.description, "description", "", "Description")
+	createCmd.Flags().StringVar(&createArgs.url, "url", "", "Service URL")
+	createCmd.Flags().StringVar(&createArgs.email, "email", "", "Associated email")
+	createCmd.Flags().StringVar(&createArgs.labels, "labels", "", "Labels (JSON string)")
+	createCmd.Flags().StringVar(&createArgs.annotations, "annotations", "", "Annotations (JSON string)")
+	createCmd.Flags().StringVarP(&createArgs.outputFormat, "output", "o", "", "Output format: json")
+
+	updateCmd.Flags().StringVar(&updateArgs.name, "name", "", "New credential name")
+	updateCmd.Flags().StringVar(&updateArgs.token, "token", "", "New secret token or API key")
+	updateCmd.Flags().StringVar(&updateArgs.description, "description", "", "New description")
+	updateCmd.Flags().StringVar(&updateArgs.url, "url", "", "New service URL")
+	updateCmd.Flags().StringVar(&updateArgs.email, "email", "", "New associated email")
+	updateCmd.Flags().StringVar(&updateArgs.labels, "labels", "", "New labels (JSON string)")
+	updateCmd.Flags().StringVar(&updateArgs.annotations, "annotations", "", "New annotations (JSON string)")
+
+	deleteCmd.Flags().BoolVar(&deleteArgs.confirm, "confirm", false, "Confirm deletion")
+
+	tokenCmd.Flags().StringVarP(&tokenArgs.outputFormat, "output", "o", "", "Output format: json")
+}
+
+func printCredentialTable(printer *output.Printer, credentials []sdktypes.Credential) error {
+	columns := []output.Column{
+		{Name: "ID", Width: 27},
+		{Name: "NAME", Width: 24},
+		{Name: "PROVIDER", Width: 12},
+		{Name: "DESCRIPTION", Width: 32},
+		{Name: "AGE", Width: 10},
+	}
+
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+
+	for _, c := range credentials {
+		age := ""
+		if c.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*c.CreatedAt))
+		}
+		table.WriteRow(c.ID, c.Name, c.Provider, c.Description, age)
+	}
+	return nil
+}

--- a/components/ambient-cli/cmd/acpctl/delete/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/delete/cmd.go
@@ -8,17 +8,22 @@ import (
 
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
+	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
+	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
 	"github.com/spf13/cobra"
 )
 
+var activePhases = map[string]bool{"Pending": true, "Creating": true, "Running": true}
+
 var deleteArgs struct {
 	yes bool
+	all bool
 }
 
 var Cmd = &cobra.Command{
-	Use:   "delete <resource> <name>",
+	Use:   "delete <resource> [name]",
 	Short: "Delete a resource",
-	Long: `Delete a resource by ID.
+	Long: `Delete a resource by ID, or delete all resources of a type with --all/-A.
 
 Valid resource types:
   project           (aliases: proj)
@@ -26,17 +31,36 @@ Valid resource types:
   session           (aliases: sess)
   agent
   role
-  role-binding      (aliases: rolebinding, rb)`,
-	Args: cobra.ExactArgs(2),
+  role-binding      (aliases: rolebinding, rb)
+  credential        (aliases: cred)
+
+Use --all / -A to delete all resources of the given type.
+For sessions, active sessions are stopped before deletion.`,
+	Args: cobra.RangeArgs(1, 2),
 	RunE: run,
+	Example: `  acpctl delete session s1 --yes
+  acpctl delete sessions --all --yes
+  acpctl delete sessions -Ay`,
 }
 
 func init() {
 	Cmd.Flags().BoolVarP(&deleteArgs.yes, "yes", "y", false, "Skip confirmation prompt")
+	Cmd.Flags().BoolVarP(&deleteArgs.all, "all", "A", false, "Delete all resources of this type")
 }
 
 func run(cmd *cobra.Command, cmdArgs []string) error {
 	resource := strings.ToLower(cmdArgs[0])
+
+	if deleteArgs.all {
+		if len(cmdArgs) > 1 {
+			return fmt.Errorf("cannot specify resource name with --all")
+		}
+		return runDeleteAll(cmd, resource)
+	}
+
+	if len(cmdArgs) < 2 {
+		return fmt.Errorf("resource name is required (or use --all)")
+	}
 	name := cmdArgs[1]
 
 	if !deleteArgs.yes {
@@ -107,7 +131,110 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "role-binding/%s deleted\n", name)
 		return nil
 
+	case "credential", "credentials", "cred", "creds":
+		if err := client.Credentials().Delete(ctx, name); err != nil {
+			return fmt.Errorf("delete credential %q: %w", name, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "credential/%s deleted\n", name)
+		return nil
+
 	default:
-		return fmt.Errorf("unknown or non-deletable resource type: %s\nDeletable types: project, project-settings, session, agent, role, role-binding", cmdArgs[0])
+		return fmt.Errorf("unknown or non-deletable resource type: %s\nDeletable types: project, project-settings, session, agent, role, role-binding, credential", cmdArgs[0])
 	}
+}
+
+func runDeleteAll(cmd *cobra.Command, resource string) error {
+	switch resource {
+	case "session", "sessions", "sess":
+		return deleteAllSessions(cmd)
+	default:
+		return fmt.Errorf("--all is only supported for sessions; got %q", resource)
+	}
+}
+
+func deleteAllSessions(cmd *cobra.Command) error {
+	client, err := connection.NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+	defer cancel()
+
+	sessions, err := listAllSessions(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	if len(sessions) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "no sessions to delete")
+		return nil
+	}
+
+	if !deleteArgs.yes {
+		fmt.Fprintf(cmd.OutOrStdout(), "Delete all %d sessions? [y/N]: ", len(sessions))
+		var confirm string
+		_, err := fmt.Fscanln(cmd.InOrStdin(), &confirm)
+		if err != nil {
+			return fmt.Errorf("interactive confirmation required; use --yes/-y to skip")
+		}
+		if strings.ToLower(confirm) != "y" {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	var stopped, deleted, failed int
+	for _, s := range sessions {
+		if activePhases[s.Phase] {
+			if _, stopErr := client.Sessions().Stop(ctx, s.ID); stopErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "session/%s: stop failed: %v\n", s.ID, stopErr)
+				failed++
+				continue
+			}
+			stopped++
+		}
+
+		if delErr := client.Sessions().Delete(ctx, s.ID); delErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "session/%s: delete failed: %v\n", s.ID, delErr)
+			failed++
+			continue
+		}
+		deleted++
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%d sessions deleted", deleted)
+	if stopped > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), " (%d stopped first)", stopped)
+	}
+	fmt.Fprintln(cmd.OutOrStdout())
+
+	if failed > 0 {
+		return fmt.Errorf("%d of %d sessions failed", failed, len(sessions))
+	}
+	return nil
+}
+
+func listAllSessions(ctx context.Context, client *sdkclient.Client) ([]sdktypes.Session, error) {
+	var all []sdktypes.Session
+	page := 1
+	pageSize := 500
+	for {
+		opts := sdktypes.NewListOptions().Page(page).Size(pageSize).Build()
+		list, err := client.Sessions().List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list sessions: %w", err)
+		}
+		all = append(all, list.Items...)
+		if len(list.Items) < pageSize {
+			break
+		}
+		page++
+	}
+	return all, nil
 }

--- a/components/ambient-cli/cmd/acpctl/describe/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/describe/cmd.go
@@ -24,7 +24,8 @@ Valid resource types:
   user              (aliases: usr)
   agent             (aliases: agents)
   role
-  role-binding      (aliases: rb)`,
+  role-binding      (aliases: rb)
+  credential        (aliases: cred)`,
 	Args: cobra.ExactArgs(2),
 	RunE: run,
 }
@@ -98,7 +99,14 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		}
 		return printer.PrintJSON(rb)
 
+	case "credential", "credentials", "cred", "creds":
+		cred, err := client.Credentials().Get(ctx, name)
+		if err != nil {
+			return fmt.Errorf("describe credential %q: %w", name, err)
+		}
+		return printer.PrintJSON(cred)
+
 	default:
-		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-settings, user, agent, role, role-binding", cmdArgs[0])
+		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-settings, user, agent, role, role-binding, credential", cmdArgs[0])
 	}
 }

--- a/components/ambient-cli/cmd/acpctl/describe/cmd_test.go
+++ b/components/ambient-cli/cmd/acpctl/describe/cmd_test.go
@@ -56,7 +56,6 @@ func TestDescribeProject(t *testing.T) {
 		srv.RespondJSON(t, w, http.StatusOK, &types.Project{
 			ObjectReference: types.ObjectReference{ID: "p1"},
 			Name:            "my-proj",
-			DisplayName:     "My Project",
 			Description:     "A test project",
 		})
 	})

--- a/components/ambient-cli/cmd/acpctl/get/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd.go
@@ -33,15 +33,22 @@ var Cmd = &cobra.Command{
 Valid resource types:
   sessions            (aliases: session, sess)
   projects            (aliases: project, proj)
+  project-agents      (aliases: project-agent, pa)
   project-settings    (aliases: projectsettings, ps)
   users               (aliases: user, usr)
   agents              (aliases: agent)
   roles               (aliases: role)
   role-bindings       (aliases: role-binding, rb)
+  credentials         (aliases: credential, cred)
 `,
 	Args:    cobra.RangeArgs(1, 2),
 	RunE:    run,
-	Example: "  acpctl get sessions\n  acpctl get session my-session-id\n  acpctl get projects -o json\n  acpctl get agents\n  acpctl get sessions -w  # Watch for real-time session changes",
+	Example: "  acpctl get sessions\n  acpctl get session my-session-id\n  acpctl get projects -o json\n  acpctl get agents\n  acpctl get project-agents --project-id <id>\n  acpctl get sessions -w  # Watch for real-time session changes",
+}
+
+var projectAgentArgs struct {
+	projectID string
+	paID      string
 }
 
 func init() {
@@ -49,6 +56,8 @@ func init() {
 	Cmd.Flags().IntVar(&args.limit, "limit", 100, "Maximum number of items to return")
 	Cmd.Flags().BoolVarP(&args.watch, "watch", "w", false, "Watch for real-time changes (sessions only)")
 	Cmd.Flags().DurationVar(&args.watchTimeout, "watch-timeout", 30*time.Minute, "Timeout for watch mode (e.g. 1h, 10m)")
+	Cmd.Flags().StringVar(&projectAgentArgs.projectID, "project-id", "", "Project ID (required for project-agents)")
+	Cmd.Flags().StringVar(&projectAgentArgs.paID, "project-agent", "", "Filter sessions by project-agent ID (requires --project-id)")
 }
 
 func run(cmd *cobra.Command, cmdArgs []string) error {
@@ -96,21 +105,41 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 
 	switch resource {
 	case "sessions":
+		if projectAgentArgs.paID != "" {
+			if projectAgentArgs.projectID == "" {
+				return fmt.Errorf("--project-id is required when using --project-agent")
+			}
+			return getSessionsByAgent(ctx, client, printer, projectAgentArgs.projectID, projectAgentArgs.paID)
+		}
 		return getSessions(ctx, client, printer, name)
 	case "projects":
 		return getProjects(ctx, client, printer, name)
+	case "project-agents":
+		if projectAgentArgs.projectID == "" {
+			return fmt.Errorf("--project-id is required for project-agents")
+		}
+		return getAgentsByProject(ctx, client, printer, projectAgentArgs.projectID, name)
 	case "project-settings":
 		return getProjectSettings(ctx, client, printer, name)
 	case "users":
 		return getUsers(ctx, client, printer, name)
 	case "agents":
-		return getAgents(ctx, client, printer, name)
+		pid := projectAgentArgs.projectID
+		if pid == "" {
+			pid = cfg.GetProject()
+		}
+		if pid == "" {
+			return fmt.Errorf("no project set; use --project-id or run 'acpctl config set project <name>'")
+		}
+		return getAgentsByProject(ctx, client, printer, pid, name)
 	case "roles":
 		return getRoles(ctx, client, printer, name)
 	case "role-bindings":
 		return getRoleBindings(ctx, client, printer, name)
+	case "credentials":
+		return getCredentials(ctx, client, printer, name)
 	default:
-		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-settings, users, agents, roles, role-bindings", cmdArgs[0])
+		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-agents, project-settings, users, agents, roles, role-bindings, credentials", cmdArgs[0])
 	}
 }
 
@@ -120,6 +149,8 @@ func normalizeResource(r string) string {
 		return "sessions"
 	case "project", "projects", "proj":
 		return "projects"
+	case "project-agent", "project-agents", "pa":
+		return "project-agents"
 	case "project-settings", "projectsettings", "project-setting", "ps":
 		return "project-settings"
 	case "user", "users", "usr":
@@ -130,9 +161,72 @@ func normalizeResource(r string) string {
 		return "roles"
 	case "role-binding", "role-bindings", "rolebinding", "rolebindings", "rb":
 		return "role-bindings"
+	case "credential", "credentials", "cred", "creds":
+		return "credentials"
 	default:
 		return r
 	}
+}
+
+func getAgentsByProject(ctx context.Context, client *sdkclient.Client, printer *output.Printer, projectID, name string) error {
+	if name != "" {
+		pa, err := client.Agents().GetByProject(ctx, projectID, name)
+		if err != nil {
+			return fmt.Errorf("get agent %q: %w", name, err)
+		}
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(pa)
+		}
+		return printAgentByProjectTable(printer, []sdktypes.Agent{*pa})
+	}
+
+	opts := sdktypes.NewListOptions().Size(args.limit).Build()
+	list, err := client.Agents().ListByProject(ctx, projectID, opts)
+	if err != nil {
+		return fmt.Errorf("list agents: %w", err)
+	}
+
+	if printer.Format() == output.FormatJSON {
+		return printer.PrintJSON(list)
+	}
+
+	return printAgentByProjectTable(printer, list.Items)
+}
+
+func printAgentByProjectTable(printer *output.Printer, pas []sdktypes.Agent) error {
+	columns := []output.Column{
+		{Name: "ID", Width: 27},
+		{Name: "NAME", Width: 24},
+		{Name: "PROJECT", Width: 27},
+		{Name: "SESSION", Width: 27},
+		{Name: "AGE", Width: 10},
+	}
+
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+
+	for _, pa := range pas {
+		age := ""
+		if pa.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*pa.CreatedAt))
+		}
+		table.WriteRow(pa.ID, pa.Name, pa.ProjectID, pa.CurrentSessionID, age)
+	}
+	return nil
+}
+
+func getSessionsByAgent(ctx context.Context, client *sdkclient.Client, printer *output.Printer, projectID, paID string) error {
+	opts := sdktypes.NewListOptions().Size(args.limit).Build()
+	list, err := client.Agents().Sessions(ctx, projectID, paID, opts)
+	if err != nil {
+		return fmt.Errorf("list sessions for agent %q: %w", paID, err)
+	}
+
+	if printer.Format() == output.FormatJSON {
+		return printer.PrintJSON(list)
+	}
+
+	return printSessionTable(printer, list.Items)
 }
 
 func getSessions(ctx context.Context, client *sdkclient.Client, printer *output.Printer, name string) error {
@@ -212,7 +306,6 @@ func printProjectTable(printer *output.Printer, projects []sdktypes.Project) err
 	columns := []output.Column{
 		{Name: "ID", Width: 27},
 		{Name: "NAME", Width: 30},
-		{Name: "DISPLAY NAME", Width: 30},
 		{Name: "STATUS", Width: 10},
 	}
 
@@ -220,7 +313,7 @@ func printProjectTable(printer *output.Printer, projects []sdktypes.Project) err
 	table.WriteHeaders()
 
 	for _, p := range projects {
-		table.WriteRow(p.ID, p.Name, p.DisplayName, p.Status)
+		table.WriteRow(p.ID, p.Name, p.Status)
 	}
 	return nil
 }
@@ -312,53 +405,6 @@ func printUserTable(printer *output.Printer, users []sdktypes.User) error {
 	return nil
 }
 
-func getAgents(ctx context.Context, client *sdkclient.Client, printer *output.Printer, name string) error {
-	if name != "" {
-		agent, err := client.Agents().Get(ctx, name)
-		if err != nil {
-			return fmt.Errorf("get agent %q: %w", name, err)
-		}
-		if printer.Format() == output.FormatJSON {
-			return printer.PrintJSON(agent)
-		}
-		return printAgentTable(printer, []sdktypes.Agent{*agent})
-	}
-
-	opts := sdktypes.NewListOptions().Size(args.limit).Build()
-	list, err := client.Agents().List(ctx, opts)
-	if err != nil {
-		return fmt.Errorf("list agents: %w", err)
-	}
-
-	if printer.Format() == output.FormatJSON {
-		return printer.PrintJSON(list)
-	}
-
-	return printAgentTable(printer, list.Items)
-}
-
-func printAgentTable(printer *output.Printer, agents []sdktypes.Agent) error {
-	columns := []output.Column{
-		{Name: "ID", Width: 27},
-		{Name: "NAME", Width: 30},
-		{Name: "PROJECT", Width: 20},
-		{Name: "MODEL", Width: 16},
-		{Name: "AGE", Width: 10},
-	}
-
-	table := output.NewTable(printer.Writer(), columns)
-	table.WriteHeaders()
-
-	for _, a := range agents {
-		age := ""
-		if a.CreatedAt != nil {
-			age = output.FormatAge(time.Since(*a.CreatedAt))
-		}
-		table.WriteRow(a.ID, a.Name, a.ProjectID, a.LlmModel, age)
-	}
-	return nil
-}
-
 func getRoles(ctx context.Context, client *sdkclient.Client, printer *output.Printer, name string) error {
 	if name != "" {
 		role, err := client.Roles().Get(ctx, name)
@@ -420,6 +466,48 @@ func getRoleBindings(ctx context.Context, client *sdkclient.Client, printer *out
 		return printer.PrintJSON(list)
 	}
 	return printRoleBindingTable(printer, list.Items)
+}
+
+func getCredentials(ctx context.Context, client *sdkclient.Client, printer *output.Printer, name string) error {
+	if name != "" {
+		cred, err := client.Credentials().Get(ctx, name)
+		if err != nil {
+			return fmt.Errorf("get credential %q: %w", name, err)
+		}
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(cred)
+		}
+		return printCredentialTable(printer, []sdktypes.Credential{*cred})
+	}
+	opts := sdktypes.NewListOptions().Size(args.limit).Build()
+	list, err := client.Credentials().List(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("list credentials: %w", err)
+	}
+	if printer.Format() == output.FormatJSON {
+		return printer.PrintJSON(list)
+	}
+	return printCredentialTable(printer, list.Items)
+}
+
+func printCredentialTable(printer *output.Printer, credentials []sdktypes.Credential) error {
+	columns := []output.Column{
+		{Name: "ID", Width: 27},
+		{Name: "NAME", Width: 24},
+		{Name: "PROVIDER", Width: 12},
+		{Name: "DESCRIPTION", Width: 32},
+		{Name: "AGE", Width: 10},
+	}
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+	for _, c := range credentials {
+		age := ""
+		if c.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*c.CreatedAt))
+		}
+		table.WriteRow(c.ID, c.Name, c.Provider, c.Description, age)
+	}
+	return nil
 }
 
 func printRoleBindingTable(printer *output.Printer, rbs []sdktypes.RoleBinding) error {

--- a/components/ambient-cli/cmd/acpctl/get/cmd_test.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd_test.go
@@ -24,8 +24,8 @@ func TestGetProjects_List(t *testing.T) {
 		srv.RespondJSON(t, w, http.StatusOK, &types.ProjectList{
 			ListMeta: types.ListMeta{Total: 2},
 			Items: []types.Project{
-				{ObjectReference: types.ObjectReference{ID: "p1", CreatedAt: makeTime("2026-01-01T00:00:00Z")}, Name: "alpha", DisplayName: "Alpha"},
-				{ObjectReference: types.ObjectReference{ID: "p2", CreatedAt: makeTime("2026-01-02T00:00:00Z")}, Name: "beta", DisplayName: "Beta"},
+				{ObjectReference: types.ObjectReference{ID: "p1", CreatedAt: makeTime("2026-01-01T00:00:00Z")}, Name: "alpha"},
+				{ObjectReference: types.ObjectReference{ID: "p2", CreatedAt: makeTime("2026-01-02T00:00:00Z")}, Name: "beta"},
 			},
 		})
 	})
@@ -49,7 +49,6 @@ func TestGetProjects_Single(t *testing.T) {
 		srv.RespondJSON(t, w, http.StatusOK, &types.Project{
 			ObjectReference: types.ObjectReference{ID: "p1"},
 			Name:            "alpha",
-			DisplayName:     "Alpha Project",
 		})
 	})
 
@@ -162,7 +161,6 @@ func TestGetAgents_List(t *testing.T) {
 				{
 					ObjectReference: types.ObjectReference{ID: "a1", CreatedAt: makeTime("2026-01-01T00:00:00Z")},
 					Name:            "overlord",
-					DisplayName:     "Overlord",
 					ProjectID:       testhelper.TestProject,
 				},
 			},

--- a/components/ambient-cli/cmd/acpctl/inbox/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/inbox/cmd.go
@@ -1,0 +1,302 @@
+// Package inbox implements the inbox subcommand for managing inbox messages.
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/output"
+	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "inbox",
+	Short: "Interact with agent inbox messages",
+	Long: `Interact with agent inbox messages.
+
+Subcommands:
+  list       List inbox messages for a project-agent
+  send       Send a message to a project-agent's inbox
+  mark-read  Mark an inbox message as read
+  delete     Delete an inbox message`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(sendCmd)
+	Cmd.AddCommand(markReadCmd)
+	Cmd.AddCommand(deleteCmd)
+
+	listCmd.Flags().StringVar(&listArgs.projectID, "project-id", "", "Project ID (required)")
+	listCmd.Flags().StringVar(&listArgs.paID, "pa-id", "", "Project-agent ID (required)")
+	listCmd.Flags().StringVarP(&listArgs.outputFormat, "output", "o", "", "Output format: json|wide")
+	listCmd.Flags().IntVar(&listArgs.limit, "limit", 100, "Maximum number of items to return")
+
+	sendCmd.Flags().StringVar(&sendArgs.projectID, "project-id", "", "Project ID (required)")
+	sendCmd.Flags().StringVar(&sendArgs.paID, "pa-id", "", "Project-agent ID (required)")
+	sendCmd.Flags().StringVar(&sendArgs.body, "body", "", "Message body (required)")
+	sendCmd.Flags().StringVar(&sendArgs.fromName, "from-name", "", "Sender display name")
+	sendCmd.Flags().StringVar(&sendArgs.fromPAID, "from-pa-id", "", "Sender project-agent ID")
+	sendCmd.Flags().StringVarP(&sendArgs.outputFormat, "output", "o", "", "Output format: json")
+
+	markReadCmd.Flags().StringVar(&markReadArgs.projectID, "project-id", "", "Project ID (required)")
+	markReadCmd.Flags().StringVar(&markReadArgs.paID, "pa-id", "", "Project-agent ID (required)")
+	markReadCmd.Flags().StringVar(&markReadArgs.msgID, "msg-id", "", "Message ID (required)")
+
+	deleteCmd.Flags().StringVar(&deleteArgs.projectID, "project-id", "", "Project ID (required)")
+	deleteCmd.Flags().StringVar(&deleteArgs.paID, "pa-id", "", "Project-agent ID (required)")
+	deleteCmd.Flags().StringVar(&deleteArgs.msgID, "msg-id", "", "Message ID (required)")
+}
+
+var listArgs struct {
+	projectID    string
+	paID         string
+	outputFormat string
+	limit        int
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List inbox messages for a project-agent",
+	Example: `  acpctl inbox list --project-id <id> --pa-id <id>
+  acpctl inbox list --project-id <id> --pa-id <id> -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if listArgs.projectID == "" {
+			return fmt.Errorf("--project-id is required")
+		}
+		if listArgs.paID == "" {
+			return fmt.Errorf("--pa-id is required")
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		format, err := output.ParseFormat(listArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		opts := sdktypes.NewListOptions().Size(listArgs.limit).Build()
+		list, err := client.InboxMessages().ListByAgent(ctx, listArgs.projectID, listArgs.paID, opts)
+		if err != nil {
+			return fmt.Errorf("list inbox messages: %w", err)
+		}
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(list)
+		}
+
+		return printInboxTable(printer, list.Items)
+	},
+}
+
+var sendArgs struct {
+	projectID    string
+	paID         string
+	body         string
+	fromName     string
+	fromPAID     string
+	outputFormat string
+}
+
+var sendCmd = &cobra.Command{
+	Use:   "send",
+	Short: "Send a message to a project-agent's inbox",
+	Example: `  acpctl inbox send --project-id <id> --pa-id <id> --body "please review PR #42"
+  acpctl inbox send --project-id <id> --pa-id <id> --body "task complete" --from-name "agent-alpha"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if sendArgs.projectID == "" {
+			return fmt.Errorf("--project-id is required")
+		}
+		if sendArgs.paID == "" {
+			return fmt.Errorf("--pa-id is required")
+		}
+		if sendArgs.body == "" {
+			return fmt.Errorf("--body is required")
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		builder := sdktypes.NewInboxMessageBuilder().
+			AgentID(sendArgs.paID).
+			Body(sendArgs.body)
+
+		if sendArgs.fromName != "" {
+			builder = builder.FromName(sendArgs.fromName)
+		}
+		if sendArgs.fromPAID != "" {
+			builder = builder.FromAgentID(sendArgs.fromPAID)
+		}
+
+		msg, err := builder.Build()
+		if err != nil {
+			return fmt.Errorf("build inbox message: %w", err)
+		}
+
+		created, err := client.InboxMessages().Send(ctx, sendArgs.projectID, sendArgs.paID, msg)
+		if err != nil {
+			return fmt.Errorf("send inbox message: %w", err)
+		}
+
+		format, err := output.ParseFormat(sendArgs.outputFormat)
+		if err != nil {
+			return err
+		}
+		printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(created)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "inbox-message/%s sent\n", created.ID)
+		return nil
+	},
+}
+
+var markReadArgs struct {
+	projectID string
+	paID      string
+	msgID     string
+}
+
+var markReadCmd = &cobra.Command{
+	Use:     "mark-read",
+	Short:   "Mark an inbox message as read",
+	Example: `  acpctl inbox mark-read --project-id <id> --pa-id <id> --msg-id <id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if markReadArgs.projectID == "" {
+			return fmt.Errorf("--project-id is required")
+		}
+		if markReadArgs.paID == "" {
+			return fmt.Errorf("--pa-id is required")
+		}
+		if markReadArgs.msgID == "" {
+			return fmt.Errorf("--msg-id is required")
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		if err := client.InboxMessages().MarkRead(ctx, markReadArgs.projectID, markReadArgs.paID, markReadArgs.msgID); err != nil {
+			return fmt.Errorf("mark-read inbox message: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "inbox-message/%s marked as read\n", markReadArgs.msgID)
+		return nil
+	},
+}
+
+var deleteArgs struct {
+	projectID string
+	paID      string
+	msgID     string
+}
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete",
+	Short:   "Delete an inbox message",
+	Example: `  acpctl inbox delete --project-id <id> --pa-id <id> --msg-id <id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if deleteArgs.projectID == "" {
+			return fmt.Errorf("--project-id is required")
+		}
+		if deleteArgs.paID == "" {
+			return fmt.Errorf("--pa-id is required")
+		}
+		if deleteArgs.msgID == "" {
+			return fmt.Errorf("--msg-id is required")
+		}
+
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		if err := client.InboxMessages().DeleteMessage(ctx, deleteArgs.projectID, deleteArgs.paID, deleteArgs.msgID); err != nil {
+			return fmt.Errorf("delete inbox message: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "inbox-message/%s deleted\n", deleteArgs.msgID)
+		return nil
+	},
+}
+
+func printInboxTable(printer *output.Printer, msgs []sdktypes.InboxMessage) error {
+	columns := []output.Column{
+		{Name: "ID", Width: 27},
+		{Name: "FROM", Width: 20},
+		{Name: "BODY", Width: 50},
+		{Name: "READ", Width: 6},
+		{Name: "AGE", Width: 10},
+	}
+
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+
+	for _, m := range msgs {
+		age := ""
+		if m.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*m.CreatedAt))
+		}
+		from := m.FromName
+		if from == "" {
+			from = m.FromAgentID
+		}
+		read := "false"
+		if m.Read {
+			read = "true"
+		}
+		body := m.Body
+		if len(body) > 48 {
+			body = body[:45] + "..."
+		}
+		table.WriteRow(m.ID, from, body, read, age)
+	}
+	return nil
+}

--- a/components/ambient-cli/cmd/acpctl/login/authcode.go
+++ b/components/ambient-cli/cmd/acpctl/login/authcode.go
@@ -1,0 +1,286 @@
+package login
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	defaultIssuerURL = "https://sso.redhat.com/auth/realms/redhat-external"
+	// TODO(RHOAIENG-56155): replace with a dedicated acpctl public client ID once registered in the redhat-external realm.
+	defaultClientID = "ocm-cli"
+	callbackTimeout = 5 * time.Minute
+	callbackHTML    = `<!DOCTYPE html><html><body>
+<h2>Login successful</h2>
+<p>You may close this tab and return to the terminal.</p>
+</body></html>`
+	callbackHTMLError = `<!DOCTYPE html><html><body>
+<h2>Login failed</h2>
+<p>%s</p>
+<p>Please close this tab and check the terminal for details.</p>
+</body></html>`
+)
+
+type authCodeResult struct {
+	code  string
+	state string
+	err   error
+}
+
+type tokenResult struct {
+	AccessToken  string
+	RefreshToken string
+}
+
+func runAuthCodeFlow(issuerURL, clientID, clientSecret string) (*tokenResult, error) {
+	issuerURL = strings.TrimRight(issuerURL, "/")
+	authorizeURL := issuerURL + "/protocol/openid-connect/auth"
+	tokenURL := issuerURL + "/protocol/openid-connect/token"
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("start local callback listener: %w", err)
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+
+	state, err := generateRandomState()
+	if err != nil {
+		return nil, fmt.Errorf("generate state: %w", err)
+	}
+
+	codeVerifier, codeChallenge, err := generatePKCE()
+	if err != nil {
+		return nil, fmt.Errorf("generate PKCE: %w", err)
+	}
+
+	authURL := buildAuthURL(authorizeURL, clientID, redirectURI, state, codeChallenge)
+
+	resultCh := make(chan authCodeResult, 1)
+	srv := &http.Server{
+		Handler: callbackHandler(state, resultCh),
+	}
+
+	go func() {
+		_ = srv.Serve(listener)
+	}()
+
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	fmt.Printf("Opening browser for authentication...\nIf the browser does not open, visit:\n\n  %s\n\n", authURL)
+	_ = openBrowser(authURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), callbackTimeout)
+	defer cancel()
+
+	var result authCodeResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("timed out waiting for authorization callback (%.0fs)", callbackTimeout.Seconds())
+	}
+
+	if result.err != nil {
+		return nil, fmt.Errorf("authorization failed: %w", result.err)
+	}
+
+	tokens, err := exchangeCodeForTokens(tokenURL, clientID, clientSecret, result.code, redirectURI, codeVerifier)
+	if err != nil {
+		return nil, fmt.Errorf("exchange authorization code: %w", err)
+	}
+
+	return tokens, nil
+}
+
+func generateRandomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func generatePKCE() (verifier, challenge string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(b)
+	h := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(h[:])
+	return
+}
+
+func buildAuthURL(authorizeURL, clientID, redirectURI, state, codeChallenge string) string {
+	params := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"state":                 {state},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+	return authorizeURL + "?" + params.Encode()
+}
+
+func callbackHandler(expectedState string, resultCh chan<- authCodeResult) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/callback" {
+			http.NotFound(w, r)
+			return
+		}
+
+		q := r.URL.Query()
+
+		if errParam := q.Get("error"); errParam != "" {
+			desc := q.Get("error_description")
+			if desc == "" {
+				desc = errParam
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprintf(w, callbackHTMLError, desc)
+			resultCh <- authCodeResult{err: errors.New(desc)}
+			return
+		}
+
+		gotState := q.Get("state")
+		if gotState != expectedState {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, callbackHTMLError, "invalid state parameter")
+			resultCh <- authCodeResult{err: errors.New("state mismatch: possible CSRF")}
+			return
+		}
+
+		code := q.Get("code")
+		if code == "" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, callbackHTMLError, "missing authorization code")
+			resultCh <- authCodeResult{err: errors.New("missing authorization code in callback")}
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, callbackHTML)
+		resultCh <- authCodeResult{code: code, state: gotState}
+	})
+}
+
+func exchangeCodeForToken(tokenURL, clientID, clientSecret, code, redirectURI, codeVerifier string) (string, error) {
+	tokens, err := exchangeCodeForTokens(tokenURL, clientID, clientSecret, code, redirectURI, codeVerifier)
+	if err != nil {
+		return "", err
+	}
+	return tokens.AccessToken, nil
+}
+
+func exchangeCodeForTokens(tokenURL, clientID, clientSecret, code, redirectURI, codeVerifier string) (*tokenResult, error) {
+	params := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {codeVerifier},
+	}
+	if clientSecret != "" {
+		params.Set("client_secret", clientSecret)
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.PostForm(tokenURL, params)
+	if err != nil {
+		return nil, fmt.Errorf("POST to token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, tokenEndpointError(resp.StatusCode, body)
+	}
+
+	return parseTokensResponse(body)
+}
+
+func tokenEndpointError(statusCode int, body []byte) error {
+	var errResp struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil {
+		if errResp.ErrorDescription != "" {
+			return fmt.Errorf("token endpoint: %s", errResp.ErrorDescription)
+		}
+		if errResp.Error != "" {
+			return fmt.Errorf("token endpoint: %s", errResp.Error)
+		}
+	}
+	return fmt.Errorf("token endpoint returned HTTP %d", statusCode)
+}
+
+func parseTokenResponse(body []byte) (string, error) {
+	tokens, err := parseTokensResponse(body)
+	if err != nil {
+		return "", err
+	}
+	return tokens.AccessToken, nil
+}
+
+func parseTokensResponse(body []byte) (*tokenResult, error) {
+	var resp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse token response: %w", err)
+	}
+	if resp.AccessToken == "" {
+		return nil, errors.New("no access_token in token response")
+	}
+	return &tokenResult{
+		AccessToken:  resp.AccessToken,
+		RefreshToken: resp.RefreshToken,
+	}, nil
+}
+
+func openBrowser(target string) error {
+	var cmd string
+	var cmdArgs []string
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+		cmdArgs = []string{target}
+	case "windows":
+		cmd = "rundll32"
+		cmdArgs = []string{"url.dll,FileProtocolHandler", target}
+	default:
+		cmd = "xdg-open"
+		cmdArgs = []string{target}
+	}
+
+	return exec.Command(cmd, cmdArgs...).Start()
+}

--- a/components/ambient-cli/cmd/acpctl/login/authcode_test.go
+++ b/components/ambient-cli/cmd/acpctl/login/authcode_test.go
@@ -1,0 +1,391 @@
+package login
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestGeneratePKCE_LengthAndUniqueness(t *testing.T) {
+	v1, c1, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE: %v", err)
+	}
+	if v1 == "" || c1 == "" {
+		t.Fatal("expected non-empty verifier and challenge")
+	}
+
+	v2, c2, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE second call: %v", err)
+	}
+	if v1 == v2 {
+		t.Error("expected unique verifiers across calls")
+	}
+	if c1 == c2 {
+		t.Error("expected unique challenges across calls")
+	}
+}
+
+func TestGeneratePKCE_ValidBase64URL(t *testing.T) {
+	verifier, challenge, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE: %v", err)
+	}
+
+	if len(verifier) < 40 {
+		t.Errorf("verifier too short: %d chars", len(verifier))
+	}
+	if len(challenge) < 40 {
+		t.Errorf("challenge too short: %d chars", len(challenge))
+	}
+
+	const base64URLChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	for _, c := range verifier + challenge {
+		if !strings.ContainsRune(base64URLChars, c) {
+			t.Errorf("unexpected character in PKCE output: %q", c)
+		}
+	}
+}
+
+func TestGenerateRandomState_Uniqueness(t *testing.T) {
+	s1, err := generateRandomState()
+	if err != nil {
+		t.Fatalf("generateRandomState: %v", err)
+	}
+	s2, err := generateRandomState()
+	if err != nil {
+		t.Fatalf("generateRandomState second call: %v", err)
+	}
+	if s1 == s2 {
+		t.Error("expected unique states across calls")
+	}
+	if len(s1) < 20 {
+		t.Errorf("state too short: %q", s1)
+	}
+}
+
+func TestBuildAuthURL_ContainsRequiredParams(t *testing.T) {
+	authURL := buildAuthURL(
+		"https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth",
+		"acpctl",
+		"http://127.0.0.1:12345/callback",
+		"test-state",
+		"test-challenge",
+	)
+
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+
+	q := parsed.Query()
+	checks := map[string]string{
+		"response_type":         "code",
+		"client_id":             "acpctl",
+		"redirect_uri":          "http://127.0.0.1:12345/callback",
+		"state":                 "test-state",
+		"code_challenge":        "test-challenge",
+		"code_challenge_method": "S256",
+	}
+	for param, want := range checks {
+		if got := q.Get(param); got != want {
+			t.Errorf("param %q: got %q, want %q", param, got, want)
+		}
+	}
+}
+
+func TestCallbackHandler_ValidCode(t *testing.T) {
+	resultCh := make(chan authCodeResult, 1)
+	handler := callbackHandler("expected-state", resultCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/callback?state=expected-state&code=authcode123", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	result := <-resultCh
+	if result.err != nil {
+		t.Errorf("unexpected error: %v", result.err)
+	}
+	if result.code != "authcode123" {
+		t.Errorf("expected code %q, got %q", "authcode123", result.code)
+	}
+}
+
+func TestCallbackHandler_StateMismatch(t *testing.T) {
+	resultCh := make(chan authCodeResult, 1)
+	handler := callbackHandler("expected-state", resultCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/callback?state=wrong-state&code=authcode123", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+
+	result := <-resultCh
+	if result.err == nil {
+		t.Fatal("expected error for state mismatch")
+	}
+	if !strings.Contains(result.err.Error(), "CSRF") {
+		t.Errorf("expected CSRF mention in error, got: %v", result.err)
+	}
+}
+
+func TestCallbackHandler_OAuthError(t *testing.T) {
+	resultCh := make(chan authCodeResult, 1)
+	handler := callbackHandler("expected-state", resultCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/callback?error=access_denied&error_description=User+denied+access", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	result := <-resultCh
+	if result.err == nil {
+		t.Fatal("expected error for OAuth error response")
+	}
+	if !strings.Contains(result.err.Error(), "User denied access") {
+		t.Errorf("expected error description in error, got: %v", result.err)
+	}
+}
+
+func TestCallbackHandler_MissingCode(t *testing.T) {
+	resultCh := make(chan authCodeResult, 1)
+	handler := callbackHandler("expected-state", resultCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/callback?state=expected-state", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+
+	result := <-resultCh
+	if result.err == nil {
+		t.Fatal("expected error for missing code")
+	}
+}
+
+func TestCallbackHandler_WrongPath(t *testing.T) {
+	resultCh := make(chan authCodeResult, 1)
+	handler := callbackHandler("expected-state", resultCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/other", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for wrong path, got %d", w.Code)
+	}
+	if len(resultCh) != 0 {
+		t.Error("expected no result sent for wrong path")
+	}
+}
+
+func TestParseTokenResponse_JSON(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{
+		"access_token": "my-access-token",
+		"token_type":   "Bearer",
+	})
+
+	token, err := parseTokenResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "my-access-token" {
+		t.Errorf("expected %q, got %q", "my-access-token", token)
+	}
+}
+
+func TestParseTokenResponse_MissingAccessToken(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"token_type": "Bearer"})
+
+	_, err := parseTokenResponse(body)
+	if err == nil {
+		t.Fatal("expected error for missing access_token")
+	}
+}
+
+func TestParseTokenResponse_InvalidJSON(t *testing.T) {
+	_, err := parseTokenResponse([]byte("not json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestTokenEndpointError_WithDescription(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{
+		"error":             "invalid_client",
+		"error_description": "Client authentication failed",
+	})
+
+	err := tokenEndpointError(http.StatusUnauthorized, body)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Client authentication failed") {
+		t.Errorf("expected description in error, got: %v", err)
+	}
+}
+
+func TestTokenEndpointError_ErrorOnly(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"error": "invalid_grant"})
+
+	err := tokenEndpointError(http.StatusBadRequest, body)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("expected error code in message, got: %v", err)
+	}
+}
+
+func TestTokenEndpointError_NonJSON(t *testing.T) {
+	err := tokenEndpointError(http.StatusServiceUnavailable, []byte("Service Unavailable"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected HTTP status in fallback error, got: %v", err)
+	}
+}
+
+func TestExchangeCodeForToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if r.FormValue("grant_type") != "authorization_code" {
+			t.Errorf("expected grant_type=authorization_code, got %q", r.FormValue("grant_type"))
+		}
+		if r.FormValue("code") != "mycode" {
+			t.Errorf("expected code=mycode, got %q", r.FormValue("code"))
+		}
+		if r.FormValue("code_verifier") != "myverifier" {
+			t.Errorf("expected code_verifier=myverifier, got %q", r.FormValue("code_verifier"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"returned-token","token_type":"Bearer"}`)
+	}))
+	defer srv.Close()
+
+	token, err := exchangeCodeForToken(srv.URL, "client-id", "", "mycode", "http://127.0.0.1:9/callback", "myverifier")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "returned-token" {
+		t.Errorf("expected %q, got %q", "returned-token", token)
+	}
+}
+
+func TestExchangeCodeForToken_ErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"invalid_client","error_description":"Bad credentials"}`)
+	}))
+	defer srv.Close()
+
+	_, err := exchangeCodeForToken(srv.URL, "bad-client", "", "code", "http://127.0.0.1:9/callback", "verifier")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "Bad credentials") {
+		t.Errorf("expected error description in error, got: %v", err)
+	}
+}
+
+func TestParseTokensResponse_WithRefreshToken(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{
+		"access_token":  "my-access-token",
+		"refresh_token": "my-refresh-token",
+		"token_type":    "Bearer",
+	})
+
+	result, err := parseTokensResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.AccessToken != "my-access-token" {
+		t.Errorf("expected %q, got %q", "my-access-token", result.AccessToken)
+	}
+	if result.RefreshToken != "my-refresh-token" {
+		t.Errorf("expected %q, got %q", "my-refresh-token", result.RefreshToken)
+	}
+}
+
+func TestParseTokensResponse_NoRefreshToken(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{
+		"access_token": "my-access-token",
+		"token_type":   "Bearer",
+	})
+
+	result, err := parseTokensResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.AccessToken != "my-access-token" {
+		t.Errorf("expected %q, got %q", "my-access-token", result.AccessToken)
+	}
+	if result.RefreshToken != "" {
+		t.Errorf("expected empty refresh token, got %q", result.RefreshToken)
+	}
+}
+
+func TestParseTokensResponse_MissingAccessToken(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"refresh_token": "refresh-only"})
+
+	_, err := parseTokensResponse(body)
+	if err == nil {
+		t.Fatal("expected error for missing access_token")
+	}
+}
+
+func TestExchangeCodeForTokens_ReturnsRefresh(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"access-123","refresh_token":"refresh-456","token_type":"Bearer"}`)
+	}))
+	defer srv.Close()
+
+	result, err := exchangeCodeForTokens(srv.URL, "client-id", "", "mycode", "http://127.0.0.1:9/callback", "myverifier")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.AccessToken != "access-123" {
+		t.Errorf("expected %q, got %q", "access-123", result.AccessToken)
+	}
+	if result.RefreshToken != "refresh-456" {
+		t.Errorf("expected %q, got %q", "refresh-456", result.RefreshToken)
+	}
+}
+
+func TestCallbackHandler_OAuthErrorFallsBackToErrorCode(t *testing.T) {
+	resultCh := make(chan authCodeResult, 1)
+	handler := callbackHandler("state", resultCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/callback?error=access_denied", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	result := <-resultCh
+	if result.err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(result.err.Error(), "access_denied") {
+		t.Errorf("expected error code as fallback, got: %v", result.err)
+	}
+}

--- a/components/ambient-cli/cmd/acpctl/login/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/login/cmd.go
@@ -15,35 +15,50 @@ var args struct {
 	url                string
 	project            string
 	insecureSkipVerify bool
+	useAuthCode        bool
+	issuerURL          string
+	clientID           string
+	clientSecret       string
 }
 
 var Cmd = &cobra.Command{
 	Use:   "login [SERVER_URL]",
 	Short: "Log in to the Ambient API server",
-	Long:  "Log in to the Ambient API server by providing an access token. The token is saved to the configuration file for subsequent commands.",
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  run,
+	Long: `Log in to the Ambient API server by providing an access token or using
+the browser-based OAuth2 authorization code flow against Red Hat SSO.
+
+To log in with a static token:
+  acpctl login --token <token> --url https://api.example.com
+
+To log in via browser (OAuth2 authorization code + PKCE via Red Hat SSO):
+  acpctl login --use-auth-code --url https://api.example.com`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: run,
 }
 
 func init() {
 	flags := Cmd.Flags()
-	flags.StringVar(&args.token, "token", "", "Access token (required)")
+	flags.StringVar(&args.token, "token", "", "Access token (mutually exclusive with --use-auth-code)")
 	flags.StringVar(&args.url, "url", "", "API server URL (default: http://localhost:8000)")
 	flags.StringVar(&args.project, "project", "", "Default project name")
 	flags.BoolVar(&args.insecureSkipVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification (insecure)")
+	flags.BoolVar(&args.useAuthCode, "use-auth-code", false, "Log in via browser using OAuth2 authorization code flow (Red Hat SSO)")
+	flags.StringVar(&args.issuerURL, "issuer-url", defaultIssuerURL, "OIDC issuer URL (used with --use-auth-code)")
+	flags.StringVar(&args.clientID, "client-id", defaultClientID, "OAuth2 client ID (used with --use-auth-code)")
+	flags.StringVar(&args.clientSecret, "client-secret", "", "OAuth2 client secret (used with --use-auth-code for confidential clients; never persisted to config)")
 }
 
 func run(cmd *cobra.Command, positional []string) error {
-	if args.token == "" {
-		return fmt.Errorf("--token is required")
+	if args.useAuthCode && args.token != "" {
+		return fmt.Errorf("--use-auth-code and --token are mutually exclusive")
 	}
-
+	if !args.useAuthCode && args.token == "" {
+		return fmt.Errorf("one of --token or --use-auth-code is required")
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-
-	cfg.AccessToken = args.token
 
 	serverURL := args.url
 	if len(positional) > 0 {
@@ -66,6 +81,26 @@ func run(cmd *cobra.Command, positional []string) error {
 		cfg.InsecureTLSVerify = true
 	}
 
+	var accessToken string
+
+	if args.useAuthCode {
+		tokens, err := runAuthCodeFlow(args.issuerURL, args.clientID, args.clientSecret)
+		if err != nil {
+			return fmt.Errorf("auth-code login: %w", err)
+		}
+		accessToken = tokens.AccessToken
+		cfg.RefreshToken = tokens.RefreshToken
+		cfg.IssuerURL = args.issuerURL
+		cfg.ClientID = args.clientID
+	} else {
+		accessToken = args.token
+		cfg.RefreshToken = ""
+		cfg.IssuerURL = ""
+		cfg.ClientID = ""
+	}
+
+	cfg.AccessToken = accessToken
+
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)
 	}
@@ -81,7 +116,7 @@ func run(cmd *cobra.Command, positional []string) error {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: TLS certificate verification is disabled (--insecure-skip-tls-verify)")
 	}
 
-	if exp, err := config.TokenExpiry(args.token); err == nil && !exp.IsZero() {
+	if exp, err := config.TokenExpiry(accessToken); err == nil && !exp.IsZero() {
 		if time.Until(exp) < 0 {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: token is already expired (at %s)\n", exp.Format(time.RFC3339))
 		} else if time.Until(exp) < 24*time.Hour {

--- a/components/ambient-cli/cmd/acpctl/main.go
+++ b/components/ambient-cli/cmd/acpctl/main.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/agent"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/ambient"
+	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/apply"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/completion"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/config"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/create"
+	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/credential"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/delete"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/describe"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/get"
+	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/inbox"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/login"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/logout"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/project"
@@ -52,6 +55,8 @@ func init() {
 	root.AddCommand(project.Cmd)
 	root.AddCommand(session.Cmd)
 	root.AddCommand(agent.Cmd)
+	root.AddCommand(credential.Cmd)
+	root.AddCommand(inbox.Cmd)
 	root.AddCommand(get.Cmd)
 	root.AddCommand(create.Cmd)
 	root.AddCommand(delete.Cmd)
@@ -60,6 +65,7 @@ func init() {
 	root.AddCommand(stop.Cmd)
 	root.AddCommand(completion.Cmd)
 	root.AddCommand(ambient.Cmd)
+	root.AddCommand(apply.Cmd)
 }
 
 func main() {

--- a/components/ambient-cli/cmd/acpctl/project/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/project/cmd.go
@@ -16,6 +16,62 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var projectUpdateArgs struct {
+	name        string
+	description string
+	prompt      string
+	labels      string
+	annotations string
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update <name-or-id>",
+	Short: "Update a project",
+	Args:  cobra.ExactArgs(1),
+	Example: `  acpctl project update my-project --description "New description"
+  acpctl project update my-project --prompt "Workspace context"
+  acpctl project update my-project --name new-name`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := connection.NewClientFromConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+		defer cancel()
+
+		patch := sdktypes.NewProjectPatchBuilder()
+		if cmd.Flags().Changed("name") {
+			patch = patch.Name(projectUpdateArgs.name)
+		}
+		if cmd.Flags().Changed("description") {
+			patch = patch.Description(projectUpdateArgs.description)
+		}
+		if cmd.Flags().Changed("prompt") {
+			patch = patch.Prompt(projectUpdateArgs.prompt)
+		}
+		if cmd.Flags().Changed("labels") {
+			patch = patch.Labels(projectUpdateArgs.labels)
+		}
+		if cmd.Flags().Changed("annotations") {
+			patch = patch.Annotations(projectUpdateArgs.annotations)
+		}
+
+		updated, err := client.Projects().Update(ctx, args[0], patch.Build())
+		if err != nil {
+			return fmt.Errorf("update project: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "project/%s updated\n", updated.Name)
+		return nil
+	},
+}
+
 var dnsLabelPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 var Cmd = &cobra.Command{
@@ -62,6 +118,13 @@ func init() {
 	Cmd.AddCommand(setCmd)
 	Cmd.AddCommand(currentCmd)
 	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(updateCmd)
+
+	updateCmd.Flags().StringVar(&projectUpdateArgs.name, "name", "", "New project name")
+	updateCmd.Flags().StringVar(&projectUpdateArgs.description, "description", "", "New description")
+	updateCmd.Flags().StringVar(&projectUpdateArgs.prompt, "prompt", "", "New workspace context prompt")
+	updateCmd.Flags().StringVar(&projectUpdateArgs.labels, "labels", "", "New labels (JSON string)")
+	updateCmd.Flags().StringVar(&projectUpdateArgs.annotations, "annotations", "", "New annotations (JSON string)")
 }
 
 func projectMain(cmd *cobra.Command, args []string) error {

--- a/components/ambient-cli/cmd/acpctl/session/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/session/cmd.go
@@ -12,9 +12,11 @@ var Cmd = &cobra.Command{
 
 Examples:
   acpctl session messages <id>               # list messages (snapshot)
-  acpctl session messages <id> -f            # stream messages live
-  acpctl session send <id> "Hello!"          # send a message (any event_type)
-  acpctl session send <id> "Hello!"          # send a message`,
+  acpctl session messages <id> -f            # live SSE stream (ends at turn end)
+  acpctl session messages <id> -F            # continuous follow (Ctrl+C to stop)
+  acpctl session send <id> "Hello!"          # send a message
+  acpctl session send <id> "Hello!" -f       # send and stream until done
+  acpctl session events <id>                 # raw AG-UI event stream`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},
@@ -23,4 +25,5 @@ Examples:
 func init() {
 	Cmd.AddCommand(messagesCmd)
 	Cmd.AddCommand(sendCmd)
+	Cmd.AddCommand(eventsCmd)
 }

--- a/components/ambient-cli/cmd/acpctl/session/events.go
+++ b/components/ambient-cli/cmd/acpctl/session/events.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
+	"github.com/spf13/cobra"
+)
+
+var eventsCmd = &cobra.Command{
+	Use:   "events <session-id>",
+	Short: "Stream live AG-UI events from a running session",
+	Long: `Stream live AG-UI events from a running session.
+
+Events are proxied from the runner pod in real time via SSE.
+Only available while the session is actively running.
+
+Examples:
+  acpctl session events <id>   # stream events (Ctrl+C to stop)`,
+	Args: cobra.ExactArgs(1),
+	RunE: runEvents,
+}
+
+func runEvents(cmd *cobra.Command, args []string) error {
+	sessionID := args[0]
+
+	client, err := connection.NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer cancel()
+
+	stream, err := client.Sessions().StreamEvents(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("stream events: %w", err)
+	}
+	defer stream.Close()
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Streaming events for session %s (Ctrl+C to stop)...\n\n", sessionID)
+
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			fmt.Fprintln(cmd.OutOrStdout(), line[6:])
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return fmt.Errorf("stream error: %w", scanErr)
+	}
+	return nil
+}

--- a/components/ambient-cli/cmd/acpctl/session/messages.go
+++ b/components/ambient-cli/cmd/acpctl/session/messages.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,14 +16,15 @@ import (
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/output"
 	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
-	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
 	"github.com/spf13/cobra"
 )
 
 var msgArgs struct {
-	follow       bool
-	outputFormat string
-	afterSeq     int
+	follow           bool
+	followContinuous bool
+	followJSON       bool
+	outputFormat     string
+	afterSeq         int
 }
 
 var messagesCmd = &cobra.Command{
@@ -30,17 +32,28 @@ var messagesCmd = &cobra.Command{
 	Short: "List or stream messages for a session",
 	Long: `List or stream messages for a session.
 
+Without -f, fetches a snapshot of messages from the message store.
+With -f, connects to the live SSE event stream and renders events
+as readable text. The stream ends when the current turn finishes.
+With -F, continuously follows the stream, reconnecting after each
+turn ends. The stream stays open until Ctrl+C.
+With -f --json or -F --json, emits raw AG-UI JSON events instead of text.
+
 Examples:
-  acpctl session messages <id>           # snapshot
-  acpctl session messages <id> -f        # live stream (Ctrl+C to stop)
-  acpctl session messages <id> -o json   # JSON snapshot
-  acpctl session messages <id> --after 5 # messages after seq 5`,
+  acpctl session messages <id>              # snapshot
+  acpctl session messages <id> -f           # live stream (ends at turn end)
+  acpctl session messages <id> -F           # continuous follow (Ctrl+C to stop)
+  acpctl session messages <id> -F --json    # continuous raw AG-UI JSON events
+  acpctl session messages <id> -o json      # JSON snapshot
+  acpctl session messages <id> --after 5    # messages after seq 5`,
 	Args: cobra.ExactArgs(1),
 	RunE: runMessages,
 }
 
 func init() {
-	messagesCmd.Flags().BoolVarP(&msgArgs.follow, "follow", "f", false, "Stream messages live")
+	messagesCmd.Flags().BoolVarP(&msgArgs.follow, "follow", "f", false, "Stream live SSE events until the current turn ends")
+	messagesCmd.Flags().BoolVarP(&msgArgs.followContinuous, "follow-continuous", "F", false, "Continuously follow SSE events, reconnecting between turns (Ctrl+C to stop)")
+	messagesCmd.Flags().BoolVar(&msgArgs.followJSON, "json", false, "with -f/-F: emit raw AG-UI JSON events instead of text")
 	messagesCmd.Flags().StringVarP(&msgArgs.outputFormat, "output", "o", "", "Output format: json")
 	messagesCmd.Flags().IntVar(&msgArgs.afterSeq, "after", 0, "Only show messages after this sequence number")
 }
@@ -53,6 +66,9 @@ func runMessages(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if msgArgs.followContinuous {
+		return streamMessagesContinuous(cmd, client, sessionID)
+	}
 	if msgArgs.follow {
 		return streamMessages(cmd, client, sessionID)
 	}
@@ -88,22 +104,53 @@ func extractField(payload, field string) string {
 	return ""
 }
 
+func extractAGUIText(payload string) string {
+	var envelope struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content any    `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal([]byte(payload), &envelope); err != nil || len(envelope.Messages) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, msg := range envelope.Messages {
+		switch v := msg.Content.(type) {
+		case string:
+			if t := strings.TrimSpace(v); t != "" {
+				parts = append(parts, fmt.Sprintf("[%s] %s", msg.Role, t))
+			}
+		case []any:
+			for _, item := range v {
+				if block, ok := item.(map[string]any); ok {
+					if text, ok := block["text"].(string); ok {
+						if t := strings.TrimSpace(text); t != "" {
+							parts = append(parts, fmt.Sprintf("[%s] %s", msg.Role, t))
+						}
+					}
+				}
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 func displayPayload(eventType, payload string) string {
 	switch eventType {
-	case "user":
+	case "user", "assistant":
+		if text := extractAGUIText(payload); text != "" {
+			return text
+		}
 		return payload
 	case "TEXT_MESSAGE_CONTENT", "REASONING_MESSAGE_CONTENT", "TOOL_CALL_ARGS":
 		if d := extractField(payload, "delta"); d != "" {
 			return d
 		}
 	case "TOOL_CALL_START":
-		if name := extractField(payload, "tool_call_name"); name != "" {
-			return name
-		}
+		return displayToolCallStart(payload)
 	case "TOOL_CALL_RESULT":
-		if c := extractField(payload, "content"); c != "" {
-			return c
-		}
+		return displayToolCallResult(payload)
 	case "RUN_FINISHED":
 		return displayRunFinished(payload)
 	case "MESSAGES_SNAPSHOT":
@@ -114,6 +161,76 @@ func displayPayload(eventType, payload string) string {
 		}
 	}
 	return ""
+}
+
+func displayToolCallStart(payload string) string {
+	var raw string
+	if err := json.Unmarshal([]byte(payload), &raw); err == nil {
+		payload = raw
+	}
+	var data struct {
+		ToolCallName string          `json:"tool_call_name"`
+		ToolCallID   string          `json:"tool_call_id"`
+		Input        json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(payload), &data); err != nil || data.ToolCallName == "" {
+		if name := extractField(payload, "tool_call_name"); name != "" {
+			return name
+		}
+		return ""
+	}
+	if len(data.Input) == 0 || string(data.Input) == "null" || string(data.Input) == "{}" {
+		return data.ToolCallName
+	}
+	var pretty map[string]any
+	if err := json.Unmarshal(data.Input, &pretty); err != nil {
+		return data.ToolCallName
+	}
+	var parts []string
+	for k, v := range pretty {
+		s := fmt.Sprintf("%v", v)
+		if len(s) > 60 {
+			s = s[:57] + "..."
+		}
+		parts = append(parts, k+"="+s)
+	}
+	return data.ToolCallName + "  " + strings.Join(parts, "  ")
+}
+
+func displayToolCallResult(payload string) string {
+	var raw string
+	if err := json.Unmarshal([]byte(payload), &raw); err == nil {
+		payload = raw
+	}
+	var data struct {
+		ToolCallID string          `json:"tool_call_id"`
+		Content    json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(payload), &data); err != nil || len(data.Content) == 0 {
+		if c := extractField(payload, "content"); c != "" {
+			return c
+		}
+		return ""
+	}
+	var contentStr string
+	if err := json.Unmarshal(data.Content, &contentStr); err == nil {
+		return strings.TrimSpace(contentStr)
+	}
+	var contentArr []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(data.Content, &contentArr); err == nil {
+		var parts []string
+		for _, c := range contentArr {
+			if c.Text != "" {
+				parts = append(parts, strings.TrimSpace(c.Text))
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	b, _ := json.MarshalIndent(json.RawMessage(data.Content), "", "  ")
+	return string(b)
 }
 
 func displayRunFinished(payload string) string {
@@ -148,24 +265,92 @@ func displayMessagesSnapshot(payload string) string {
 	if err := json.Unmarshal([]byte(payload), &raw); err == nil {
 		payload = raw
 	}
+
 	var msgs []struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
 	}
 	if err := json.Unmarshal([]byte(payload), &msgs); err != nil {
 		return fmt.Sprintf("(%d bytes)", len(payload))
 	}
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == "assistant" && msgs[i].Content != "" {
-			return msgs[i].Content
+
+	var lines []string
+	for _, msg := range msgs {
+		if msg.Role == "user" || len(msg.Content) == 0 {
+			continue
+		}
+		var contentStr string
+		if err := json.Unmarshal(msg.Content, &contentStr); err == nil {
+			if t := strings.TrimSpace(contentStr); t != "" {
+				lines = append(lines, fmt.Sprintf("[%s] %s", msg.Role, t))
+			}
+			continue
+		}
+		var blocks []struct {
+			Type    string          `json:"type"`
+			Text    string          `json:"text"`
+			Name    string          `json:"name"`
+			ID      string          `json:"id"`
+			Input   json.RawMessage `json:"input"`
+			Content json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(msg.Content, &blocks); err != nil {
+			continue
+		}
+		for _, b := range blocks {
+			switch b.Type {
+			case "text":
+				if t := strings.TrimSpace(b.Text); t != "" {
+					lines = append(lines, fmt.Sprintf("[%s] %s", msg.Role, t))
+				}
+			case "tool_use":
+				var inputMap map[string]any
+				inputSummary := ""
+				if len(b.Input) > 0 && json.Unmarshal(b.Input, &inputMap) == nil {
+					var kv []string
+					for k, v := range inputMap {
+						s := fmt.Sprintf("%v", v)
+						if len(s) > 60 {
+							s = s[:57] + "..."
+						}
+						kv = append(kv, k+"="+s)
+					}
+					inputSummary = "  " + strings.Join(kv, "  ")
+				}
+				lines = append(lines, fmt.Sprintf("[tool_use] %s%s", b.Name, inputSummary))
+			case "tool_result":
+				var resultText string
+				if len(b.Content) > 0 {
+					var s string
+					if json.Unmarshal(b.Content, &s) == nil {
+						resultText = strings.TrimSpace(s)
+					} else {
+						var arr []struct {
+							Type string `json:"type"`
+							Text string `json:"text"`
+						}
+						if json.Unmarshal(b.Content, &arr) == nil {
+							var parts []string
+							for _, c := range arr {
+								if t := strings.TrimSpace(c.Text); t != "" {
+									parts = append(parts, t)
+								}
+							}
+							resultText = strings.Join(parts, " | ")
+						}
+					}
+				}
+				if len(resultText) > 200 {
+					resultText = resultText[:197] + "..."
+				}
+				lines = append(lines, fmt.Sprintf("[tool_result] %s", resultText))
+			}
 		}
 	}
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Content != "" {
-			return fmt.Sprintf("[%s] %s", msgs[i].Role, msgs[i].Content)
-		}
+	if len(lines) == 0 {
+		return fmt.Sprintf("(%d messages, no displayable content)", len(msgs))
 	}
-	return fmt.Sprintf("(%d messages, no text content)", len(msgs))
+	return strings.Join(lines, "\n")
 }
 
 func listMessages(ctx context.Context, client *sdkclient.Client, printer *output.Printer, sessionID string) error {
@@ -228,40 +413,146 @@ func streamMessages(cmd *cobra.Command, client *sdkclient.Client, sessionID stri
 	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
 	defer cancel()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Streaming messages for session %s (Ctrl+C to stop)...\n\n", sessionID)
-
-	msgs, stop, err := client.Sessions().WatchMessages(ctx, sessionID, msgArgs.afterSeq)
+	stream, err := client.Sessions().StreamEvents(ctx, sessionID)
 	if err != nil {
-		return fmt.Errorf("watch messages: %w", err)
+		return fmt.Errorf("stream events: %w", err)
 	}
-	defer stop()
+	defer stream.Close()
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Streaming events for session %s (Ctrl+C to stop)...\n\n", sessionID)
+
+	return renderSSEStream(stream, cmd.OutOrStdout(), msgArgs.followJSON, false)
+}
+
+func streamMessagesContinuous(cmd *cobra.Command, client *sdkclient.Client, sessionID string) error {
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer cancel()
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Continuously following session %s (Ctrl+C to stop)...\n\n", sessionID)
+
+	const reconnectDelay = 3 * time.Second
 
 	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case msg, ok := <-msgs:
-			if !ok {
+		stream, err := client.Sessions().StreamEvents(ctx, sessionID)
+		if err != nil {
+			if ctx.Err() != nil {
 				return nil
 			}
-			printStreamLine(cmd, *msg)
+			fmt.Fprintf(out, "[reconnect] stream not available: %v — retrying in %s\n", err, reconnectDelay)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(reconnectDelay):
+				continue
+			}
+		}
+
+		streamErr := renderSSEStream(stream, out, msgArgs.followJSON, false)
+		stream.Close()
+
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		if streamErr != nil {
+			fmt.Fprintf(out, "\n[reconnect] stream ended: %v — reconnecting in %s\n", streamErr, reconnectDelay)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(reconnectDelay):
+			}
+		} else {
+			fmt.Fprintf(out, "\n[reconnect] stream ended cleanly — reconnecting immediately\n")
 		}
 	}
 }
 
-func printStreamLine(cmd *cobra.Command, msg sdktypes.SessionMessage) {
-	display := displayPayload(msg.EventType, msg.Payload)
-	if display == "" {
-		return
+func renderSSEStream(stream io.Reader, out io.Writer, jsonMode, exitOnRunFinished bool) error {
+	scanner := bufio.NewScanner(stream)
+	var reasoningBuf strings.Builder
+	var inText bool
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := line[6:]
+
+		if jsonMode {
+			fmt.Fprintln(out, data)
+			continue
+		}
+
+		var evt struct {
+			Type         string `json:"type"`
+			Delta        string `json:"delta"`
+			ToolCallName string `json:"toolCallName"`
+			Content      string `json:"content"`
+		}
+		if err := json.Unmarshal([]byte(data), &evt); err != nil {
+			continue
+		}
+		switch evt.Type {
+		case "REASONING_MESSAGE_CONTENT":
+			reasoningBuf.WriteString(evt.Delta)
+		case "REASONING_END":
+			if reasoningBuf.Len() > 0 {
+				fmt.Fprintf(out, "[thinking] %s\n", strings.TrimSpace(reasoningBuf.String()))
+				reasoningBuf.Reset()
+			}
+		case "TEXT_MESSAGE_CONTENT":
+			if evt.Delta != "" {
+				inText = true
+				fmt.Fprint(out, evt.Delta)
+			}
+		case "TEXT_MESSAGE_END":
+			if inText {
+				fmt.Fprintln(out)
+				inText = false
+			}
+		case "TOOL_CALL_START":
+			if evt.ToolCallName != "" {
+				fmt.Fprintf(out, "[%s] ", evt.ToolCallName)
+			}
+		case "TOOL_CALL_RESULT":
+			if evt.Content != "" {
+				var content string
+				if err := json.Unmarshal([]byte(evt.Content), &content); err != nil {
+					content = evt.Content
+				}
+				lines := strings.SplitN(strings.TrimSpace(content), "\n", 4)
+				preview := strings.Join(lines, " | ")
+				if len(lines) >= 4 {
+					preview += " ..."
+				}
+				fmt.Fprintf(out, "→ %s\n", preview)
+			}
+		case "RUN_FINISHED":
+			if inText {
+				fmt.Fprintln(out)
+				inText = false
+			}
+			if exitOnRunFinished {
+				return nil
+			}
+		case "RUN_ERROR":
+			if inText {
+				fmt.Fprintln(out)
+				inText = false
+			}
+			if exitOnRunFinished {
+				return fmt.Errorf("run failed")
+			}
+		}
 	}
-	w := cmd.OutOrStdout()
-	ts := msg.CreatedAt.Format("15:04:05")
-	width := output.TerminalWidthFor(w)
-	if width < 40 {
-		width = 80
+
+	if inText {
+		fmt.Fprintln(out)
 	}
-	header := fmt.Sprintf("[%s] #%-4d  %s", ts, msg.Seq, msg.EventType)
-	fmt.Fprintln(w, header)
-	printWrapped(w, display, width, "             ")
-	fmt.Fprintln(w)
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		return fmt.Errorf("stream error: %w", scanErr)
+	}
+	return nil
 }

--- a/components/ambient-cli/cmd/acpctl/session/send.go
+++ b/components/ambient-cli/cmd/acpctl/session/send.go
@@ -3,22 +3,37 @@ package session
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
 
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
 	"github.com/spf13/cobra"
 )
 
+var sendFollow bool
+var sendFollowJSON bool
+
 var sendCmd = &cobra.Command{
 	Use:   "send <session-id> <message>",
 	Short: "Send a message to a session",
 	Long: `Send a message to a session.
 
+Without -f, prints the message sequence number and returns immediately.
+With -f, streams the assistant response as readable text until RUN_FINISHED.
+With -f --json, streams raw AG-UI JSON events instead of assembled text.
+
 Examples:
   acpctl session send <id> "Hello! What's today's date?"
-  acpctl session send <id> "Run the tests"`,
+  acpctl session send <id> "Run the tests" -f
+  acpctl session send <id> "Run the tests" -f --json`,
 	Args: cobra.ExactArgs(2),
 	RunE: runSend,
+}
+
+func init() {
+	sendCmd.Flags().BoolVarP(&sendFollow, "follow", "f", false, "stream response after sending until RUN_FINISHED")
+	sendCmd.Flags().BoolVar(&sendFollowJSON, "json", false, "with -f: emit raw AG-UI JSON events instead of text")
 }
 
 func runSend(cmd *cobra.Command, args []string) error {
@@ -44,5 +59,24 @@ func runSend(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "sent (seq=%d)\n", msg.Seq)
-	return nil
+
+	if !sendFollow {
+		return nil
+	}
+
+	// NOTE: We intentionally open the SSE stream AFTER sending the message.
+	// The api-server SSE proxy does not return HTTP 200 until the runner has
+	// an active run, so subscribing first would deadlock. The event gap is
+	// negligible in practice because the runner takes time to start producing
+	// events after receiving the message.
+	streamCtx, streamCancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer streamCancel()
+
+	stream, err := client.Sessions().StreamEvents(streamCtx, sessionID)
+	if err != nil {
+		return fmt.Errorf("stream events: %w", err)
+	}
+	defer stream.Close()
+
+	return renderSSEStream(stream, cmd.OutOrStdout(), sendFollowJSON, true)
 }

--- a/components/ambient-cli/cmd/acpctl/start/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/start/cmd.go
@@ -1,4 +1,4 @@
-// Package start implements the start subcommand for launching agentic sessions.
+// Package start implements the start subcommand for starting a project-agent session.
 package start
 
 import (
@@ -10,15 +10,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var startArgs struct {
+	projectID string
+	prompt    string
+}
+
 var Cmd = &cobra.Command{
-	Use:   "start <session-id>",
-	Short: "Start an agentic session",
-	Args:  cobra.ExactArgs(1),
-	RunE:  run,
+	Use:   "start <project-agent-id>",
+	Short: "Start a session for a project-agent (idempotent)",
+	Long: `Start a session for a project-agent.
+
+If an active session already exists for this project-agent, it is returned.
+If not, a new session is created. Unread inbox messages are drained and
+injected into the start context.`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    run,
+	Example: "  acpctl start <pa-id> --project-id <project-id>\n  acpctl start <pa-id> --project-id <project-id> --prompt \"fix the RBAC middleware\"",
+}
+
+func init() {
+	Cmd.Flags().StringVar(&startArgs.projectID, "project-id", "", "Project ID (required)")
+	Cmd.Flags().StringVar(&startArgs.prompt, "prompt", "", "Task prompt for this session run")
 }
 
 func run(cmd *cobra.Command, cmdArgs []string) error {
-	sessionID := cmdArgs[0]
+	paID := cmdArgs[0]
+
+	if startArgs.projectID == "" {
+		return fmt.Errorf("--project-id is required")
+	}
 
 	client, err := connection.NewClientFromConfig()
 	if err != nil {
@@ -28,11 +48,15 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	session, err := client.Sessions().Start(ctx, sessionID)
+	resp, err := client.Agents().Start(ctx, startArgs.projectID, paID, startArgs.prompt)
 	if err != nil {
-		return fmt.Errorf("start session %q: %w", sessionID, err)
+		return fmt.Errorf("start agent %q: %w", paID, err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "session/%s started (phase: %s)\n", session.ID, session.Phase)
+	if resp.Session != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "session/%s started (phase: %s)\n", resp.Session.ID, resp.Session.Phase)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "project-agent/%s started\n", paID)
+	}
 	return nil
 }

--- a/components/ambient-cli/cmd/acpctl/start/cmd_test.go
+++ b/components/ambient-cli/cmd/acpctl/start/cmd_test.go
@@ -11,19 +11,21 @@ import (
 
 func TestStart_Success(t *testing.T) {
 	srv := testhelper.NewServer(t)
-	srv.Handle("/api/ambient/v1/sessions/s1/start", func(w http.ResponseWriter, r *http.Request) {
+	srv.Handle("/api/ambient/v1/projects/proj-1/agents/pa-1/start", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		srv.RespondJSON(t, w, http.StatusOK, &types.Session{
-			ObjectReference: types.ObjectReference{ID: "s1"},
-			Name:            "my-session",
-			Phase:           "running",
+		srv.RespondJSON(t, w, http.StatusCreated, &types.StartResponse{
+			Session: &types.Session{
+				ObjectReference: types.ObjectReference{ID: "s1"},
+				Name:            "my-session",
+				Phase:           "running",
+			},
 		})
 	})
 
 	testhelper.Configure(t, srv.URL)
-	result := testhelper.Run(t, Cmd, "s1")
+	result := testhelper.Run(t, Cmd, "pa-1", "--project-id", "proj-1")
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v\nstdout: %s\nstderr: %s", result.Err, result.Stdout, result.Stderr)
 	}
@@ -37,20 +39,20 @@ func TestStart_Success(t *testing.T) {
 
 func TestStart_NotFound(t *testing.T) {
 	srv := testhelper.NewServer(t)
-	srv.Handle("/api/ambient/v1/sessions/missing/start", func(w http.ResponseWriter, r *http.Request) {
+	srv.Handle("/api/ambient/v1/projects/proj-1/agents/missing/start", func(w http.ResponseWriter, r *http.Request) {
 		srv.RespondJSON(t, w, http.StatusNotFound, &types.APIError{
 			Code:   "not_found",
-			Reason: "session not found",
+			Reason: "project-agent not found",
 		})
 	})
 
 	testhelper.Configure(t, srv.URL)
-	result := testhelper.Run(t, Cmd, "missing")
+	result := testhelper.Run(t, Cmd, "missing", "--project-id", "proj-1")
 	if result.Err == nil {
-		t.Fatal("expected error for missing session")
+		t.Fatal("expected error for missing project-agent")
 	}
-	if !strings.Contains(result.Err.Error(), "start session") {
-		t.Errorf("expected 'start session' in error, got: %v", result.Err)
+	if !strings.Contains(result.Err.Error(), "start agent") {
+		t.Errorf("expected 'start agent' in error, got: %v", result.Err)
 	}
 }
 
@@ -59,21 +61,35 @@ func TestStart_RequiresArg(t *testing.T) {
 	testhelper.Configure(t, srv.URL)
 	result := testhelper.Run(t, Cmd)
 	if result.Err == nil {
-		t.Fatal("expected error for missing session ID argument")
+		t.Fatal("expected error for missing project-agent ID argument")
+	}
+}
+
+func TestStart_RequiresProjectID(t *testing.T) {
+	srv := testhelper.NewServer(t)
+	testhelper.Configure(t, srv.URL)
+	result := testhelper.Run(t, Cmd, "pa-1")
+	if result.Err == nil {
+		t.Fatal("expected error for missing --project-id")
+	}
+	if !strings.Contains(result.Err.Error(), "--project-id is required") {
+		t.Errorf("expected '--project-id is required', got: %v", result.Err)
 	}
 }
 
 func TestStart_OutputContainsID(t *testing.T) {
 	srv := testhelper.NewServer(t)
-	srv.Handle("/api/ambient/v1/sessions/abc-123/start", func(w http.ResponseWriter, r *http.Request) {
-		srv.RespondJSON(t, w, http.StatusOK, &types.Session{
-			ObjectReference: types.ObjectReference{ID: "abc-123"},
-			Phase:           "pending",
+	srv.Handle("/api/ambient/v1/projects/proj-1/agents/pa-abc/start", func(w http.ResponseWriter, r *http.Request) {
+		srv.RespondJSON(t, w, http.StatusCreated, &types.StartResponse{
+			Session: &types.Session{
+				ObjectReference: types.ObjectReference{ID: "abc-123"},
+				Phase:           "pending",
+			},
 		})
 	})
 
 	testhelper.Configure(t, srv.URL)
-	result := testhelper.Run(t, Cmd, "abc-123")
+	result := testhelper.Run(t, Cmd, "pa-abc", "--project-id", "proj-1")
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
 	}

--- a/components/ambient-cli/demo-github.sh
+++ b/components/ambient-cli/demo-github.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+# demo-github.sh — acpctl end-to-end demo: GitHub credential → interactive session
+#
+# What this demo does:
+#   1. Log in (reads from existing acpctl config, or prompts)
+#   2. Create a project
+#   3. Create an agent
+#   4. Create a credential (GitHub PAT — prompts for token path, defaults to env var)
+#   5. Bind the credential to the agent (credential:reader scope=agent)
+#   6. Start an interactive session with a prompt to open a GitHub issue as a test
+#   7. Stream session messages live until RUN_FINISHED
+#   8. Clean up
+#
+# Usage:
+#   ./demo-github.sh
+#   GITHUB_TOKEN_FILE=/path/to/token ./demo-github.sh
+#   GITHUB_REPO=org/repo ./demo-github.sh
+#   PAUSE=1 ./demo-github.sh     # pause between steps
+#
+# Optional env:
+#   GITHUB_TOKEN_FILE   — path to file containing GitHub PAT (default: prompted, falls back to $GITHUB_TOKEN)
+#   GITHUB_REPO         — org/repo to open test issue in (default: prompted)
+#   ACPCTL              — path to acpctl binary (default: acpctl from PATH)
+#   PAUSE               — seconds between demo steps (default: 0)
+#   SESSION_READY_TIMEOUT — seconds to wait for Running (default: 180)
+#   MESSAGE_WAIT_TIMEOUT  — seconds to wait for RUN_FINISHED (default: 300)
+
+set -euo pipefail
+
+ACPCTL="${ACPCTL:-acpctl}"
+PAUSE="${PAUSE:-0}"
+SESSION_READY_TIMEOUT="${SESSION_READY_TIMEOUT:-180}"
+MESSAGE_WAIT_TIMEOUT="${MESSAGE_WAIT_TIMEOUT:-300}"
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
+cyan()  { printf '\033[36m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow(){ printf '\033[33m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+sep()   { printf '\033[2m%s\033[0m\n' "──────────────────────────────────────────────────"; }
+
+step() {
+    local description="$1"
+    shift
+    echo
+    sep
+    bold "▶  $description"
+    printf '\033[38;5;214m   $ %s\033[0m\n' "$*"
+    sleep "$PAUSE"
+    "$@"
+    echo
+}
+
+announce() {
+    echo
+    sep
+    cyan "━━  $*"
+    sep
+    sleep "$PAUSE"
+}
+
+die() { red "error: $*" >&2; exit 1; }
+
+# ── preflight ──────────────────────────────────────────────────────────────────
+
+command -v "$ACPCTL" &>/dev/null || die "${ACPCTL} not found. Set ACPCTL=/path/to/acpctl or add to PATH."
+command -v python3   &>/dev/null || die "python3 not found."
+
+# ── intro ──────────────────────────────────────────────────────────────────────
+
+echo
+bold "Ambient CLI Demo — GitHub Credential"
+sep
+echo
+printf '  %s\n' "1. Create a project + agent"
+printf '  %s\n' "2. Create a GitHub credential (PAT)"
+printf '  %s\n' "3. Bind the credential to the agent"
+printf '  %s\n' "4. Start an interactive session"
+printf '  %s\n' "5. Agent opens a test GitHub issue to verify auth"
+echo
+printf '  \033[38;5;214m%-38s\033[0m %s\n' "Orange text like this" "= a terminal command being run"
+echo
+sep
+
+# ── gather inputs ──────────────────────────────────────────────────────────────
+
+announce "0 · Configuration"
+
+# GitHub PAT
+if [[ -n "${GITHUB_TOKEN_FILE:-}" ]]; then
+    dim "   Using GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE}"
+    GITHUB_PAT_PATH="${GITHUB_TOKEN_FILE}"
+else
+    DEFAULT_TOKEN_PATH="${GITHUB_TOKEN:-}"
+    printf '\033[1m   GitHub PAT file path\033[0m (leave blank to use \$GITHUB_TOKEN env var): '
+    read -r GITHUB_PAT_PATH
+    GITHUB_PAT_PATH="${GITHUB_PAT_PATH:-}"
+fi
+
+if [[ -n "${GITHUB_PAT_PATH}" && -f "${GITHUB_PAT_PATH}" ]]; then
+    GITHUB_TOKEN_VALUE="$(cat "${GITHUB_PAT_PATH}")"
+    dim "   Token read from file: ${GITHUB_PAT_PATH}"
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    GITHUB_TOKEN_VALUE="${GITHUB_TOKEN}"
+    dim "   Token read from \$GITHUB_TOKEN env var"
+else
+    die "No GitHub token found. Set GITHUB_TOKEN_FILE, pass a file path, or export GITHUB_TOKEN."
+fi
+
+[[ -z "${GITHUB_TOKEN_VALUE}" ]] && die "GitHub token is empty."
+
+# GitHub repo
+if [[ -n "${GITHUB_REPO:-}" ]]; then
+    dim "   Using GITHUB_REPO=${GITHUB_REPO}"
+else
+    printf '\033[1m   GitHub repo to open test issue in\033[0m (e.g. org/repo): '
+    read -r GITHUB_REPO
+    [[ -z "${GITHUB_REPO}" ]] && die "GITHUB_REPO is required."
+fi
+
+RUN_ID=$(date +%s | tail -c6)
+PROJECT_NAME="demo-github-${RUN_ID}"
+AGENT_NAME="github-agent"
+CRED_NAME="github-pat-demo-${RUN_ID}"
+
+echo
+dim "   Project:    ${PROJECT_NAME}"
+dim "   Agent:      ${AGENT_NAME}"
+dim "   Credential: ${CRED_NAME}"
+dim "   Repo:       ${GITHUB_REPO}"
+
+echo
+bold "   Press Enter to begin..."
+read -r
+
+# ── cleanup trap ───────────────────────────────────────────────────────────────
+
+CREATED_SESSION_ID=""
+CREATED_PROJECT=""
+CREATED_CREDENTIAL_ID=""
+
+cleanup() {
+    if [[ -n "${NO_CLEANUP:-}" ]]; then
+        echo
+        yellow "   NO_CLEANUP set — skipping cleanup"
+        dim    "   session:    ${CREATED_SESSION_ID}"
+        dim    "   credential: ${CREATED_CREDENTIAL_ID}"
+        dim    "   project:    ${CREATED_PROJECT}"
+        return
+    fi
+    echo
+    announce "Cleanup"
+    if [[ -n "${CREATED_SESSION_ID}" ]]; then
+        dim "   stopping session ${CREATED_SESSION_ID}..."
+        "$ACPCTL" stop "${CREATED_SESSION_ID}" 2>/dev/null || true
+        "$ACPCTL" delete session "${CREATED_SESSION_ID}" -y 2>/dev/null || true
+    fi
+    if [[ -n "${CREATED_CREDENTIAL_ID}" ]]; then
+        dim "   deleting credential ${CREATED_CREDENTIAL_ID}..."
+        "$ACPCTL" credential delete "${CREATED_CREDENTIAL_ID}" --confirm 2>/dev/null || true
+    fi
+    if [[ -n "${CREATED_PROJECT}" ]]; then
+        dim "   deleting project ${CREATED_PROJECT}..."
+        "$ACPCTL" delete project "${CREATED_PROJECT}" -y 2>/dev/null || true
+    fi
+    green "   cleanup done"
+}
+trap cleanup EXIT
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+json_field() {
+    local json="$1" field="$2"
+    echo "$json" | python3 -c "import sys,json; print(json.load(sys.stdin)['${field}'])" 2>/dev/null
+}
+
+wait_for_running() {
+    local session_id="$1"
+    local deadline=$(( $(date +%s) + SESSION_READY_TIMEOUT ))
+    local last_phase=""
+    printf '   waiting for Running (timeout %ds)...\n' "${SESSION_READY_TIMEOUT}"
+    while true; do
+        local phase
+        phase=$(
+            "$ACPCTL" get session "$session_id" -o json 2>/dev/null \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('phase',''))" 2>/dev/null || true
+        )
+        if [[ "$phase" != "$last_phase" ]]; then
+            printf '   phase: %s\n' "$phase"
+            last_phase="$phase"
+        fi
+        [[ "$phase" == "Running" ]] && { green "   ✓ session is Running"; return 0; }
+        [[ $(date +%s) -ge $deadline ]] && { yellow "   ✗ timed out (phase=${phase:-unknown})"; return 1; }
+        sleep 3
+    done
+}
+
+max_seq() {
+    local session_id="$1"
+    "$ACPCTL" session messages "${session_id}" -o json 2>/dev/null \
+    | python3 -c "
+import sys, json
+try:
+    msgs = json.load(sys.stdin)
+    print(max((m.get('seq', 0) for m in msgs), default=0) if isinstance(msgs, list) else 0)
+except Exception:
+    print(0)
+" 2>/dev/null || echo 0
+}
+
+wait_for_run_finished() {
+    local session_id="$1" after_seq="$2"
+    local start=$(date +%s)
+    local status="none"
+    local matched_type=""
+
+    while IFS= read -r line; do
+        if echo "$line" | grep -qE 'RUN_FINISHED|RUN_ERROR'; then
+            if echo "$line" | grep -q 'RUN_FINISHED'; then
+                status="finished"; matched_type="RUN_FINISHED"; break
+            elif echo "$line" | grep -q 'RUN_ERROR'; then
+                status="error"; matched_type="RUN_ERROR"; break
+            fi
+        fi
+    done < <(timeout "${MESSAGE_WAIT_TIMEOUT}" "${ACPCTL}" session messages "${session_id}" -f --after "${after_seq}" 2>/dev/null)
+
+    local elapsed=$(( $(date +%s) - start ))
+    case "$status" in
+        finished) green  "   ✓ ${matched_type} (${elapsed}s)"; return 0 ;;
+        error)    yellow "   ✗ ${matched_type} (${elapsed}s)"; return 1 ;;
+        *)        yellow "   ✗ timeout after ${MESSAGE_WAIT_TIMEOUT}s"; return 1 ;;
+    esac
+}
+
+# ── 1: login / whoami ──────────────────────────────────────────────────────────
+
+announce "1 · Verify login"
+
+step "Show authenticated user" \
+    "$ACPCTL" whoami
+
+# ── 2: project ────────────────────────────────────────────────────────────────
+
+announce "2 · Create project"
+
+step "Create project: ${PROJECT_NAME}" \
+    "$ACPCTL" create project \
+        --name "${PROJECT_NAME}" \
+        --description "GitHub credential demo"
+
+CREATED_PROJECT="${PROJECT_NAME}"
+
+step "Set project context" \
+    "$ACPCTL" project "${PROJECT_NAME}"
+
+# ── 3: agent ──────────────────────────────────────────────────────────────────
+
+announce "3 · Create agent"
+
+sep; bold "▶  Create agent: ${AGENT_NAME}"; sleep "$PAUSE"
+AGENT_JSON=$(
+    "$ACPCTL" agent create \
+        --project-id "${PROJECT_NAME}" \
+        --name "${AGENT_NAME}" \
+        --prompt "You are a GitHub automation agent. You use the GitHub CLI (gh) and GitHub API to manage issues and pull requests. When given a credential, you authenticate with it and perform the requested GitHub operations." \
+        -o json 2>/dev/null
+)
+AGENT_ID=$(json_field "$AGENT_JSON" "id")
+[[ -z "${AGENT_ID}" ]] && die "Failed to parse agent ID"
+green "   ✓ agent created: ${AGENT_ID}"
+echo
+
+# ── 4: credential ─────────────────────────────────────────────────────────────
+
+announce "4 · Create GitHub credential"
+
+sep; bold "▶  Create credential: ${CRED_NAME}"; sleep "$PAUSE"
+_CRED_MANIFEST=$(mktemp --suffix=.yaml)
+cat > "${_CRED_MANIFEST}" <<'CRED_EOF'
+kind: Credential
+name: CRED_NAME_PLACEHOLDER
+provider: github
+token: $DEMO_GITHUB_PAT
+description: CRED_DESC_PLACEHOLDER
+CRED_EOF
+sed -i \
+    -e "s/CRED_NAME_PLACEHOLDER/${CRED_NAME}/" \
+    -e "s/CRED_DESC_PLACEHOLDER/GitHub PAT for demo ${RUN_ID}/" \
+    "${_CRED_MANIFEST}"
+DEMO_GITHUB_PAT="${GITHUB_TOKEN_VALUE}" \
+    "$ACPCTL" apply -f "${_CRED_MANIFEST}" 2>/dev/null
+rm -f "${_CRED_MANIFEST}"
+CRED_JSON=$(
+    "$ACPCTL" get credentials -o json 2>/dev/null \
+    | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+items = data.get('items', []) if isinstance(data, dict) else data
+for c in items:
+    if c.get('name') == '${CRED_NAME}':
+        print(json.dumps(c))
+        break
+" 2>/dev/null
+)
+CREDENTIAL_ID=$(json_field "$CRED_JSON" "id")
+[[ -z "${CREDENTIAL_ID}" ]] && die "Failed to parse credential ID"
+CREATED_CREDENTIAL_ID="${CREDENTIAL_ID}"
+green "   ✓ credential created: ${CREDENTIAL_ID}"
+echo
+
+step "Verify credential visible" \
+    "$ACPCTL" get credentials
+
+# ── 5: role binding ───────────────────────────────────────────────────────────
+
+announce "5 · Bind credential to agent"
+
+sep; bold "▶  Look up credential:token-reader role ID"; sleep "$PAUSE"
+ROLES_JSON=$("$ACPCTL" get roles -o json 2>/dev/null)
+READER_ROLE_ID=$(
+    echo "$ROLES_JSON" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+items = data.get('items', []) if isinstance(data, dict) else data
+for r in items:
+    if r.get('name') == 'credential:token-reader':
+        print(r['id'])
+        break
+" 2>/dev/null
+)
+
+MY_USER_ID=$(
+    "$ACPCTL" whoami 2>/dev/null \
+    | awk '/^User:/{print $2}' || true
+)
+
+if [[ -z "${READER_ROLE_ID}" ]]; then
+    yellow "   credential:token-reader role not in this deployment — skipping role binding"
+    dim   "   (credential roles are seeded by the api-server migration; redeploy may be needed)"
+else
+    dim "   credential:token-reader role ID: ${READER_ROLE_ID}"
+    dim "   my user ID: ${MY_USER_ID}"
+
+    sep; bold "▶  Create role-binding: credential:token-reader scope=agent"; sleep "$PAUSE"
+    "$ACPCTL" create role-binding \
+        --user-id "${MY_USER_ID}" \
+        --role-id "${READER_ROLE_ID}" \
+        --scope agent \
+        --scope-id "${AGENT_ID}" || yellow "   role-binding creation failed (may already exist)"
+    echo
+    green "   ✓ credential bound to agent"
+fi
+
+# ── 6: start session ──────────────────────────────────────────────────────────
+
+announce "6 · Start interactive session"
+
+SESSION_PROMPT="You have access to a GitHub Personal Access Token via the platform credential API.
+
+To authenticate with GitHub:
+1. Call GET /api/ambient/v1/credentials/${CREDENTIAL_ID}/token to retrieve the raw token
+2. Use the token to authenticate: export GITHUB_TOKEN=<token>
+3. Use the gh CLI or curl to interact with the GitHub API
+
+Your task: Open a test GitHub issue in the repository ${GITHUB_REPO} with:
+  Title: [ambient-demo] Credential integration test ${RUN_ID}
+  Body:  This issue was automatically opened by the Ambient platform credential demo on $(date -u +%Y-%m-%dT%H:%M:%SZ). It can be closed immediately.
+
+After opening the issue, report the issue URL back as confirmation."
+
+sep; bold "▶  Start session for agent ${AGENT_NAME}"; sleep "$PAUSE"
+SESSION_JSON=$(
+    "$ACPCTL" agent start "${AGENT_NAME}" \
+        --project-id "${PROJECT_NAME}" \
+        --prompt "${SESSION_PROMPT}" \
+        -o json 2>&1
+)
+SESSION_ID=$(json_field "$SESSION_JSON" "id")
+if [[ -z "${SESSION_ID}" ]]; then
+    red "   Failed to start session. Output:"
+    echo "${SESSION_JSON}"
+    die "Failed to parse session ID"
+fi
+CREATED_SESSION_ID="${SESSION_ID}"
+green "   ✓ session created: ${SESSION_ID}"
+echo
+
+# ── 7: wait for Running ───────────────────────────────────────────────────────
+
+announce "7 · Wait for session Running"
+
+wait_for_running "${SESSION_ID}" || true
+
+# ── 8: stream messages ────────────────────────────────────────────────────────
+
+announce "8 · Streaming session messages (waiting for RUN_FINISHED)"
+
+BEFORE_SEQ=0
+wait_for_run_finished "${SESSION_ID}" "${BEFORE_SEQ}" || true
+
+# ── 9: show result ────────────────────────────────────────────────────────────
+
+announce "9 · Session result"
+
+step "Final session messages" \
+    "$ACPCTL" session messages "${SESSION_ID}"
+
+step "Final session state" \
+    "$ACPCTL" describe session "${SESSION_ID}"
+
+# ── done (cleanup runs via trap) ──────────────────────────────────────────────
+
+echo
+sep
+green "  Demo complete ✓"
+dim   "  Project ${PROJECT_NAME} and credential ${CREDENTIAL_ID} will be deleted by cleanup."
+sep
+echo

--- a/components/ambient-cli/demo-kind.sh
+++ b/components/ambient-cli/demo-kind.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # demo-kind.sh — acpctl end-to-end demo against a local kind cluster
 #
-# Manages port-forwards for API (:18000), gRPC (:19000), and frontend (:18080).
-# Watches the gRPC WatchSessions stream in a background pane so you can see
-# control-plane events in real time as demo.sh drives the session lifecycle.
+# Layout: left half = demo output, right half = 3 stacked session watch panels.
+# As sessions are created, each gets a live `acpctl session messages -f` watch
+# in the next available right panel. Up to 3 concurrent session watches.
 #
 # Usage:
 #   ./demo-kind.sh                          # auto-detects kind cluster + token
@@ -23,6 +23,53 @@
 #   SKIP_GRPC_WATCH        — set to 1 to skip grpcurl stream (default: unset)
 
 set -euo pipefail
+
+# ── tmux layout bootstrap ──────────────────────────────────────────────────────
+#
+# If we are not already inside a tmux session, create one and re-exec this
+# script inside the left pane. The right side is pre-split into 3 watch panels
+# (right-0, right-1, right-2) which start idle and are claimed as sessions appear.
+
+TMUX_SESSION="ambient-demo"
+DEMO_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+if [[ -z "${TMUX:-}" ]]; then
+    tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 50
+
+    # right column: split the window vertically (left=main, right=watches)
+    tmux split-window -h -t "${TMUX_SESSION}:0" -p 40
+    # right pane is now pane 1 — split into 3 equal rows
+    tmux split-window -v -t "${TMUX_SESSION}:0.1" -p 67
+    tmux split-window -v -t "${TMUX_SESSION}:0.2" -p 50
+
+    # label each watch pane so the user can see what it will show
+    tmux send-keys -t "${TMUX_SESSION}:0.1" "printf '\\033[2m[watch slot 1 — waiting for session]\\033[0m\\n'" Enter
+    tmux send-keys -t "${TMUX_SESSION}:0.2" "printf '\\033[2m[watch slot 2 — waiting for session]\\033[0m\\n'" Enter
+    tmux send-keys -t "${TMUX_SESSION}:0.3" "printf '\\033[2m[watch slot 3 — waiting for session]\\033[0m\\n'" Enter
+
+    # run this script in the left pane with TMUX_SESSION exported
+    tmux send-keys -t "${TMUX_SESSION}:0.0" \
+        "TMUX_SESSION=${TMUX_SESSION} INSIDE_DEMO_TMUX=1 bash ${DEMO_SCRIPT}" Enter
+
+    tmux select-pane -t "${TMUX_SESSION}:0.0"
+    tmux attach-session -t "$TMUX_SESSION"
+    exit 0
+fi
+
+# track which right panes are still free (pane indices 1, 2, 3)
+WATCH_PANES=(1 2 3)
+WATCH_PANE_IDX=0
+
+attach_session_watch() {
+    local session_id="$1"
+    if [[ $WATCH_PANE_IDX -ge ${#WATCH_PANES[@]} ]]; then
+        return
+    fi
+    local pane="${WATCH_PANES[$WATCH_PANE_IDX]}"
+    WATCH_PANE_IDX=$(( WATCH_PANE_IDX + 1 ))
+    tmux send-keys -t "${TMUX_SESSION}:0.${pane}" \
+        "AMBIENT_API_URL=${AMBIENT_API_URL} AMBIENT_TOKEN=${AMBIENT_TOKEN} AMBIENT_GRPC_URL=${AMBIENT_GRPC_URL} ${ACPCTL:-acpctl} session messages ${session_id} -f" Enter
+}
 
 NAMESPACE="${NAMESPACE:-ambient-code}"
 KIND_CONTEXT="${KIND_CONTEXT:-$(kubectl config current-context 2>/dev/null | grep -E '^kind-' | head -1)}"
@@ -163,6 +210,9 @@ wait_for_port "${API_PORT}"      "REST API"
 wait_for_port "${GRPC_PORT}"     "gRPC"
 wait_for_port "${FRONTEND_PORT}" "Frontend"
 
+export AMBIENT_GRPC_URL="localhost:${GRPC_PORT}"
+dim "   AMBIENT_GRPC_URL=${AMBIENT_GRPC_URL}"
+
 # ── token from cluster ─────────────────────────────────────────────────────────
 
 AMBIENT_TOKEN=$(
@@ -235,49 +285,25 @@ wait_for_running() {
 wait_for_run_finished() {
     local session_id="$1" after_seq="$2"
     local start=$(date +%s)
-    local deadline=$(( start + MESSAGE_WAIT_TIMEOUT ))
-    local spinner='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
-    local spin_i=0
-    printf '   '
-    while true; do
-        local result
-        result=$(
-            api_get "/sessions/${session_id}/messages?after_seq=${after_seq}" \
-            | python3 -c "
-import sys, json
-try:
-    msgs = json.load(sys.stdin)
-    if not isinstance(msgs, list):
-        print('none')
-    else:
-        types = [m.get('event_type','') for m in msgs]
-        if 'RUN_FINISHED' in types or 'MESSAGES_SNAPSHOT' in types:
-            print('finished')
-        elif 'RUN_ERROR' in types:
-            print('error')
-        elif len(msgs) > 0:
-            print('partial')
-        else:
-            print('none')
-except Exception as e:
-    print('none')
-" 2>/dev/null || echo none
-        )
-        local elapsed=$(( $(date +%s) - start ))
-        case "$result" in
-            finished)
-                printf '\r'
-                green "   ✓ RUN_FINISHED (${elapsed}s)"; return 0 ;;
-            error)
-                printf '\r'
-                yellow "   ✗ RUN_ERROR (${elapsed}s)"; return 1 ;;
-        esac
-        [[ $(date +%s) -ge $deadline ]] && { printf '\r'; yellow "   ✗ timeout after ${MESSAGE_WAIT_TIMEOUT}s"; return 1; }
-        local ch="${spinner:$(( spin_i % ${#spinner} )):1}"
-        printf "\r   %s %ds" "$ch" "$elapsed"
-        spin_i=$(( spin_i + 1 ))
-        sleep 2
-    done
+    local status="none"
+    local matched_type=""
+
+    while IFS= read -r line; do
+        if echo "$line" | grep -qE '^\[|RUN_FINISHED|RUN_ERROR'; then
+            if echo "$line" | grep -q 'RUN_FINISHED'; then
+                status="finished"; matched_type="RUN_FINISHED"; break
+            elif echo "$line" | grep -q 'RUN_ERROR'; then
+                status="error"; matched_type="RUN_ERROR"; break
+            fi
+        fi
+    done < <(timeout "${MESSAGE_WAIT_TIMEOUT}" "${ACPCTL:-acpctl}" session messages "${session_id}" -f --after "${after_seq}" 2>/dev/null)
+
+    local elapsed=$(( $(date +%s) - start ))
+    case "$status" in
+        finished) green   "   ✓ ${matched_type} (${elapsed}s)"; return 0 ;;
+        error)    yellow  "   ✗ ${matched_type} (${elapsed}s)"; return 1 ;;
+        *)        yellow  "   ✗ timeout after ${MESSAGE_WAIT_TIMEOUT}s";  return 1 ;;
+    esac
 }
 
 max_seq() {
@@ -337,6 +363,8 @@ if [[ -z "$SESSION_ID" ]]; then
     exit 1
 fi
 dim "   session ID: ${SESSION_ID}"; echo
+
+attach_session_watch "${SESSION_ID}"
 
 if [[ -n "${GRPC_WATCH_PID:-}" ]]; then
     sleep 1

--- a/components/ambient-cli/demo-remote.sh
+++ b/components/ambient-cli/demo-remote.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# demo-remote.sh — acpctl two-agent conversation demo against a remote deployment
+#
+# Layout: 2-pane tmux — left = main demo, right = live message watch.
+# Creates two sessions ("historian" and "poet"). They have an extended
+# conversation about Charleston, SC by exchanging messages via push_message.
+# The script relays each agent's response to the other agent.
+#
+# Usage:
+#   ./demo-remote.sh https://ambient-api-server-ambient-code--ambient-s5.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com/
+#   AMBIENT_API_URL=https://... ./demo-remote.sh
+#
+# Optional env:
+#   AMBIENT_API_URL            — API server URL (or pass as positional arg)
+#   AMBIENT_TOKEN              — pre-existing token (skips browser login)
+#   ACPCTL                     — path to acpctl binary    (default: acpctl from PATH)
+#   PAUSE                      — seconds between demo steps (default: 2)
+#   SESSION_READY_TIMEOUT      — seconds to wait for Running (default: 180)
+#   MESSAGE_WAIT_TIMEOUT       — seconds to wait for messages (default: 120)
+#   INSECURE_TLS               — set to 1 to skip TLS verification (default: unset)
+
+set -euo pipefail
+
+# ── tmux layout bootstrap ──────────────────────────────────────────────────────
+
+TMUX_SESSION="ambient-demo"
+DEMO_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+DEMO_ARGS=("${@}")
+
+if [[ -z "${TMUX:-}" ]]; then
+    tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+    tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 50
+
+    tmux split-window -h -t "${TMUX_SESSION}:0" -p 40
+
+    tmux send-keys -t "${TMUX_SESSION}:0.1" "printf '\\033[2m[watch panel — waiting for session]\\033[0m\\n'" Enter
+
+    ESCAPED_ARGS=""
+    for arg in "${DEMO_ARGS[@]}"; do
+        ESCAPED_ARGS+="$(printf ' %q' "$arg")"
+    done
+    tmux send-keys -t "${TMUX_SESSION}:0.0" \
+        "TMUX_SESSION=$(printf '%q' "$TMUX_SESSION") INSIDE_DEMO_TMUX=1 bash $(printf '%q' "$DEMO_SCRIPT")${ESCAPED_ARGS}" Enter
+
+    tmux select-pane -t "${TMUX_SESSION}:0.0"
+    tmux attach-session -t "$TMUX_SESSION"
+    exit 0
+fi
+
+WATCH_PANE="1"
+
+attach_watch() {
+    local session_id="$1"
+    tmux send-keys -t "${TMUX_SESSION}:0.${WATCH_PANE}" \
+        "$(printf '%q' "${ACPCTL:-acpctl}") session messages $(printf '%q' "$session_id") -F" Enter
+}
+
+# ── config ────────────────────────────────────────────────────────────────────
+
+ACPCTL="${ACPCTL:-acpctl}"
+PAUSE="${PAUSE:-2}"
+SESSION_READY_TIMEOUT="${SESSION_READY_TIMEOUT:-180}"
+MESSAGE_WAIT_TIMEOUT="${MESSAGE_WAIT_TIMEOUT:-120}"
+INSECURE_TLS="${INSECURE_TLS:-}"
+
+if [[ $# -ge 1 ]]; then
+    AMBIENT_API_URL="${1}"
+fi
+AMBIENT_API_URL="${AMBIENT_API_URL:-}"
+
+if [[ -z "${AMBIENT_API_URL}" ]]; then
+    AMBIENT_API_URL=$("$ACPCTL" config get api_url 2>/dev/null || true)
+fi
+
+if [[ -z "${AMBIENT_API_URL}" ]]; then
+    printf '\033[31merror: no API URL. Pass as argument or set AMBIENT_API_URL.\033[0m\n' >&2
+    exit 1
+fi
+
+AMBIENT_API_URL="${AMBIENT_API_URL%/}"
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
+cyan()  { printf '\033[36m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow(){ printf '\033[33m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+sep()   { printf '\033[2m%s\033[0m\n' "──────────────────────────────────────────────────"; }
+
+step() {
+    local description="$1"
+    shift
+    echo
+    sep
+    bold "▶  $description"
+    printf '\033[38;5;214m   $ %s\033[0m\n' "$*"
+    sleep "$PAUSE"
+    "$@"
+    echo
+}
+
+announce() {
+    echo
+    sep
+    cyan "━━  $*"
+    sep
+    sleep "$PAUSE"
+}
+
+# ── preflight ──────────────────────────────────────────────────────────────────
+
+if ! command -v "$ACPCTL" &>/dev/null; then
+    red "error: ${ACPCTL} not found. Set ACPCTL=/path/to/acpctl or add to PATH." >&2; exit 1
+fi
+
+cleanup() {
+    :
+}
+trap cleanup EXIT
+
+# ── intro ─────────────────────────────────────────────────────────────────────
+
+echo
+bold "Ambient CLI Demo — Two-Agent Conversation (remote)"
+dim  "  API:  ${AMBIENT_API_URL}"
+
+echo
+sep
+bold "What this demo will do:"
+echo
+printf '  %s\n' "1. Log in and create a project"
+printf '  %s\n' "2. Create two sessions: historian and poet"
+printf '  %s\n' "3. Wait for both to reach Running"
+printf '  %s\n' "4. Attach live message watch for the poet (right panel)"
+printf '  %s\n' "5. Seed the historian with Charleston context"
+printf '  %s\n' "6. Relay the historian's response to the poet via push_message"
+printf '  %s\n' "7. Relay the poet's response back to the historian"
+printf '  %s\n' "8. Continue the relay for an extended conversation"
+printf '  %s\n' "9. Show final state and clean up"
+echo
+printf '  \033[38;5;214m%-38s\033[0m %s\n' "Orange text like this" "= a terminal command being run"
+echo
+sep
+if [[ "${PAUSE}" -gt 0 ]] 2>/dev/null; then
+    bold "   Press Enter to begin..."
+    read -r
+fi
+
+# ── session helpers ───────────────────────────────────────────────────────────
+
+wait_for_phase() {
+    local session_id="$1" target_phase="$2"
+    local deadline=$(( $(date +%s) + SESSION_READY_TIMEOUT ))
+    local last_phase=""
+    printf '   waiting for %s (timeout %ds)...\n' "${target_phase}" "${SESSION_READY_TIMEOUT}"
+    while true; do
+        local phase
+        phase=$(
+            "$ACPCTL" get session "$session_id" -o json 2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('phase',''))" 2>/dev/null || true
+        )
+        if [[ "$phase" != "$last_phase" ]]; then
+            printf '   phase: %s\n' "$phase"
+            last_phase="$phase"
+        fi
+        [[ "$phase" == "$target_phase" ]] && { green "   ✓ session is ${target_phase}"; return 0; }
+        [[ "$phase" == "Failed" || "$phase" == "Stopped" ]] && { red "   ✗ session is ${phase}"; return 1; }
+        [[ $(date +%s) -ge $deadline ]] && { yellow "   ✗ timed out (phase=${phase:-unknown})"; return 1; }
+        sleep 3
+    done
+}
+
+create_session() {
+    local name="$1"
+    local json
+    json=$(
+        "$ACPCTL" create session \
+            --name "$name" \
+            -o json 2>/dev/null
+    )
+    local sid
+    sid=$(echo "$json" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+    if [[ -z "$sid" ]]; then
+        red "   ✗ failed to parse session ID for ${name}"
+        return 1
+    fi
+    echo "$sid"
+}
+
+extract_last_assistant_text() {
+    local session_id="$1"
+    "$ACPCTL" session messages "${session_id}" -o json 2>/dev/null \
+    | python3 -c "
+import sys, json
+try:
+    msgs = json.load(sys.stdin)
+    for m in reversed(msgs):
+        if m.get('event_type') == 'MESSAGES_SNAPSHOT':
+            snapshot = json.loads(m.get('payload', '[]'))
+            for msg in reversed(snapshot):
+                if msg.get('role') == 'assistant':
+                    content = msg.get('content', '')
+                    if isinstance(content, list):
+                        parts = []
+                        for p in content:
+                            if isinstance(p, dict) and p.get('type') == 'text':
+                                parts.append(p.get('text', ''))
+                        content = ' '.join(parts)
+                    if content.strip():
+                        print(content.strip())
+                        sys.exit(0)
+except Exception:
+    pass
+" 2>/dev/null || true
+}
+
+send_and_capture() {
+    local session_id="$1" label="$2" msg="$3"
+
+    echo; sep
+    bold "▶  → ${label}: sending message"
+    if [[ ${#msg} -gt 120 ]]; then
+        dim "   ${msg:0:117}..."
+    else
+        dim "   ${msg}"
+    fi
+    sleep "$PAUSE"
+
+    bold "▶  → ${label}: waiting for response..."
+    if timeout "${MESSAGE_WAIT_TIMEOUT}" "$ACPCTL" session send "${session_id}" "$msg" -f 2>&1; then
+        green "   ✓ ${label} responded"
+    else
+        red "   ✗ ${label}: send -f failed or timed out — aborting demo"
+        exit 1
+    fi
+    echo
+
+    LAST_RESPONSE=$(extract_last_assistant_text "${session_id}")
+
+    bold "▶  ${label} says:"
+    if [[ -n "${LAST_RESPONSE}" ]]; then
+        echo "   ${LAST_RESPONSE}" | fold -s -w 76 | sed 's/^/   /'
+    else
+        dim "   (no response captured)"
+    fi
+    echo
+    sleep "$PAUSE"
+}
+
+# ── section 1: login ──────────────────────────────────────────────────────────
+
+announce "1 · Log in"
+
+if [[ -n "${AMBIENT_TOKEN:-}" ]]; then
+    TLS_FLAG=""
+    if [[ -n "${INSECURE_TLS}" ]]; then
+        TLS_FLAG="--insecure-skip-tls-verify"
+    fi
+    step "Log in with existing token" \
+        "$ACPCTL" login "${AMBIENT_API_URL}" \
+            --token "${AMBIENT_TOKEN}" \
+            ${TLS_FLAG}
+else
+    TLS_FLAG=""
+    if [[ -n "${INSECURE_TLS}" ]]; then
+        TLS_FLAG="--insecure-skip-tls-verify"
+    fi
+    step "Log in via browser (Red Hat SSO)" \
+        "$ACPCTL" login --use-auth-code \
+            --url "${AMBIENT_API_URL}" \
+            ${TLS_FLAG}
+fi
+
+step "Show authenticated user" \
+    "$ACPCTL" whoami
+
+# ── section 2: project ───────────────────────────────────────────────────────
+
+announce "2 · Create project"
+
+RUN_ID=$(date +%s | tail -c5)
+PROJECT_NAME="demo-${RUN_ID}"
+
+step "Create project: ${PROJECT_NAME}" \
+    "$ACPCTL" create project \
+        --name "${PROJECT_NAME}" \
+        --display-name "Demo Project ${RUN_ID}" \
+        --description "two-agent conversation demo"
+
+step "Set project context" \
+    "$ACPCTL" project "${PROJECT_NAME}"
+
+step "Confirm project context" \
+    "$ACPCTL" project current
+
+# ── section 3: create both sessions ──────────────────────────────────────────
+
+announce "3 · Create two sessions"
+
+sep; bold "▶  Create session: historian"; sleep "$PAUSE"
+HISTORIAN_ID=$(create_session "historian")
+dim "   historian ID: ${HISTORIAN_ID}"; echo
+
+sep; bold "▶  Create session: poet"; sleep "$PAUSE"
+POET_ID=$(create_session "poet")
+dim "   poet ID: ${POET_ID}"; echo
+
+step "List sessions" \
+    "$ACPCTL" get sessions
+
+# ── section 4: wait for both to reach Running ────────────────────────────────
+
+announce "4 · Wait for both sessions to reach Running"
+
+bold "▶  Waiting for historian..."
+wait_for_phase "${HISTORIAN_ID}" "Running" || { red "   historian did not reach Running"; exit 1; }
+echo
+
+bold "▶  Waiting for poet..."
+wait_for_phase "${POET_ID}" "Running" || { red "   poet did not reach Running"; exit 1; }
+echo
+
+# ── attach watch for poet in the right panel ─────────────────────────────────
+
+announce "5 · Attach live watch for poet session"
+
+dim "   attaching poet message watch to right panel..."
+sleep 2
+attach_watch "${POET_ID}"
+sleep 3
+green "   ✓ right panel watching poet messages (Ctrl+C to stop)"
+
+# ── section 6: seed the historian ─────────────────────────────────────────────
+
+announce "6 · Seed the historian with Charleston context"
+
+LAST_RESPONSE=""
+send_and_capture "${HISTORIAN_ID}" "historian" \
+    "You are a Charleston, SC historian. Tell me about what makes Charleston's geography and ecology unique — the salt marshes, barrier islands, tidal creeks, and how they shape life in the Lowcountry. Keep your response to 2-3 sentences."
+
+HISTORIAN_OPENING="${LAST_RESPONSE}"
+
+# ── section 7: relay to poet ─────────────────────────────────────────────────
+
+announce "7 · Relay historian's response → poet (watch the right panel!)"
+
+dim "   Forwarding the historian's words to the poet via push_message..."
+sleep "$PAUSE"
+
+send_and_capture "${POET_ID}" "poet" \
+    "You are a Charleston poet. A historian just told you this about Charleston: \"${HISTORIAN_OPENING}\" — Respond with your own poetic perspective on what the historian described. How does this landscape feel, smell, sound? 2-3 sentences, evocative language."
+
+POET_RESPONSE="${LAST_RESPONSE}"
+
+# ── section 8: relay back to historian ────────────────────────────────────────
+
+announce "8 · Relay poet's response → historian"
+
+dim "   Forwarding the poet's words back to the historian..."
+sleep "$PAUSE"
+
+send_and_capture "${HISTORIAN_ID}" "historian" \
+    "A poet responded to your description with this: \"${POET_RESPONSE}\" — Now tell me about one specific historical event or tradition in Charleston that connects to the marshes or the sea. 2-3 sentences."
+
+HISTORIAN_HISTORY="${LAST_RESPONSE}"
+
+# ── section 9: relay history back to poet ─────────────────────────────────────
+
+announce "9 · Relay historian's history → poet for a final poem"
+
+dim "   Forwarding the historian's story back to the poet..."
+sleep "$PAUSE"
+
+send_and_capture "${POET_ID}" "poet" \
+    "The historian shared this story: \"${HISTORIAN_HISTORY}\" — Write a 4-line poem inspired by what the historian told you. Mention the marshes and the sea."
+
+# ── section 10: final summary ─────────────────────────────────────────────────
+
+announce "10 · Conversation summary"
+
+echo
+bold "The two agents had the following exchange about Charleston:"
+echo
+cyan "  HISTORIAN (opening):"
+echo "   ${HISTORIAN_OPENING}" | fold -s -w 76 | sed 's/^/   /'
+echo
+cyan "  POET (response):"
+echo "   ${POET_RESPONSE}" | fold -s -w 76 | sed 's/^/   /'
+echo
+cyan "  HISTORIAN (history):"
+echo "   ${HISTORIAN_HISTORY}" | fold -s -w 76 | sed 's/^/   /'
+echo
+cyan "  POET (final poem):"
+echo "   ${LAST_RESPONSE}" | fold -s -w 76 | sed 's/^/   /'
+echo
+
+sep
+sleep "$PAUSE"
+
+step "Historian — all messages" \
+    "$ACPCTL" session messages "${HISTORIAN_ID}"
+
+step "Poet — all messages" \
+    "$ACPCTL" session messages "${POET_ID}"
+
+# ── section 11: cleanup ──────────────────────────────────────────────────────
+
+announce "11 · Stop and clean up"
+
+sep; bold "▶  Stop historian"; sleep "$PAUSE"
+"$ACPCTL" stop "${HISTORIAN_ID}" || true; echo
+
+sep; bold "▶  Stop poet"; sleep "$PAUSE"
+"$ACPCTL" stop "${POET_ID}" || true; echo
+
+sleep 3
+
+step "Delete historian session" \
+    "$ACPCTL" delete session "${HISTORIAN_ID}" -y
+
+step "Delete poet session" \
+    "$ACPCTL" delete session "${POET_ID}" -y
+
+step "Delete project ${PROJECT_NAME}" \
+    "$ACPCTL" delete project "${PROJECT_NAME}" -y
+
+step "Confirm cleanup" \
+    "$ACPCTL" get projects
+
+# ── done ──────────────────────────────────────────────────────────────────────
+
+echo
+sep
+green "  Demo complete ✓"
+sep
+echo

--- a/components/ambient-cli/go.mod
+++ b/components/ambient-cli/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/term v0.38.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/components/ambient-cli/go.sum
+++ b/components/ambient-cli/go.sum
@@ -89,5 +89,7 @@ google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/components/ambient-cli/multi-demo.sh
+++ b/components/ambient-cli/multi-demo.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# multi-demo.sh — create a 4-panel tmux session for a lead/fe/api/cp agent group discussion
+#
+# Usage:
+#   ./multi-demo.sh [--project-id <id>] [--session <tmux-session-name>]
+#
+# Requires: acpctl, jq, tmux
+
+set -euo pipefail
+
+TMUX_SESSION="${TMUX_SESSION:-ambient-demo}"
+PROJECT_ID="${PROJECT_ID:-}"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --project-id) PROJECT_ID="$2"; shift 2 ;;
+    --session)    TMUX_SESSION="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+# ── 1. Resolve project ────────────────────────────────────────────────────────
+
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID=$(acpctl project current 2>/dev/null | awk '{print $NF}')
+fi
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "error: no project set — use --project-id or: acpctl project set <name>" >&2
+  exit 1
+fi
+echo "Project: $PROJECT_ID"
+
+# ── 2. Fetch sessions and resolve lead/fe/api/cp ──────────────────────────────
+
+SESSIONS_JSON=$(acpctl get sessions -o json 2>/dev/null)
+
+resolve_session() {
+  local prefix=$1
+  echo "$SESSIONS_JSON" | jq -r --arg p "$prefix" \
+    '.items[] | select(.name | startswith($p)) | .id' | head -1
+}
+
+resolve_agent() {
+  local prefix=$1
+  echo "$SESSIONS_JSON" | jq -r --arg p "$prefix" \
+    '.items[] | select(.name | startswith($p)) | .agent_id' | head -1
+}
+
+# Resolve or start a session for the given agent name prefix.
+# Prints the session ID; starts the agent if no session exists.
+resolve_or_start_session() {
+  local prefix=$1
+  local sid
+  sid=$(resolve_session "$prefix")
+  if [[ -n "$sid" ]]; then
+    echo "$sid"
+    return
+  fi
+  echo "No session found for '$prefix' — starting agent..." >&2
+  local out
+  out=$(acpctl agent start "$prefix" --project-id "$PROJECT_ID" 2>&1) || {
+    echo "error: failed to start agent '$prefix': $out" >&2
+    exit 1
+  }
+  # output format: "session/<id> started (phase: ...)"
+  echo "$out" | sed -n 's|^session/\([^ ]*\) .*|\1|p'
+}
+
+LEAD_SID=$(resolve_or_start_session "lead")
+API_SID=$(resolve_or_start_session "api")
+FE_SID=$(resolve_or_start_session "fe")
+CP_SID=$(resolve_or_start_session "cp")
+
+# Refresh session list so agent_id fields are available for newly started sessions
+SESSIONS_JSON=$(acpctl get sessions -o json 2>/dev/null)
+
+LEAD_AID=$(resolve_agent "lead")
+API_AID=$(resolve_agent "api")
+FE_AID=$(resolve_agent "fe")
+CP_AID=$(resolve_agent "cp")
+
+echo "Sessions found:"
+echo "  lead  session=$LEAD_SID  agent=$LEAD_AID"
+echo "  api   session=$API_SID   agent=$API_AID"
+echo "  fe    session=$FE_SID    agent=$FE_AID"
+echo "  cp    session=$CP_SID    agent=$CP_AID"
+
+# ── 3. Build initial lead message ─────────────────────────────────────────────
+
+read -r -d '' LEAD_MSG <<EOF || true
+You are the lead agent coordinating a multi-agent team in project '${PROJECT_ID}'.
+Your team members and their agent IDs are:
+  - fe  (frontend):       ${FE_AID}
+  - api (backend API):    ${API_AID}
+  - cp  (control-plane):  ${CP_AID}
+
+Your task for this session:
+
+1. First, examine your own annotations using available tools (e.g. acpctl or kubectl).
+   Report what you find — especially any communication protocol or coordination
+   conventions encoded there.
+
+2. Send an inbox message to each team member asking them to:
+   a) Examine their own annotations and report what they mean.
+   b) Reply to you (lead) with a summary.
+   c) If they find a communication protocol in the annotations, use it going forward.
+
+   Use: acpctl inbox send --project-id ${PROJECT_ID} --pa-id <agent-id> --body "<message>" --from-name lead
+
+3. After each agent replies, synthesize what you learn and send a follow-up directing
+   each agent on next steps based on their annotations and any discovered protocol.
+
+Begin now. Send the inbox messages to your team first, then examine your own annotations.
+EOF
+
+# ── 4. Kill any existing tmux session with the same name ─────────────────────
+
+if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+  echo "Killing existing tmux session '$TMUX_SESSION'..."
+  tmux kill-session -t "$TMUX_SESSION"
+fi
+
+# ── 5. Create layout ──────────────────────────────────────────────────────────
+#
+#  ┌───────────────────┬──────────────────┐
+#  │                   │  lead  (pane 1)  │
+#  │                   ├──────────────────┤
+#  │  interactive      │  api   (pane 2)  │
+#  │  (pane 0)         ├──────────────────┤
+#  │                   │  cp    (pane 3)  │
+#  │                   ├──────────────────┤
+#  │                   │  fe    (pane 4)  │
+#  └───────────────────┴──────────────────┘
+
+tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 55
+
+# Split right column off pane 0
+tmux split-window -h -t "${TMUX_SESSION}:0.0"   # pane 0=left, pane 1=right
+
+# Stack 3 more panes in the right column by splitting pane 1 repeatedly
+tmux split-window -v -t "${TMUX_SESSION}:0.1"   # pane 2 below pane 1
+tmux split-window -v -t "${TMUX_SESSION}:0.2"   # pane 3 below pane 2
+tmux split-window -v -t "${TMUX_SESSION}:0.3"   # pane 4 below pane 3
+
+# Set pane titles
+tmux select-pane -t "${TMUX_SESSION}:0.0" -T "INTERACTIVE"
+tmux select-pane -t "${TMUX_SESSION}:0.1" -T "lead msgs"
+tmux select-pane -t "${TMUX_SESSION}:0.2" -T "api msgs"
+tmux select-pane -t "${TMUX_SESSION}:0.3" -T "cp msgs"
+tmux select-pane -t "${TMUX_SESSION}:0.4" -T "fe msgs"
+
+# ── 6. Start message watchers in right column ─────────────────────────────────
+
+tmux send-keys -t "${TMUX_SESSION}:0.1" \
+  "echo '=== lead: ${LEAD_SID} ===' && acpctl session messages '${LEAD_SID}' -f" Enter
+
+tmux send-keys -t "${TMUX_SESSION}:0.2" \
+  "echo '=== api: ${API_SID} ===' && acpctl session messages '${API_SID}' -f" Enter
+
+tmux send-keys -t "${TMUX_SESSION}:0.3" \
+  "echo '=== cp: ${CP_SID} ===' && acpctl session messages '${CP_SID}' -f" Enter
+
+tmux send-keys -t "${TMUX_SESSION}:0.4" \
+  "echo '=== fe: ${FE_SID} ===' && acpctl session messages '${FE_SID}' -f" Enter
+
+# ── 7. Left pane: send initial message, then stay interactive ─────────────────
+
+tmux send-keys -t "${TMUX_SESSION}:0.0" \
+  "echo '=== interactive — lead session: ${LEAD_SID} ==='" Enter
+
+# Write message to a temp file to avoid quoting nightmares
+TMPFILE=$(mktemp /tmp/lead-msg-XXXXXX.txt)
+printf '%s' "$LEAD_MSG" > "$TMPFILE"
+
+tmux send-keys -t "${TMUX_SESSION}:0.0" \
+  "acpctl session send '${LEAD_SID}' \"\$(cat ${TMPFILE})\"; rm -f ${TMPFILE}" Enter
+
+# Focus the lead pane after startup
+tmux select-pane -t "${TMUX_SESSION}:0.0"
+
+# ── 8. Attach ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Attaching to tmux session '$TMUX_SESSION'..."
+echo "  Ctrl+B D  — detach"
+echo "  Ctrl+B arrow — switch pane"
+echo ""
+echo "Lead pane shortcuts (once interactive):"
+echo "  acpctl session send '${LEAD_SID}' \"your message\""
+echo "  acpctl inbox send --project-id '${PROJECT_ID}' --pa-id <agent-id> --body \"...\""
+echo ""
+
+tmux attach-session -t "$TMUX_SESSION"

--- a/components/ambient-cli/pkg/config/config.go
+++ b/components/ambient-cli/pkg/config/config.go
@@ -13,6 +13,9 @@ import (
 type Config struct {
 	APIUrl            string `json:"api_url,omitempty"`
 	AccessToken       string `json:"access_token,omitempty"`
+	RefreshToken      string `json:"refresh_token,omitempty"`
+	IssuerURL         string `json:"issuer_url,omitempty"`
+	ClientID          string `json:"client_id,omitempty"`
 	Project           string `json:"project,omitempty"`
 	Pager             string `json:"pager,omitempty"`            // TODO: Wire pager support into output commands (e.g. pipe through less)
 	RequestTimeout    int    `json:"request_timeout,omitempty"`  // Request timeout in seconds
@@ -107,6 +110,41 @@ func (c *Config) GetToken() string {
 		return env
 	}
 	return c.AccessToken
+}
+
+func (c *Config) GetTokenWithRefresh() (string, error) {
+	if env := os.Getenv("AMBIENT_TOKEN"); env != "" {
+		return env, nil
+	}
+
+	if c.AccessToken == "" {
+		return "", nil
+	}
+
+	expired, err := IsTokenExpired(c.AccessToken)
+	if err != nil || !expired {
+		return c.AccessToken, nil
+	}
+
+	if c.RefreshToken == "" || c.IssuerURL == "" || c.ClientID == "" {
+		return c.AccessToken, nil
+	}
+
+	newAccess, newRefresh, refreshErr := RefreshAccessToken(c.IssuerURL, c.ClientID, c.RefreshToken)
+	if refreshErr != nil {
+		return c.AccessToken, nil
+	}
+
+	c.AccessToken = newAccess
+	if newRefresh != "" {
+		c.RefreshToken = newRefresh
+	}
+
+	if saveErr := Save(c); saveErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to persist refreshed token: %v\n", saveErr)
+	}
+
+	return c.AccessToken, nil
 }
 
 // GetRequestTimeout returns the request timeout duration with fallback to default

--- a/components/ambient-cli/pkg/config/token.go
+++ b/components/ambient-cli/pkg/config/token.go
@@ -1,7 +1,11 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -46,4 +50,50 @@ func IsTokenExpired(tokenStr string) (bool, error) {
 	}
 
 	return time.Now().After(expiry), nil
+}
+
+func RefreshAccessToken(issuerURL, clientID, refreshToken string) (accessToken, newRefreshToken string, err error) {
+	tokenURL := strings.TrimRight(issuerURL, "/") + "/protocol/openid-connect/token"
+
+	params := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {refreshToken},
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.PostForm(tokenURL, params)
+	if err != nil {
+		return "", "", fmt.Errorf("POST to token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.ErrorDescription != "" {
+			return "", "", fmt.Errorf("token refresh: %s", errResp.ErrorDescription)
+		}
+		return "", "", fmt.Errorf("token refresh: HTTP %d", resp.StatusCode)
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", "", fmt.Errorf("parse token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", "", fmt.Errorf("no access_token in refresh response")
+	}
+
+	return tokenResp.AccessToken, tokenResp.RefreshToken, nil
 }

--- a/components/ambient-cli/pkg/config/token_test.go
+++ b/components/ambient-cli/pkg/config/token_test.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -94,5 +98,145 @@ func TestIsTokenExpiredNoExp(t *testing.T) {
 	}
 	if expired {
 		t.Error("expected non-expired for token without exp claim")
+	}
+}
+
+func TestRefreshAccessToken_Success(t *testing.T) {
+	newAccessToken := makeJWT(jwt.MapClaims{"exp": float64(time.Now().Add(1 * time.Hour).Unix())})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if r.FormValue("grant_type") != "refresh_token" {
+			t.Errorf("expected grant_type=refresh_token, got %q", r.FormValue("grant_type"))
+		}
+		if r.FormValue("refresh_token") != "my-refresh-token" {
+			t.Errorf("expected refresh_token=my-refresh-token, got %q", r.FormValue("refresh_token"))
+		}
+		if r.FormValue("client_id") != "test-client" {
+			t.Errorf("expected client_id=test-client, got %q", r.FormValue("client_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":%q,"refresh_token":"new-refresh"}`, newAccessToken)
+	}))
+	defer srv.Close()
+
+	access, refresh, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if access != newAccessToken {
+		t.Errorf("access token mismatch")
+	}
+	if refresh != "new-refresh" {
+		t.Errorf("expected new-refresh, got %q", refresh)
+	}
+}
+
+func TestRefreshAccessToken_ErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid_grant","error_description":"Token is expired"}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := RefreshAccessToken(srv.URL, "test-client", "bad-refresh")
+	if err == nil {
+		t.Fatal("expected error for expired refresh token")
+	}
+}
+
+func TestRefreshAccessToken_NoAccessToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"refresh_token":"new-refresh"}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh")
+	if err == nil {
+		t.Fatal("expected error for missing access_token")
+	}
+}
+
+func TestGetTokenWithRefresh_ValidToken(t *testing.T) {
+	t.Setenv("AMBIENT_TOKEN", "")
+	validToken := makeJWT(jwt.MapClaims{"exp": float64(time.Now().Add(1 * time.Hour).Unix())})
+	cfg := &Config{AccessToken: validToken}
+
+	token, err := cfg.GetTokenWithRefresh()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != validToken {
+		t.Error("expected valid token returned as-is")
+	}
+}
+
+func TestGetTokenWithRefresh_ExpiredNoRefreshToken(t *testing.T) {
+	t.Setenv("AMBIENT_TOKEN", "")
+	expiredToken := makeJWT(jwt.MapClaims{"exp": float64(time.Now().Add(-1 * time.Hour).Unix())})
+	cfg := &Config{AccessToken: expiredToken}
+
+	token, err := cfg.GetTokenWithRefresh()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != expiredToken {
+		t.Error("expected expired token returned when no refresh available")
+	}
+}
+
+func TestGetTokenWithRefresh_ExpiredWithRefresh(t *testing.T) {
+	t.Setenv("AMBIENT_TOKEN", "")
+	expiredToken := makeJWT(jwt.MapClaims{"exp": float64(time.Now().Add(-1 * time.Hour).Unix())})
+	newAccessToken := makeJWT(jwt.MapClaims{"exp": float64(time.Now().Add(1 * time.Hour).Unix())})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp, _ := json.Marshal(map[string]string{
+			"access_token":  newAccessToken,
+			"refresh_token": "rotated-refresh",
+		})
+		w.Write(resp)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("AMBIENT_CONFIG", dir+"/config.json")
+
+	cfg := &Config{
+		AccessToken:  expiredToken,
+		RefreshToken: "old-refresh",
+		IssuerURL:    srv.URL,
+		ClientID:     "test-client",
+	}
+
+	token, err := cfg.GetTokenWithRefresh()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != newAccessToken {
+		t.Error("expected refreshed access token")
+	}
+	if cfg.RefreshToken != "rotated-refresh" {
+		t.Errorf("expected rotated refresh token, got %q", cfg.RefreshToken)
+	}
+}
+
+func TestGetTokenWithRefresh_EnvOverride(t *testing.T) {
+	t.Setenv("AMBIENT_TOKEN", "env-token-at-least-20chars")
+	cfg := &Config{AccessToken: "config-token"}
+
+	token, err := cfg.GetTokenWithRefresh()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "env-token-at-least-20chars" {
+		t.Errorf("expected env token, got %q", token)
 	}
 }

--- a/components/ambient-cli/pkg/connection/connection.go
+++ b/components/ambient-cli/pkg/connection/connection.go
@@ -17,21 +17,57 @@ func SetInsecureSkipTLSVerify(v bool) {
 	insecureSkipTLSVerify = v
 }
 
+// ClientFactory holds credentials for creating per-project SDK clients.
+type ClientFactory struct {
+	APIURL   string
+	Token    string
+	Insecure bool
+}
+
+// ForProject creates an SDK client scoped to the given project name.
+func (f *ClientFactory) ForProject(project string) (*sdkclient.Client, error) {
+	opts := []sdkclient.ClientOption{
+		sdkclient.WithUserAgent("acpctl/" + info.Version),
+	}
+	if f.Insecure {
+		opts = append(opts, sdkclient.WithInsecureSkipVerify())
+	}
+	return sdkclient.NewClient(f.APIURL, f.Token, project, opts...)
+}
+
 // NewClientFromConfig creates an SDK client from the saved configuration.
 func NewClientFromConfig() (*sdkclient.Client, error) {
+	factory, err := NewClientFactory()
+	if err != nil {
+		return nil, err
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
 
-	token := cfg.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not logged in; run 'acpctl login' first")
-	}
-
 	project := cfg.GetProject()
 	if project == "" {
 		return nil, fmt.Errorf("no project set; run 'acpctl config set project <name>' or set AMBIENT_PROJECT")
+	}
+
+	return factory.ForProject(project)
+}
+
+// NewClientFactory loads config and returns a factory for creating per-project clients.
+func NewClientFactory() (*ClientFactory, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	token, err := cfg.GetTokenWithRefresh()
+	if err != nil {
+		return nil, fmt.Errorf("token refresh: %w", err)
+	}
+	if token == "" {
+		return nil, fmt.Errorf("not logged in; run 'acpctl login' first")
 	}
 
 	apiURL := cfg.GetAPIUrl()
@@ -40,12 +76,9 @@ func NewClientFromConfig() (*sdkclient.Client, error) {
 		return nil, fmt.Errorf("invalid API URL %q: must include scheme and host (e.g. https://api.example.com)", apiURL)
 	}
 
-	opts := []sdkclient.ClientOption{
-		sdkclient.WithUserAgent("acpctl/" + info.Version),
-	}
-	if cfg.InsecureTLSVerify || insecureSkipTLSVerify {
-		opts = append(opts, sdkclient.WithInsecureSkipVerify())
-	}
-
-	return sdkclient.NewClient(apiURL, token, project, opts...)
+	return &ClientFactory{
+		APIURL:   apiURL,
+		Token:    token,
+		Insecure: cfg.InsecureTLSVerify || insecureSkipTLSVerify,
+	}, nil
 }

--- a/components/ambient-sdk/go-sdk/client/credential_api.go
+++ b/components/ambient-sdk/go-sdk/client/credential_api.go
@@ -70,6 +70,14 @@ func (a *CredentialAPI) Delete(ctx context.Context, id string) error {
 	return a.client.do(ctx, http.MethodDelete, a.basePath()+"/"+url.PathEscape(id), nil, http.StatusNoContent, nil)
 }
 
+func (a *CredentialAPI) GetToken(ctx context.Context, id string) (*types.CredentialTokenResponse, error) {
+	var result types.CredentialTokenResponse
+	if err := a.client.do(ctx, http.MethodGet, a.basePath()+"/"+url.PathEscape(id)+"/token", nil, http.StatusOK, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (a *CredentialAPI) ListAll(ctx context.Context, opts *types.ListOptions) *Iterator[types.Credential] {
 	return NewIterator(func(page int) (*types.CredentialList, error) {
 		o := *opts

--- a/components/ambient-sdk/go-sdk/types/credential.go
+++ b/components/ambient-sdk/go-sdk/types/credential.go
@@ -155,3 +155,9 @@ func (b *CredentialPatchBuilder) URL(v string) *CredentialPatchBuilder {
 func (b *CredentialPatchBuilder) Build() map[string]any {
 	return b.patch
 }
+
+type CredentialTokenResponse struct {
+	CredentialID string `json:"credential_id"`
+	Provider     string `json:"provider"`
+	Token        string `json:"token"`
+}


### PR DESCRIPTION
## Summary

PR 5 of the alpha-to-main migration ([plan](docs/internal/proposals/alpha-to-main-migration.md)).

- Adds new CLI subcommands: `credential`, `inbox`, `apply` (declarative resource management)
- TUI dashboard enhancements: session message streaming, agent editing, compose mode, port-forward status
- OAuth authorization code login flow (`login --authcode`)
- Session events streaming command
- Agent start with prompt support
- Credential token retrieval
- Demo scripts for GitHub, remote, and multi-agent workflows

### Conflict resolution

- Removed `client.Project()` parameter from all credential API calls (main's generated SDK scopes via `basePath()`)
- Fixed `Url()` → `URL()` naming convention (Go naming, main's generated builders)
- Removed `agent.Version` references (field doesn't exist in main's generated Agent type)
- Replaced `WatchSessionMessages` (alpha gRPC watcher) with `WatchMessages` (main's SSE-based API)
- Added `GetToken` method and `CredentialTokenResponse` type to SDK (needed by new `credential token` command)
- Restored main's `go.mod` (avoids Go 1.25 requirement from alpha's replace directives)
- Applied `gofmt` formatting fixes

### Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `gofmt -l .` ✅ (clean)
- `go test ./...` ✅ (all pass)

## Test plan

- [ ] Verify `go build ./...` passes in CI
- [ ] Verify all CLI tests pass
- [ ] Smoke test `acpctl credential list`, `acpctl inbox list`, `acpctl apply`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative apply for YAML/Kustomize manifests.
  * Credential management (list/get/create/update/delete/token) and runtime token injection.
  * Inbox messaging (list/send/mark-read/delete).
  * Session events streaming command and continuous/JSON follow for messages/send.
  * Project-scoped agent management and idempotent agent start; project-agent create/list.
  * Browser-based OAuth2 (auth-code PKCE) login and token refresh support.

* **Documentation**
  * Expanded CLI examples for login, projects, credentials, role bindings, agents, and apply.

* **Improvements**
  * Dashboard-first TUI with edit/compose/split-detail modes and multi-project session fetching.
  * New demo scripts and improved CLI UX (flags, examples, bulk delete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->