### PR TITLE
fix(manifests): add roles permission to control-plane ClusterRole

### DIFF
--- a/components/manifests/base/rbac/control-plane-clusterrole.yaml
+++ b/components/manifests/base/rbac/control-plane-clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch"]
 # RoleBindings (reconcile group access from ProjectSettings)
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["rolebindings"]
+  resources: ["roles", "rolebindings"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 # Session runner resources (provision/deprovision per-session workloads in project namespaces)
 - apiGroups: [""]


### PR DESCRIPTION
## Summary

- Add `roles` to the control-plane ClusterRole alongside `rolebindings` in the `rbac.authorization.k8s.io` API group
- The CP's `ensureControlPlaneRBAC` (`project_reconciler.go:194`) creates a Role `ambient-control-plane-project-manager` in each project namespace, but the ClusterRole only granted access to `rolebindings` — causing `forbidden: cannot get resource "roles"` errors

## Test plan

- [x] Patched ClusterRole live on Stage — verified rule index 3 now includes `["roles", "rolebindings"]`
- [ ] After merge + deploy, verify CP logs no longer show RBAC errors for project reconciliation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded control plane permissions to include management of both roles and role bindings, in addition to existing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->