### PR TITLE
fix(frontend): pass redirect_uri for multi-cluster GitHub App OAuth

### DIFF
--- a/components/frontend/README.md
+++ b/components/frontend/README.md
@@ -94,6 +94,10 @@ In production, put an OAuth/ingress proxy in front of the app to set these heade
   - Used by server-side API routes to reach the backend.
 - `FEEDBACK_URL` (optional)
   - URL for the feedback link in the masthead. If not set, the link will not appear.
+- `GITHUB_APP_SLUG` (required for GitHub integration)
+  - The slug of the GitHub App (e.g. `ambient-code`). Without this, the Connect button on the Integrations page is disabled.
+- `GITHUB_CALLBACK_URL` (optional)
+  - Explicit callback URL for GitHub App OAuth. Used when multiple clusters share one GitHub App. Falls back to `<current origin>/integrations/github/setup`. Must be registered as a callback URL in the GitHub App settings.
 - Optional dev helpers: `OC_USER`, `OC_EMAIL`, `OC_TOKEN`, `ENABLE_OC_WHOAMI=1`
 
 You can also put these in a `.env.local` file in this folder:

--- a/components/frontend/src/app/integrations/IntegrationsClient.tsx
+++ b/components/frontend/src/app/integrations/IntegrationsClient.tsx
@@ -10,9 +10,9 @@ import { PageHeader } from '@/components/page-header'
 import { useIntegrationsStatus } from '@/services/queries/use-integrations'
 import { Loader2 } from 'lucide-react'
 
-type Props = { appSlug?: string }
+type Props = { appSlug?: string; githubCallbackUrl?: string }
 
-export default function IntegrationsClient({ appSlug }: Props) {
+export default function IntegrationsClient({ appSlug, githubCallbackUrl }: Props) {
   const { data: integrations, isLoading, refetch } = useIntegrationsStatus()
 
   return (
@@ -38,6 +38,7 @@ export default function IntegrationsClient({ appSlug }: Props) {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <GitHubConnectionCard
                 appSlug={appSlug}
+                githubCallbackUrl={githubCallbackUrl}
                 showManageButton={true}
                 status={integrations?.github}
                 onRefresh={refetch}

--- a/components/frontend/src/app/integrations/page.tsx
+++ b/components/frontend/src/app/integrations/page.tsx
@@ -6,5 +6,6 @@ export const revalidate = 0
 
 export default function IntegrationsPage() {
   const appSlug = process.env.GITHUB_APP_SLUG
-  return <IntegrationsClient appSlug={appSlug} />
+  const githubCallbackUrl = process.env.GITHUB_CALLBACK_URL
+  return <IntegrationsClient appSlug={appSlug} githubCallbackUrl={githubCallbackUrl} />
 }

--- a/components/frontend/src/components/github-connection-card.tsx
+++ b/components/frontend/src/components/github-connection-card.tsx
@@ -11,6 +11,7 @@ import { toast } from 'sonner'
 
 type Props = {
   appSlug?: string
+  githubCallbackUrl?: string
   showManageButton?: boolean
   status?: {
     installed: boolean
@@ -27,7 +28,7 @@ type Props = {
   onRefresh?: () => void
 }
 
-export function GitHubConnectionCard({ appSlug, showManageButton = true, status, onRefresh }: Props) {
+export function GitHubConnectionCard({ appSlug, githubCallbackUrl, showManageButton = true, status, onRefresh }: Props) {
   const disconnectMutation = useDisconnectGitHub()
   const savePATMutation = useSaveGitHubPAT()
   const deletePATMutation = useDeleteGitHubPAT()
@@ -41,10 +42,8 @@ export function GitHubConnectionCard({ appSlug, showManageButton = true, status,
 
   const handleConnect = () => {
     if (!appSlug) return
-    // Let GitHub use the Callback URL configured in the App settings
-    // rather than overriding with redirect_uri (which GitHub ignores
-    // unless it matches a configured callback URL)
-    const url = `https://github.com/apps/${appSlug}/installations/new`
+    const callbackUrl = githubCallbackUrl || `${window.location.origin}/integrations/github/setup`
+    const url = `https://github.com/apps/${appSlug}/installations/new?redirect_uri=${encodeURIComponent(callbackUrl)}`
     window.location.href = url
   }
 

--- a/components/runners/ambient-runner/tests/test_shared_session_credentials.py
+++ b/components/runners/ambient-runner/tests/test_shared_session_credentials.py
@@ -12,6 +12,8 @@ from urllib.error import HTTPError
 import pytest
 
 from ambient_runner.platform.auth import (
+    _GH_WRAPPER_DIR,  # noqa: F401 — used via _auth_mod in gh wrapper tests
+    _GH_WRAPPER_PATH,  # noqa: F401 — used via _auth_mod in gh wrapper tests
     _GITHUB_TOKEN_FILE,
     _GITLAB_TOKEN_FILE,
     _fetch_credential,

--- a/components/runners/ambient-runner/tests/test_shared_session_credentials.py
+++ b/components/runners/ambient-runner/tests/test_shared_session_credentials.py
@@ -12,8 +12,6 @@ from urllib.error import HTTPError
 import pytest
 
 from ambient_runner.platform.auth import (
-    _GH_WRAPPER_DIR,
-    _GH_WRAPPER_PATH,
     _GITHUB_TOKEN_FILE,
     _GITLAB_TOKEN_FILE,
     _fetch_credential,


### PR DESCRIPTION
## Summary

- When multiple clusters share a single GitHub App, GitHub doesn't know which cluster to redirect back to after installation
- Pass `redirect_uri` in the GitHub App install URL so GitHub redirects to the correct cluster
- Adds `GITHUB_CALLBACK_URL` env var for explicit override; falls back to `window.location.origin + '/integrations/github/setup'`

## Root cause

The `handleConnect` function sent users to `https://github.com/apps/{slug}/installations/new` without a `redirect_uri`. GitHub would pick its default callback URL, which could point to a different cluster.

## Test plan

- [ ] Set `GITHUB_CALLBACK_URL` on frontend deployment, verify redirect goes to correct cluster
- [ ] Without `GITHUB_CALLBACK_URL` set, verify it falls back to current origin
- [ ] Verify GitHub App install flow completes successfully on multi-cluster setup

🤖 Generated with [Claude Code](https://claude.ai/code)