### PR TITLE
fix(api-server): recognize OIDC service tokens as service callers for gRPC authz

### DIFF
--- a/components/ambient-api-server/pkg/middleware/bearer_token.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token.go
@@ -11,7 +11,10 @@ import (
 	pkgserver "github.com/openshift-online/rh-trex-ai/pkg/server"
 )
 
-const ambientAPITokenEnv = "AMBIENT_API_TOKEN"
+const (
+	ambientAPITokenEnv    = "AMBIENT_API_TOKEN"
+	grpcServiceAccountEnv = "GRPC_SERVICE_ACCOUNT"
+)
 
 var httpBypassPaths = map[string]bool{
 	"/healthcheck": true,
@@ -25,9 +28,13 @@ func init() {
 		glog.Infof("Service token auth disabled: %s not set", ambientAPITokenEnv)
 		return
 	}
+	serviceAccount := os.Getenv(grpcServiceAccountEnv)
 	glog.Infof("Service token auth enabled via %s (gRPC only)", ambientAPITokenEnv)
-	pkgserver.RegisterPreAuthGRPCUnaryInterceptor(bearerTokenGRPCUnaryInterceptor(token))
-	pkgserver.RegisterPreAuthGRPCStreamInterceptor(bearerTokenGRPCStreamInterceptor(token))
+	if serviceAccount != "" {
+		glog.Infof("OIDC service account username: %s", serviceAccount)
+	}
+	pkgserver.RegisterPreAuthGRPCUnaryInterceptor(bearerTokenGRPCUnaryInterceptor(token, serviceAccount))
+	pkgserver.RegisterPreAuthGRPCStreamInterceptor(bearerTokenGRPCStreamInterceptor(token, serviceAccount))
 }
 
 func extractBearerToken(header string) (string, error) {

--- a/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
@@ -16,7 +16,7 @@ var grpcBypassMethods = map[string]bool{
 	"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo": true,
 }
 
-func bearerTokenGRPCUnaryInterceptor(expectedToken string) grpc.UnaryServerInterceptor {
+func bearerTokenGRPCUnaryInterceptor(expectedToken, serviceAccountUsername string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if grpcBypassMethods[info.FullMethod] {
 			return handler(ctx, req)
@@ -29,6 +29,9 @@ func bearerTokenGRPCUnaryInterceptor(expectedToken string) grpc.UnaryServerInter
 						return handler(withCallerType(ctx, CallerTypeService), req)
 					}
 					if username := usernameFromJWT(token); username != "" {
+						if serviceAccountUsername != "" && username == serviceAccountUsername {
+							ctx = withCallerType(ctx, CallerTypeService)
+						}
 						return handler(auth.SetUsernameContext(ctx, username), req)
 					}
 				}
@@ -39,7 +42,7 @@ func bearerTokenGRPCUnaryInterceptor(expectedToken string) grpc.UnaryServerInter
 	}
 }
 
-func bearerTokenGRPCStreamInterceptor(expectedToken string) grpc.StreamServerInterceptor {
+func bearerTokenGRPCStreamInterceptor(expectedToken, serviceAccountUsername string) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if grpcBypassMethods[info.FullMethod] {
 			return handler(srv, ss)
@@ -53,6 +56,9 @@ func bearerTokenGRPCStreamInterceptor(expectedToken string) grpc.StreamServerInt
 					}
 					if username := usernameFromJWT(token); username != "" {
 						ctx := auth.SetUsernameContext(ss.Context(), username)
+						if serviceAccountUsername != "" && username == serviceAccountUsername {
+							ctx = withCallerType(ctx, CallerTypeService)
+						}
 						return handler(srv, &serviceCallerStream{ServerStream: ss, ctx: ctx})
 					}
 				}

--- a/components/manifests/base/core/ambient-api-server-service.yml
+++ b/components/manifests/base/core/ambient-api-server-service.yml
@@ -93,6 +93,12 @@ spec:
           env:
             - name: AMBIENT_ENV
               value: development
+            - name: GRPC_SERVICE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: ambient-api-server
+                  key: clientId
+                  optional: true
           ports:
             - name: api
               containerPort: 8000


### PR DESCRIPTION
## Summary

- Runner pods get OIDC tokens (SSO JWTs) from the CP token server for gRPC auth. These tokens pass JWT verification but carry the OIDC client username (`ocm-ams-service`), not the session creator's username
- `WatchSessionMessages` rejects the call with `PERMISSION_DENIED` because the JWT username doesn't match `session.CreatedByUserId`
- Add `GRPC_SERVICE_ACCOUNT` env var: when the JWT's `preferred_username` matches this value, the pre-auth interceptor sets `CallerTypeService`, bypassing per-user ownership checks — same as static `AMBIENT_API_TOKEN` calls
- The env var is sourced from `ambient-api-server` secret's `clientId` key (same OIDC client ID the CP uses), `optional: true`

## Test plan

- [ ] Merge and deploy to Stage (auto-deploy on push to main)
- [ ] Delete existing session, create new one via `acpctl start`
- [ ] Tail runner logs for 30s — verify no `PERMISSION_DENIED` errors on `WatchSessionMessages`
- [ ] Verify CP logs show clean gRPC watch streams

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service accounts can now authenticate via gRPC bearer tokens.

* **Chores**
  * Updated authentication middleware to read and configure service account credentials from environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->