### PR TITLE
fix: resolve golangci-lint errcheck and unused findings

### DIFF
--- a/components/ambient-api-server/plugins/proxy/proxy_test.go
+++ b/components/ambient-api-server/plugins/proxy/proxy_test.go
@@ -12,9 +12,9 @@ import (
 
 // buildHandler wraps a mock backend with the proxy middleware and a sentinel native handler.
 func buildHandler(backendURL string) http.Handler {
-	nativeHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	nativeHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("native"))
+		_, _ = w.Write([]byte("native"))
 	})
 	mw := proxy.NewBackendProxyMiddleware(backendURL)
 	return mw(nativeHandler)
@@ -62,9 +62,9 @@ func TestNativePath_Metrics_PassesThrough(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestProxyPath_ForwardsToBackend(t *testing.T) {
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("from-backend"))
+		_, _ = w.Write([]byte("from-backend"))
 	}))
 	defer backend.Close()
 

--- a/components/ambient-api-server/plugins/scheduledSessions/handler.go
+++ b/components/ambient-api-server/plugins/scheduledSessions/handler.go
@@ -1,7 +1,6 @@
 package scheduledSessions
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
@@ -198,11 +197,4 @@ func (h *scheduledSessionHandler) Runs(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	handlers.HandleList(w, r, cfg)
-}
-
-// writeJSON is a helper for action endpoints that don't use the handler framework.
-func writeJSON(w http.ResponseWriter, status int, v interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
 }

--- a/components/ambient-api-server/plugins/sessions/handlerunit/handler_agui_test.go
+++ b/components/ambient-api-server/plugins/sessions/handlerunit/handler_agui_test.go
@@ -61,7 +61,9 @@ func TestAGUICapabilities_NoRunner_ReturnsStub(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body)
 	}
 	var m map[string]interface{}
-	json.Unmarshal(rr.Body.Bytes(), &m)
+	if err := json.Unmarshal(rr.Body.Bytes(), &m); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if m["framework"] != "unknown" {
 		t.Errorf("expected framework=unknown, got %v", m["framework"])
 	}
@@ -81,7 +83,9 @@ func TestMCPStatus_NoRunner_ReturnsStub(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body)
 	}
 	var m map[string]interface{}
-	json.Unmarshal(rr.Body.Bytes(), &m)
+	if err := json.Unmarshal(rr.Body.Bytes(), &m); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if _, ok := m["servers"]; !ok {
 		t.Error("expected servers field in stub response")
 	}

--- a/components/ambient-api-server/plugins/sessions/handlerunit/handler_operational_test.go
+++ b/components/ambient-api-server/plugins/sessions/handlerunit/handler_operational_test.go
@@ -78,7 +78,9 @@ func TestWorkflowMetadata_NoWorkflow_ReturnsNullWorkflow(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body)
 	}
 	var m map[string]interface{}
-	json.Unmarshal(rr.Body.Bytes(), &m)
+	if err := json.Unmarshal(rr.Body.Bytes(), &m); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if m["workflow"] != nil {
 		t.Errorf("expected null workflow, got %v", m["workflow"])
 	}
@@ -109,7 +111,9 @@ func TestWorkflowMetadata_WithWorkflow_ReturnsMetadata(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr2.Code, rr2.Body)
 	}
 	var m map[string]interface{}
-	json.Unmarshal(rr2.Body.Bytes(), &m)
+	if err := json.Unmarshal(rr2.Body.Bytes(), &m); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if m["workflow"] == nil {
 		t.Error("expected non-null workflow in metadata")
 	}

--- a/components/ambient-api-server/plugins/sessions/handlerunit/handler_runner_proxy_test.go
+++ b/components/ambient-api-server/plugins/sessions/handlerunit/handler_runner_proxy_test.go
@@ -10,32 +10,6 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-func seedWithRunner(t *testing.T, svc SessionService) *Session {
-	t.Helper()
-	proj := "proj-runner"
-	sess, err := svc.Create(t.Context(), &Session{
-		Name:      "runner-session",
-		ProjectId: &proj,
-	})
-	if err != nil {
-		t.Fatalf("seed runner session: %v", err)
-	}
-	// Populate KubeCrName + KubeNamespace so runnerBaseURL returns a non-empty URL.
-	crName := "test-runner"
-	ns := "test-ns"
-	sess.KubeCrName = &crName
-	sess.KubeNamespace = &ns
-	updated, err := svc.Replace(t.Context(), sess)
-	if err != nil {
-		t.Fatalf("set runner fields: %v", err)
-	}
-	return updated
-}
-
-// ---------------------------------------------------------------------------
 // Workspace list
 // ---------------------------------------------------------------------------
 

--- a/components/ambient-api-server/plugins/sessions/handlerunit/handler_subresource_test.go
+++ b/components/ambient-api-server/plugins/sessions/handlerunit/handler_subresource_test.go
@@ -216,7 +216,9 @@ func TestAddRepo_DefaultBranch(t *testing.T) {
 	}
 	m := decodeSession(t, rr.Body.Bytes())
 	var repos []RepoEntry
-	json.Unmarshal([]byte(m["repos"].(string)), &repos)
+	if err := json.Unmarshal([]byte(m["repos"].(string)), &repos); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if repos[0].Branch != "main" {
 		t.Errorf("expected default branch=main, got %s", repos[0].Branch)
 	}
@@ -262,7 +264,9 @@ func TestAddRepo_Accumulates(t *testing.T) {
 		t.Fatal(err)
 	}
 	var repos []RepoEntry
-	json.Unmarshal([]byte(*sess.Repos), &repos)
+	if err := json.Unmarshal([]byte(*sess.Repos), &repos); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if len(repos) != 2 {
 		t.Errorf("expected 2 repos, got %d", len(repos))
 	}
@@ -303,7 +307,9 @@ func TestRemoveRepo_Success(t *testing.T) {
 	}
 	sess, _ := svc.Get(context.Background(), src.ID)
 	var repos []RepoEntry
-	json.Unmarshal([]byte(*sess.Repos), &repos)
+	if err := json.Unmarshal([]byte(*sess.Repos), &repos); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if len(repos) != 1 {
 		t.Errorf("expected 1 repo after removal, got %d", len(repos))
 	}
@@ -362,7 +368,9 @@ func TestSetWorkflow_DefaultBranch(t *testing.T) {
 	}
 	sess, _ := svc.Get(context.Background(), src.ID)
 	var wf SetWorkflowRequest
-	json.Unmarshal([]byte(*sess.WorkflowId), &wf)
+	if err := json.Unmarshal([]byte(*sess.WorkflowId), &wf); err != nil {
+		t.Fatalf("json: %v", err)
+	}
 	if wf.Branch != "main" {
 		t.Errorf("expected default branch=main, got %s", wf.Branch)
 	}


### PR DESCRIPTION
## Summary
- Remove unused `writeJSON` function from `scheduledSessions/handler.go`
- Remove unused `seedWithRunner` function from `sessions/handlerunit/handler_runner_proxy_test.go`
- Check all `json.Unmarshal` return values in handlerunit test files (errcheck)

Follow-up to #1503 — resolves remaining golangci-lint CI failures.

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] All handlerunit tests pass
- [ ] CI golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling in test assertions for JSON response validation.
  * Simplified test handler implementations for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->