### PR TITLE
fix(manifests): reconcile base manifests with MPP — add missing CP and api-server config

### DIFF
--- a/components/manifests/base/ambient-control-plane-service.yml
+++ b/components/manifests/base/ambient-control-plane-service.yml
@@ -55,12 +55,44 @@ spec:
           value: "kube"
         - name: LOG_LEVEL
           value: "info"
+        - name: RUNNER_IMAGE
+          value: "quay.io/ambient_code/vteam_claude_runner:latest"
+        - name: MCP_IMAGE
+          value: "quay.io/ambient_code/vteam_mcp:latest"
+        - name: USE_VERTEX
+          valueFrom:
+            configMapKeyRef:
+              name: operator-config
+              key: USE_VERTEX
+              optional: true
+        - name: CLOUD_ML_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: operator-config
+              key: CLOUD_ML_REGION
+              optional: true
+        - name: ANTHROPIC_VERTEX_PROJECT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: operator-config
+              key: ANTHROPIC_VERTEX_PROJECT_ID
+              optional: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          valueFrom:
+            configMapKeyRef:
+              name: operator-config
+              key: GOOGLE_APPLICATION_CREDENTIALS
+              optional: true
         - name: CP_TOKEN_URL
           value: "http://ambient-control-plane.ambient-code.svc:8080/token"
         - name: CP_RUNTIME_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        volumeMounts:
+        - name: vertex-credentials
+          mountPath: /app/vertex
+          readOnly: true
         resources:
           requests:
             cpu: 50m
@@ -68,4 +100,9 @@ spec:
           limits:
             cpu: 200m
             memory: 256Mi
+      volumes:
+      - name: vertex-credentials
+        secret:
+          secretName: ambient-vertex
+          optional: true
       restartPolicy: Always

--- a/components/manifests/base/core/ambient-api-server-service.yml
+++ b/components/manifests/base/core/ambient-api-server-service.yml
@@ -32,6 +32,10 @@ spec:
         component: api
     spec:
       serviceAccountName: ambient-api-server
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: migration
           image: quay.io/ambient_code/vteam_api_server:latest
@@ -55,6 +59,13 @@ spec:
             capabilities:
               drop:
                 - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
       containers:
         - name: api-server
           image: quay.io/ambient_code/vteam_api_server:latest


### PR DESCRIPTION
## Summary

Gaps found by comparing the MPP overlay (which works) with base+production manifests:

- **Control-plane**: Add `RUNNER_IMAGE` and `MCP_IMAGE` env vars so CP can create runner Jobs and MCP sidecars. Add Vertex AI env vars (`USE_VERTEX`, `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_PROJECT_ID`, `GOOGLE_APPLICATION_CREDENTIALS`) from the `operator-config` ConfigMap (all `optional: true`), plus `ambient-vertex` secret volume mount
- **API server**: Add pod-level `securityContext` (`runAsNonRoot`, `seccompProfile: RuntimeDefault`) per project conventions. Add resource limits to the migration init container (50m/128Mi → 500m/512Mi)

## Test plan

- [ ] After merge + deploy to Stage, verify CP logs show runner image config and Vertex settings (if operator-config ConfigMap exists)
- [ ] Verify api-server pod starts successfully with new securityContext
- [ ] Verify migration init container completes within resource limits

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Vertex AI integration with credential configuration capabilities.

* **Chores**
  * Enhanced container security by enforcing non-root execution and runtime seccomp profiles.
  * Added resource request and limit constraints for improved deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->