### PR TITLE
fix: use absolute paths for all Claude Code hook commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "scripts/hooks/pr-review-gate.sh"
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && bash scripts/hooks/pr-review-gate.sh"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/claude-hooks/convention-guard.sh"
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && bash scripts/claude-hooks/convention-guard.sh"
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/claude-hooks/auto-format.sh"
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && bash scripts/claude-hooks/auto-format.sh"
           }
         ]
       },
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/claude-hooks/stop-review.sh"
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && bash scripts/claude-hooks/stop-review.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- All hook commands in `.claude/settings.json` used relative paths (`scripts/hooks/...`), which fail when the shell's cwd isn't the repo root
- Prefix each with `cd "$(git rev-parse --show-toplevel)" &&` so hooks resolve reliably regardless of working directory
- Fixes the `stop-review.sh: No such file or directory` error seen at session end

## Test plan

- [x] Verify all hooks fire correctly from a non-root cwd
- [ ] Start a new Claude Code session and confirm stop hook runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to improve hook command execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->