### PR TITLE
learned: Session data uses K8s CRDs not PostgreSQL (demo mo8yuc4j)

### DIFF
--- a/docs/learned/corrections/2026-04-21-session-data-uses-k8s-crds-not-postgresql-demo-mo8yuc4j.md
+++ b/docs/learned/corrections/2026-04-21-session-data-uses-k8s-crds-not-postgresql-demo-mo8yuc4j.md
@@ -1,0 +1,8 @@
+---
+type: correction
+date: 2026-04-21T18:38:29Z
+author: system-serviceaccount-ambient-code-test-user
+title: "Session data uses K8s CRDs not PostgreSQL (demo mo8yuc4j)"
+---
+
+Session data uses K8s CRDs not PostgreSQL. The operator creates Jobs from CRDs. PostgreSQL is only used by the api-server.


### PR DESCRIPTION
## New Memory

**Type:** correction
**Source:** Manual entry

---

Session data uses K8s CRDs not PostgreSQL. The operator creates Jobs from CRDs. PostgreSQL is only used by the api-server.