### PR TITLE
fix(api-server,control-plane): replace remaining AutoMigrate with raw SQL, fix CP_RUNTIME_NAMESPACE

### DIFF
--- a/components/ambient-control-plane/internal/config/config.go
+++ b/components/ambient-control-plane/internal/config/config.go
@@ -55,7 +55,7 @@ func Load() (*ControlPlaneConfig, error) {
 		Mode:                  envOrDefault("MODE", "kube"),
 		PlatformMode:          envOrDefault("PLATFORM_MODE", "standard"),
 		MPPConfigNamespace:    envOrDefault("MPP_CONFIG_NAMESPACE", "ambient-code--config"),
-		CPRuntimeNamespace:    envOrDefault("CP_RUNTIME_NAMESPACE", "ambient-code--runtime-int"),
+		CPRuntimeNamespace:    envOrDefault("CP_RUNTIME_NAMESPACE", envOrDefault("NAMESPACE", "ambient-code")),
 		OIDCTokenURL:          envOrDefault("OIDC_TOKEN_URL", "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"),
 		OIDCClientID:          os.Getenv("OIDC_CLIENT_ID"),
 		OIDCClientSecret:      os.Getenv("OIDC_CLIENT_SECRET"),

--- a/components/manifests/base/ambient-control-plane-service.yml
+++ b/components/manifests/base/ambient-control-plane-service.yml
@@ -45,6 +45,10 @@ spec:
           value: "kube"
         - name: LOG_LEVEL
           value: "info"
+        - name: CP_RUNTIME_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
## Summary
- Replace `AutoMigrate` in agents, inbox, and credentials initial migrations with raw `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` — fixes `pq: got 2 parameters but the statement requires 1` on non-fresh databases where tables already exist
- Fix `CP_RUNTIME_NAMESPACE` defaulting to MPP-specific `ambient-code--runtime-int` on vanilla OpenShift by falling back to `NAMESPACE` env var and adding downward API to base manifest

## Root Cause
GORM's postgres migrator injects `pgx.QueryExecModeSimpleProtocol` as a query parameter in `GetRows()` when `DriverName` is empty. Since rh-trex-ai uses `lib/pq` (not native pgx), this sentinel is counted as an extra bind parameter, causing the mismatch. This only triggers when `AutoMigrate` finds an already-existing table (ALTER TABLE path calls `ColumnTypes` → `GetRows`).

## Test plan
- [x] `go vet ./...` and `go build ./...` pass for both api-server and control-plane
- [x] Full api-server test suite passes (migrations run on fresh testcontainer PostgreSQL)
- [ ] CI builds image
- [ ] Deploy to UAT/Stage and verify migration init container succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the ambient control plane to dynamically derive its runtime namespace from the pod's actual namespace instead of using a fixed default value. This improves namespace configuration flexibility and ensures the control plane correctly identifies its runtime environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->