### PR TITLE
Fix identity resolution for ServiceAccount tokens behind OAuth proxy

### DIFF
--- a/components/backend/server/server.go
+++ b/components/backend/server/server.go
@@ -161,12 +161,23 @@ func forwardedIdentityMiddleware() gin.HandlerFunc {
 			c.Set("forwardedAccessToken", v)
 		}
 
-		// Fallback: if userID is still empty, verify the Bearer token via
-		// TokenReview to securely resolve the ServiceAccount identity, then
-		// read the created-by-user-id annotation. This enables API key-
-		// authenticated requests to inherit the creating user's identity
-		// so that integration credentials (GitHub, Jira, GitLab) are accessible.
-		if c.GetString("userID") == "" && K8sClient != nil {
+		// Resolve the creating user's identity for ServiceAccount tokens.
+		// The OAuth proxy sets X-Forwarded-User to the SA subject
+		// (e.g. "system:serviceaccount:ns:sa-name"), which the code above
+		// sanitizes into a synthetic userID. That synthetic ID doesn't match
+		// the session owner, breaking credential RBAC. We resolve the SA's
+		// created-by-user-id annotation to get the real human identity.
+		//
+		// This runs in two cases:
+		// 1. X-Forwarded-User was a SA subject (set by OAuth proxy for API key requests)
+		// 2. No X-Forwarded-User at all (direct API key requests bypassing proxy)
+		resolveNeeded := c.GetString("userID") == ""
+		if !resolveNeeded {
+			if orig := c.GetString("userIDOriginal"); strings.HasPrefix(orig, "system:serviceaccount:") {
+				resolveNeeded = true
+			}
+		}
+		if resolveNeeded && K8sClient != nil {
 			if ns, saName, ok := resolveServiceAccountFromToken(c); ok {
 				sa, err := K8sClient.CoreV1().ServiceAccounts(ns).Get(c.Request.Context(), saName, v1.GetOptions{})
 				if err == nil && sa.Annotations != nil {


### PR DESCRIPTION
## Summary

- Fix `forwardedIdentityMiddleware` to resolve the creating user's identity when `X-Forwarded-User` is a ServiceAccount subject
- This enables API key-authenticated requests (mobile apps, CLI tools) to access integration credentials (GitHub, Jira, Google, GitLab)

## Problem

When a mobile app or CLI tool uses a K8s ServiceAccount JWT (created via "Access Keys"), the OAuth proxy sets `X-Forwarded-User` to the SA subject: `system:serviceaccount:stackrox-1:ambient-key-test-write-2b3908aa`.

The middleware sanitizes this into `system-serviceaccount-stackrox-1-ambient-key-test-write-2b3908aa` and sets it as `userID`. The SA annotation fallback (`created-by-user-id`) was guarded by `userID == ""`, which was never true — so the creating user's identity was never resolved.

This caused a cascade of failures:
1. AG-UI proxy forwards the synthetic SA identity as `X-Current-User-ID` to the runner
2. Runner uses it for credential requests (`X-Runner-Current-User` header)
3. Backend RBAC rejects because SA identity ≠ session owner identity
4. All credential providers fail → `PermissionError` → `RUN_ERROR` → agent run aborted

The web UI doesn't hit this because the OAuth proxy sets `X-Forwarded-User` to the human username (e.g. `userid`), not a SA subject.

## Fix

When `X-Forwarded-User` starts with `system:serviceaccount:`, also check the SA's `ambient-code.io/created-by-user-id` annotation and use the real human identity. This is the same annotation already set by the access key creation endpoint (`permissions.go:420`).

## Test plan

- [ ] Create an access key, send a prompt via API, verify agent responds with full credential access
- [ ] Verify web UI sessions continue working as before (human `X-Forwarded-User` values are unchanged)
- [ ] Verify SA tokens without the annotation still work (synthetic ID used as fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)