### PR TITLE
fix(manifests): add CP token server Service and CP_TOKEN_URL for runner gRPC auth

### DIFF
--- a/components/manifests/base/ambient-control-plane-service.yml
+++ b/components/manifests/base/ambient-control-plane-service.yml
@@ -55,6 +55,8 @@ spec:
           value: "kube"
         - name: LOG_LEVEL
           value: "info"
+        - name: CP_TOKEN_URL
+          value: "http://ambient-control-plane.ambient-code.svc:8080/token"
         - name: CP_RUNTIME_NAMESPACE
           valueFrom:
             fieldRef:

--- a/components/manifests/base/ambient-control-plane-token-svc.yaml
+++ b/components/manifests/base/ambient-control-plane-token-svc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ambient-control-plane
+  labels:
+    app: ambient-control-plane
+spec:
+  selector:
+    app: ambient-control-plane
+  ports:
+    - name: token
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/components/manifests/base/kustomization.yaml
+++ b/components/manifests/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - rbac
 - platform
 - ambient-control-plane-service.yml
+- ambient-control-plane-token-svc.yaml
 
 # Default images (can be overridden by overlays)
 images:


### PR DESCRIPTION
## Summary

- Add a K8s Service (`ambient-control-plane`, port 8080) to expose the control-plane's token server
- Add `CP_TOKEN_URL` env var to the CP Deployment so it injects the token endpoint URL into runner pods
- Without these, runners start with an empty auth token and get `UNAUTHENTICATED` errors on all gRPC streams

## Root Cause

The control-plane runs a token server on `:8080` that runner pods call to exchange an RSA-encrypted session ID for an OIDC access token. The base manifests had neither a Service to make this endpoint reachable nor the `CP_TOKEN_URL` env var that tells the CP what URL to pass to runners. The MPP overlay already had both (with MPP-specific namespaces), but the base/production overlay did not.

## Test plan

- [x] Verified on Stage that runners get `UNAUTHENTICATED` without these changes
- [x] MPP overlay already uses this pattern successfully (self-contained, no deduplication needed)
- [ ] After merge + deploy to Stage, verify runner pods receive a non-empty `AMBIENT_CP_TOKEN_URL` and gRPC streams authenticate successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a token service endpoint for the control plane accessible within the cluster for internal authentication and communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->