### PR TITLE
fix(api-server): handle Keycloak service-account- prefix in OIDC username matching

### DIFF
--- a/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
@@ -29,7 +29,7 @@ func bearerTokenGRPCUnaryInterceptor(expectedToken, serviceAccountUsername strin
 						return handler(withCallerType(ctx, CallerTypeService), req)
 					}
 					if username := usernameFromJWT(token); username != "" {
-						if serviceAccountUsername != "" && username == serviceAccountUsername {
+						if isServiceAccount(username, serviceAccountUsername) {
 							ctx = withCallerType(ctx, CallerTypeService)
 						}
 						return handler(auth.SetUsernameContext(ctx, username), req)
@@ -56,7 +56,7 @@ func bearerTokenGRPCStreamInterceptor(expectedToken, serviceAccountUsername stri
 					}
 					if username := usernameFromJWT(token); username != "" {
 						ctx := auth.SetUsernameContext(ss.Context(), username)
-						if serviceAccountUsername != "" && username == serviceAccountUsername {
+						if isServiceAccount(username, serviceAccountUsername) {
 							ctx = withCallerType(ctx, CallerTypeService)
 						}
 						return handler(srv, &serviceCallerStream{ServerStream: ss, ctx: ctx})
@@ -91,6 +91,16 @@ func usernameFromJWT(tokenString string) string {
 		}
 	}
 	return ""
+}
+
+const keycloakServiceAccountPrefix = "service-account-"
+
+func isServiceAccount(jwtUsername, configuredAccount string) bool {
+	if configuredAccount == "" {
+		return false
+	}
+	return jwtUsername == configuredAccount ||
+		jwtUsername == keycloakServiceAccountPrefix+configuredAccount
 }
 
 type serviceCallerStream struct {

--- a/components/ambient-api-server/pkg/middleware/bearer_token_test.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token_test.go
@@ -38,6 +38,29 @@ func TestExtractBearerToken(t *testing.T) {
 	}
 }
 
+func TestIsServiceAccount(t *testing.T) {
+	tests := []struct {
+		name              string
+		jwtUsername       string
+		configuredAccount string
+		want              bool
+	}{
+		{"exact match", "ocm-ams-service", "ocm-ams-service", true},
+		{"keycloak prefixed match", "service-account-ocm-ams-service", "ocm-ams-service", true},
+		{"no match", "other-user", "ocm-ams-service", false},
+		{"empty configured", "service-account-ocm-ams-service", "", false},
+		{"empty jwt username", "", "ocm-ams-service", false},
+		{"partial prefix no match", "service-account-other", "ocm-ams-service", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isServiceAccount(tt.jwtUsername, tt.configuredAccount); got != tt.want {
+				t.Errorf("isServiceAccount(%q, %q) = %v, want %v", tt.jwtUsername, tt.configuredAccount, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBearerTokenAuth(t *testing.T) {
 	const validToken = "test-secret-token"
 	handler := BearerTokenAuth(validToken)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Keycloak client credentials tokens set `preferred_username` to `service-account-<clientId>` (e.g. `service-account-ocm-ams-service`), not the raw client ID (`ocm-ams-service`)
- `GRPC_SERVICE_ACCOUNT` is populated from the `clientId` secret key, so the comparison `username == serviceAccountUsername` always failed
- Adds `isServiceAccount()` helper that matches both the raw client ID and the Keycloak-prefixed form
- Includes unit tests for the new helper

## Evidence
Decoded the actual OIDC token issued by Red Hat SSO via client credentials grant:
```json
{
  "sub": "90d50f80-2bb6-4b7a-8781-9e322691dc33",
  "preferred_username": "service-account-ocm-ams-service",
  "azp": "ocm-ams-service"
}
```
This confirms the `service-account-` prefix is added by Keycloak for all client credentials tokens.

## Root cause trace
1. Runner calls CP token server → gets raw OIDC access token
2. Runner sends token to api-server gRPC → pre-auth interceptor extracts `preferred_username` = `"service-account-ocm-ams-service"`
3. Interceptor compares to `GRPC_SERVICE_ACCOUNT` = `"ocm-ams-service"` → **no match** → CallerTypeService not set
4. Framework auth interceptor runs → sets username = `"service-account-ocm-ams-service"`
5. WatchSessionMessages checks `IsServiceCaller(ctx)` → false
6. Falls through to ownership check: `"service-account-ocm-ams-service" \!= "mturansk"` → **PERMISSION_DENIED**

## Test plan
- [x] Unit tests pass (`TestIsServiceAccount` — 6 cases)
- [ ] Merge and auto-deploy to Stage
- [ ] Verify api-server logs show CallerTypeService being set
- [ ] Verify runner WatchSessionMessages no longer returns PERMISSION_DENIED

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced service account caller attribution by implementing improved validation logic that provides more reliable authentication handling and better support for various account configuration formats and username extraction scenarios.

* **Tests**
  * Added extensive test coverage for service account validation, comprehensively validating multiple authentication scenarios including exact account matches, formatted variations, and edge cases involving empty configurations or partial matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->