### PR TITLE
fix(manifests): add OIDC client credentials to control-plane deployment

### DIFF
--- a/components/manifests/base/ambient-control-plane-service.yml
+++ b/components/manifests/base/ambient-control-plane-service.yml
@@ -35,6 +35,16 @@ spec:
             secretKeyRef:
               name: ambient-control-plane-token
               key: token
+        - name: OIDC_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: ambient-api-server
+              key: clientId
+        - name: OIDC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: ambient-api-server
+              key: clientSecret
         - name: AMBIENT_API_SERVER_URL
           value: "https://ambient-api-server.ambient-code.svc:8000"
         - name: AMBIENT_GRPC_SERVER_ADDR


### PR DESCRIPTION
## Summary

- Add `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` env vars to the base control-plane deployment manifest, sourced from the `ambient-api-server` secret
- The control-plane was getting 401 errors because it sent K8s SA tokens that fail JWT verification against SSO JWKS keys. With OIDC client credentials, the CP obtains real SSO JWTs via the OIDC client credentials flow — matching the working MPP configuration
- Verified on Stage: CP acquires OIDC tokens and all gRPC watch streams establish successfully with no auth errors

## Root Cause

The rh-trex-ai framework's `AuthStreamInterceptor` unconditionally runs JWT verification after pre-auth interceptors, even when the pre-auth bearer token interceptor already authenticated the caller. This means K8s SA tokens (set via `AMBIENT_API_TOKEN`) fail with `invalid token: unknown kid` because their kid is not in the SSO JWKS. The OIDC approach bypasses this by providing actual SSO-issued JWTs.

## Test plan

- [x] Deployed to Stage and verified CP logs show `using OIDC client credentials token provider` and `OIDC token acquired`
- [x] All gRPC watch streams (sessions, projects, project_settings, users) established successfully
- [x] No 401 auth errors in CP or API server logs
- [ ] Release to UAT/production via Release button after merge

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The ambient-control-plane container now receives OIDC-related configuration: OIDC_CLIENT_ID and OIDC_CLIENT_SECRET are injected from the ambient-api-server secret (clientId and clientSecret keys).
  * No other environment variables or container settings were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->