### PR TITLE
fix(ci): handle non-zero exit code in SDK version bump workflow

### DIFF
--- a/.github/workflows/sdk-version-bump.yml
+++ b/.github/workflows/sdk-version-bump.yml
@@ -50,8 +50,8 @@ jobs:
         env:
           PACKAGE_ARG: ${{ inputs.package || 'all' }}
         run: |
-          python scripts/sdk-version-bump.py --check-only --package "$PACKAGE_ARG"
-          EXIT_CODE=$?
+          EXIT_CODE=0
+          python scripts/sdk-version-bump.py --check-only --package "$PACKAGE_ARG" || EXIT_CODE=$?
 
           if [ "$EXIT_CODE" -eq 2 ]; then
             echo "updates_available=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- SDK version bump workflow has been failing daily since at least April 17
- Root cause: GitHub Actions' `set -e` aborts the shell when the Python check script exits with code 2 (meaning "updates available"), before `EXIT_CODE=$?` can capture it
- Fix: initialize `EXIT_CODE=0` and use `|| EXIT_CODE=$?` to safely capture non-zero exits

Pending SDK updates once this lands and the workflow re-runs:
- `claude-agent-sdk`: 0.1.50 → 0.1.64
- `anthropic`: 0.88.0 → 0.96.0

## Test plan
- [ ] Merge and trigger `SDK Version Bump` workflow manually
- [ ] Verify it creates a PR bumping the two SDK versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling in the SDK version update checking workflow to better capture and report script exit statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->