### PR TITLE
fix(api-server): register pre-auth interceptors when only GRPC_SERVICE_ACCOUNT is set

### DIFF
--- a/components/ambient-api-server/pkg/middleware/bearer_token.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token.go
@@ -24,12 +24,14 @@ var httpBypassPaths = map[string]bool{
 
 func init() {
 	token := os.Getenv(ambientAPITokenEnv)
-	if token == "" {
-		glog.Infof("Service token auth disabled: %s not set", ambientAPITokenEnv)
+	serviceAccount := os.Getenv(grpcServiceAccountEnv)
+	if token == "" && serviceAccount == "" {
+		glog.Infof("Service token auth disabled: neither %s nor %s set", ambientAPITokenEnv, grpcServiceAccountEnv)
 		return
 	}
-	serviceAccount := os.Getenv(grpcServiceAccountEnv)
-	glog.Infof("Service token auth enabled via %s (gRPC only)", ambientAPITokenEnv)
+	if token != "" {
+		glog.Infof("Service token auth enabled via %s (gRPC only)", ambientAPITokenEnv)
+	}
 	if serviceAccount != "" {
 		glog.Infof("OIDC service account username: %s", serviceAccount)
 	}


### PR DESCRIPTION
## Summary

Bug in #1452: the `init()` guard requires `AMBIENT_API_TOKEN` to be non-empty before registering gRPC pre-auth interceptors. On Stage, only `GRPC_SERVICE_ACCOUNT` is set — `AMBIENT_API_TOKEN` is not in the api-server env vars — so interceptors are never registered and the OIDC service caller logic is dead code.

## Evidence

Stage api-server env vars (no `AMBIENT_API_TOKEN`):
```
AMBIENT_ENV: production
GRPC_SERVICE_ACCOUNT: {secretKeyRef: {key: clientId, name: ambient-api-server}}
```

Stage api-server startup logs — no bearer token init messages, confirming early return:
```
I0423 23:54:22.927314  Enabling JWT authentication middleware
# no "Service token auth enabled" or "OIDC service account" line
```

Runner pods still getting `PERMISSION_DENIED` on `WatchSessionMessages` because the interceptor that would set `CallerTypeService` was never registered.

## Fix

Change `init()` guard from `if token == ""` to `if token == "" && serviceAccount == ""` — register interceptors when either env var is set.

## Test plan

- [ ] After merge + deploy, verify api-server logs show `OIDC service account username: ocm-ams-service`
- [ ] Create session, tail runner logs — no `PERMISSION_DENIED` on `WatchSessionMessages`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gRPC authentication middleware initialization to support multiple authentication configuration options simultaneously. Bearer token interceptors are now enabled based on the presence of either authentication method, providing greater flexibility in authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->