### PR TITLE
learned: Session data uses K8s CRDs not PostgreSQL (demo mo8yev8c)

### DIFF
--- a/docs/learned/corrections/2026-04-21-session-data-uses-k8s-crds-not-postgresql-demo-mo8yev8c.md
+++ b/docs/learned/corrections/2026-04-21-session-data-uses-k8s-crds-not-postgresql-demo-mo8yev8c.md
@@ -1,0 +1,10 @@
+---
+type: correction
+date: 2026-04-21T18:26:27Z
+author: system-serviceaccount-ambient-code-test-user
+title: "Session data uses K8s CRDs not PostgreSQL (demo mo8yev8c)"
+---
+
+The Ambient Code Platform stores session data in Kubernetes Custom Resources (AgenticSession CRDs), not in PostgreSQL. The backend creates the CR, the operator watches it and creates a K8s Job to run the agent. PostgreSQL is only used by the ambient-api-server component for its own data model.
+
+Source: User corrections during session — agent incorrectly described the storage layer.


### PR DESCRIPTION
## New Memory

**Type:** correction
**Source:** Manual entry

---

The Ambient Code Platform stores session data in Kubernetes Custom Resources (AgenticSession CRDs), not in PostgreSQL. The backend creates the CR, the operator watches it and creates a K8s Job to run the agent. PostgreSQL is only used by the ambient-api-server component for its own data model.

Source: User corrections during session — agent incorrectly described the storage layer.