### PR TITLE
fix(api-server): register pre-auth interceptors when only GRPC_SERVICE_ACCOUNT is set

### DIFF
--- a/components/ambient-api-server/pkg/middleware/bearer_token.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token.go
@@ -24,12 +24,14 @@ var httpBypassPaths = map[string]bool{
 
 func init() {
 	token := os.Getenv(ambientAPITokenEnv)
-	if token == "" {
-		glog.Infof("Service token auth disabled: %s not set", ambientAPITokenEnv)
+	serviceAccount := os.Getenv(grpcServiceAccountEnv)
+	if token == "" && serviceAccount == "" {
+		glog.Infof("Service token auth disabled: neither %s nor %s set", ambientAPITokenEnv, grpcServiceAccountEnv)
 		return
 	}
-	serviceAccount := os.Getenv(grpcServiceAccountEnv)
-	glog.Infof("Service token auth enabled via %s (gRPC only)", ambientAPITokenEnv)
+	if token != "" {
+		glog.Infof("Service token auth enabled via %s (gRPC only)", ambientAPITokenEnv)
+	}
 	if serviceAccount != "" {
 		glog.Infof("OIDC service account username: %s", serviceAccount)
 	}

--- a/components/ambient-api-server/pkg/middleware/bearer_token.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token.go
@@ -11,7 +11,10 @@ import (
 	pkgserver "github.com/openshift-online/rh-trex-ai/pkg/server"
 )
 
-const ambientAPITokenEnv = "AMBIENT_API_TOKEN"
+const (
+	ambientAPITokenEnv    = "AMBIENT_API_TOKEN"
+	grpcServiceAccountEnv = "GRPC_SERVICE_ACCOUNT"
+)
 
 var httpBypassPaths = map[string]bool{
 	"/healthcheck": true,
@@ -25,9 +28,13 @@ func init() {
 		glog.Infof("Service token auth disabled: %s not set", ambientAPITokenEnv)
 		return
 	}
+	serviceAccount := os.Getenv(grpcServiceAccountEnv)
 	glog.Infof("Service token auth enabled via %s (gRPC only)", ambientAPITokenEnv)
-	pkgserver.RegisterPreAuthGRPCUnaryInterceptor(bearerTokenGRPCUnaryInterceptor(token))
-	pkgserver.RegisterPreAuthGRPCStreamInterceptor(bearerTokenGRPCStreamInterceptor(token))
+	if serviceAccount != "" {
+		glog.Infof("OIDC service account username: %s", serviceAccount)
+	}
+	pkgserver.RegisterPreAuthGRPCUnaryInterceptor(bearerTokenGRPCUnaryInterceptor(token, serviceAccount))
+	pkgserver.RegisterPreAuthGRPCStreamInterceptor(bearerTokenGRPCStreamInterceptor(token, serviceAccount))
 }
 
 func extractBearerToken(header string) (string, error) {

--- a/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
@@ -16,7 +16,7 @@ var grpcBypassMethods = map[string]bool{
 	"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo": true,
 }
 
-func bearerTokenGRPCUnaryInterceptor(expectedToken string) grpc.UnaryServerInterceptor {
+func bearerTokenGRPCUnaryInterceptor(expectedToken, serviceAccountUsername string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if grpcBypassMethods[info.FullMethod] {
 			return handler(ctx, req)
@@ -29,6 +29,9 @@ func bearerTokenGRPCUnaryInterceptor(expectedToken string) grpc.UnaryServerInter
 						return handler(withCallerType(ctx, CallerTypeService), req)
 					}
 					if username := usernameFromJWT(token); username != "" {
+						if serviceAccountUsername != "" && username == serviceAccountUsername {
+							ctx = withCallerType(ctx, CallerTypeService)
+						}
 						return handler(auth.SetUsernameContext(ctx, username), req)
 					}
 				}
@@ -39,7 +42,7 @@ func bearerTokenGRPCUnaryInterceptor(expectedToken string) grpc.UnaryServerInter
 	}
 }
 
-func bearerTokenGRPCStreamInterceptor(expectedToken string) grpc.StreamServerInterceptor {
+func bearerTokenGRPCStreamInterceptor(expectedToken, serviceAccountUsername string) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if grpcBypassMethods[info.FullMethod] {
 			return handler(srv, ss)
@@ -53,6 +56,9 @@ func bearerTokenGRPCStreamInterceptor(expectedToken string) grpc.StreamServerInt
 					}
 					if username := usernameFromJWT(token); username != "" {
 						ctx := auth.SetUsernameContext(ss.Context(), username)
+						if serviceAccountUsername != "" && username == serviceAccountUsername {
+							ctx = withCallerType(ctx, CallerTypeService)
+						}
 						return handler(srv, &serviceCallerStream{ServerStream: ss, ctx: ctx})
 					}
 				}

--- a/components/manifests/base/core/ambient-api-server-service.yml
+++ b/components/manifests/base/core/ambient-api-server-service.yml
@@ -93,6 +93,12 @@ spec:
           env:
             - name: AMBIENT_ENV
               value: development
+            - name: GRPC_SERVICE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: ambient-api-server
+                  key: clientId
+                  optional: true
           ports:
             - name: api
               containerPort: 8000


### PR DESCRIPTION
## Summary

- Follow-up to #1452: the `init()` guard required `AMBIENT_API_TOKEN` to be non-empty before registering gRPC pre-auth interceptors
- On Stage/production with OIDC auth, `AMBIENT_API_TOKEN` is not set — only `GRPC_SERVICE_ACCOUNT` is — so interceptors were never registered and OIDC service tokens were not recognized as service callers
- Register interceptors when **either** env var is set

## Test plan

- [ ] After merge + auto-deploy, verify api-server logs show `OIDC service account username: ocm-ams-service`
- [ ] Create session via `acpctl start`, tail runner logs — no `PERMISSION_DENIED` on `WatchSessionMessages`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded gRPC authentication capabilities with support for service account-based authentication in addition to bearer token authentication.

* **Configuration**
  * Added `GRPC_SERVICE_ACCOUNT` environment variable to enable service account credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->