### PR TITLE
feat(frontend): add catch-all proxy route for ambient API v1

### DIFF
--- a/components/frontend/.env.example
+++ b/components/frontend/.env.example
@@ -12,6 +12,10 @@ GITHUB_APP_SLUG=ambient-code-vteam
 # Default local backend URL
 BACKEND_URL=http://localhost:8080/api
 
+# Ambient API Server URL (ambient-api-server microservice)
+# Proxied via /api/ambient/v1/... catch-all route
+API_SERVER_URL=http://localhost:8000
+
 # Optional: OpenShift identity details for local development
 # If you login with 'oc login', you can set these to forward identity headers
 OC_TOKEN=

--- a/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
+++ b/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
@@ -39,6 +39,10 @@ async function proxyRequest(
     );
   }
 
+  if (!upstream.ok) {
+    console.error('[Ambient API proxy] upstream error:', upstream.status, pathStr);
+  }
+
   // SSE/streaming: pipe through without buffering
   const upstreamContentType = upstream.headers.get('content-type') || '';
   if (
@@ -49,8 +53,8 @@ async function proxyRequest(
 
     if (upstream.body) {
       upstream.body.pipeTo(writable).catch((err: unknown) => {
-        // AbortError is normal when client disconnects
-        if (err instanceof Error && err.name !== 'AbortError') {
+        // AbortError / ResponseAborted is normal when client disconnects
+        if (err instanceof Error && err.name !== 'AbortError' && !err.message?.includes('ResponseAborted')) {
           console.error('Ambient API proxy pipe error:', err);
         }
       });

--- a/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
+++ b/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
@@ -1,35 +1,38 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { buildForwardHeadersAsync } from '@/lib/auth';
 import { API_SERVER_URL } from '@/lib/config';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+const METHODS_WITH_BODY = new Set(['POST', 'PUT', 'PATCH']);
+
 async function proxyRequest(
-  request: NextRequest,
+  request: Request,
   { params }: { params: Promise<{ path: string[] }> },
 ): Promise<Response> {
   const { path } = await params;
   if (path.some(s => s === '..' || s === '.')) {
-    return NextResponse.json({ error: 'invalid_path' }, { status: 400 });
+    return Response.json({ error: 'invalid_path' }, { status: 400 });
   }
   const pathStr = path.map(s => encodeURIComponent(s)).join('/');
   const url = new URL(`/api/ambient/v1/${pathStr}`, API_SERVER_URL);
-  url.search = request.nextUrl.search;
+  url.search = new URL(request.url).search;
 
   const headers = await buildForwardHeadersAsync(request);
 
-  // Forward the client's Accept header so the upstream can respond with the
-  // correct content type (e.g. text/event-stream for SSE endpoints).
   const accept = request.headers.get('accept');
   if (accept) {
     headers['Accept'] = accept;
   }
 
-  // Forward content-type for requests with bodies
   const contentType = request.headers.get('content-type');
   if (contentType) {
     headers['content-type'] = contentType;
+  }
+
+  let body: string | undefined;
+  if (METHODS_WITH_BODY.has(request.method)) {
+    body = await request.text();
   }
 
   let upstream: Response;
@@ -37,14 +40,12 @@ async function proxyRequest(
     upstream = await fetch(url.toString(), {
       method: request.method,
       headers,
-      body: request.body,
-      // @ts-expect-error -- Node.js fetch supports duplex for streaming request bodies
-      duplex: 'half',
+      body,
     });
   } catch (error: unknown) {
     console.error('[Ambient API proxy] fetch failed:', error instanceof Error ? error.message : error);
-    return NextResponse.json(
-      { error: 'upstream_unavailable' },
+    return Response.json(
+      { error: 'Failed to reach ambient API', details: error instanceof Error ? error.message : String(error) },
       { status: 502 },
     );
   }
@@ -53,7 +54,6 @@ async function proxyRequest(
     console.error('[Ambient API proxy] upstream error:', upstream.status, pathStr);
   }
 
-  // SSE/streaming: pipe through without buffering
   const upstreamContentType = upstream.headers.get('content-type') || '';
   if (
     upstreamContentType.includes('text/event-stream') ||
@@ -63,11 +63,12 @@ async function proxyRequest(
 
     if (upstream.body) {
       upstream.body.pipeTo(writable).catch((err: unknown) => {
-        // AbortError / ResponseAborted is normal when client disconnects
         if (err instanceof Error && err.name !== 'AbortError' && !err.message?.includes('ResponseAborted')) {
           console.error('Ambient API proxy pipe error:', err);
         }
       });
+    } else {
+      writable.close();
     }
 
     return new Response(readable, {
@@ -81,13 +82,10 @@ async function proxyRequest(
     });
   }
 
-  // Non-streaming: buffer and forward
-  const body = await upstream.arrayBuffer();
-  return new Response(body, {
+  const text = await upstream.text();
+  return new Response(text, {
     status: upstream.status,
-    headers: {
-      'Content-Type': upstreamContentType || 'application/json',
-    },
+    headers: { 'Content-Type': upstreamContentType || 'application/json' },
   });
 }
 

--- a/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
+++ b/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
@@ -10,11 +10,21 @@ async function proxyRequest(
   { params }: { params: Promise<{ path: string[] }> },
 ): Promise<Response> {
   const { path } = await params;
+  if (path.some(s => s === '..' || s === '.')) {
+    return NextResponse.json({ error: 'invalid_path' }, { status: 400 });
+  }
   const pathStr = path.map(s => encodeURIComponent(s)).join('/');
   const url = new URL(`/api/ambient/v1/${pathStr}`, API_SERVER_URL);
   url.search = request.nextUrl.search;
 
   const headers = await buildForwardHeadersAsync(request);
+
+  // Forward the client's Accept header so the upstream can respond with the
+  // correct content type (e.g. text/event-stream for SSE endpoints).
+  const accept = request.headers.get('accept');
+  if (accept) {
+    headers['Accept'] = accept;
+  }
 
   // Forward content-type for requests with bodies
   const contentType = request.headers.get('content-type');
@@ -32,9 +42,9 @@ async function proxyRequest(
       duplex: 'half',
     });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Ambient API proxy] fetch failed:', error instanceof Error ? error.message : error);
     return NextResponse.json(
-      { error: 'upstream_unavailable', message },
+      { error: 'upstream_unavailable' },
       { status: 502 },
     );
   }

--- a/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
+++ b/components/frontend/src/app/api/ambient/v1/[...path]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildForwardHeadersAsync } from '@/lib/auth';
+import { API_SERVER_URL } from '@/lib/config';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function proxyRequest(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const { path } = await params;
+  const pathStr = path.map(s => encodeURIComponent(s)).join('/');
+  const url = new URL(`/api/ambient/v1/${pathStr}`, API_SERVER_URL);
+  url.search = request.nextUrl.search;
+
+  const headers = await buildForwardHeadersAsync(request);
+
+  // Forward content-type for requests with bodies
+  const contentType = request.headers.get('content-type');
+  if (contentType) {
+    headers['content-type'] = contentType;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url.toString(), {
+      method: request.method,
+      headers,
+      body: request.body,
+      // @ts-expect-error -- Node.js fetch supports duplex for streaming request bodies
+      duplex: 'half',
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      { error: 'upstream_unavailable', message },
+      { status: 502 },
+    );
+  }
+
+  // SSE/streaming: pipe through without buffering
+  const upstreamContentType = upstream.headers.get('content-type') || '';
+  if (
+    upstreamContentType.includes('text/event-stream') ||
+    upstreamContentType.includes('application/x-ndjson')
+  ) {
+    const { readable, writable } = new TransformStream();
+
+    if (upstream.body) {
+      upstream.body.pipeTo(writable).catch((err: unknown) => {
+        // AbortError is normal when client disconnects
+        if (err instanceof Error && err.name !== 'AbortError') {
+          console.error('Ambient API proxy pipe error:', err);
+        }
+      });
+    }
+
+    return new Response(readable, {
+      status: upstream.status,
+      headers: {
+        'Content-Type': upstreamContentType,
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    });
+  }
+
+  // Non-streaming: buffer and forward
+  const body = await upstream.arrayBuffer();
+  return new Response(body, {
+    status: upstream.status,
+    headers: {
+      'Content-Type': upstreamContentType || 'application/json',
+    },
+  });
+}
+
+export const GET = proxyRequest;
+export const POST = proxyRequest;
+export const PUT = proxyRequest;
+export const PATCH = proxyRequest;
+export const DELETE = proxyRequest;

--- a/components/frontend/src/lib/config.ts
+++ b/components/frontend/src/lib/config.ts
@@ -1,6 +1,9 @@
 // API configuration for frontend
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8080/api'
 
+// Ambient API Server URL (ambient-api-server microservice)
+export const API_SERVER_URL = process.env.API_SERVER_URL || 'http://localhost:8000'
+
 /**
  * Get the API base URL for frontend requests
  */

--- a/components/frontend/src/lib/env.ts
+++ b/components/frontend/src/lib/env.ts
@@ -12,6 +12,9 @@ type EnvConfig = {
   // Backend API URL (server-side only)
   BACKEND_URL: string;
 
+  // Ambient API Server URL (server-side only)
+  API_SERVER_URL: string;
+
   // GitHub configuration (public)
   GITHUB_APP_SLUG: string;
 
@@ -64,6 +67,7 @@ function getBooleanEnv(key: string, defaultValue = false): boolean {
 export const env: EnvConfig = {
   NODE_ENV: (process.env.NODE_ENV || 'development') as Environment,
   BACKEND_URL: getEnv('BACKEND_URL', 'http://localhost:8080/api'),
+  API_SERVER_URL: getEnv('API_SERVER_URL', 'http://localhost:8000'),
   GITHUB_APP_SLUG: getEnv('GITHUB_APP_SLUG', 'ambient-code-vteam'),
   FEEDBACK_URL: getOptionalEnv('FEEDBACK_URL'),
   OC_TOKEN: getOptionalEnv('OC_TOKEN'),

--- a/components/manifests/base/core/frontend-deployment.yaml
+++ b/components/manifests/base/core/frontend-deployment.yaml
@@ -24,6 +24,8 @@ spec:
         env:
         - name: BACKEND_URL
           value: "http://backend-service:8080/api"
+        - name: API_SERVER_URL
+          value: "http://ambient-api-server:8000"
         - name: NODE_ENV
           value: "production"
         - name: GITHUB_APP_SLUG

--- a/components/manifests/overlays/e2e/frontend-test-patch.yaml
+++ b/components/manifests/overlays/e2e/frontend-test-patch.yaml
@@ -12,6 +12,9 @@ spec:
         # Backend API URL for server-side Next.js API routes
         - name: BACKEND_URL
           value: "http://backend-service.ambient-code.svc.cluster.local:8080/api"
+        # API Server URL for intelligence and other ambient-api-server proxy routes
+        - name: API_SERVER_URL
+          value: "http://ambient-api-server.ambient-code.svc.cluster.local:8000"
         # E2E testing: provide token for both server-side and client-side
         - name: OC_TOKEN
           valueFrom:

--- a/components/manifests/overlays/local-dev/frontend-deployment-patch.yaml
+++ b/components/manifests/overlays/local-dev/frontend-deployment-patch.yaml
@@ -14,6 +14,8 @@ spec:
           value: "https://vteam-backend-vteam-dev.apps-crc.testing/api"
         - name: BACKEND_URL
           value: "http://vteam-backend:8080/api"
+        - name: API_SERVER_URL
+          value: "http://ambient-api-server:8000"
         - name: OC_USER
           value: "developer"
         - name: OC_EMAIL

--- a/components/manifests/overlays/local-dev/frontend-patch.yaml
+++ b/components/manifests/overlays/local-dev/frontend-patch.yaml
@@ -14,6 +14,8 @@ spec:
           value: "https://vteam-backend-vteam-dev.apps-crc.testing/api"
         - name: BACKEND_URL
           value: "http://vteam-backend:8080/api"
+        - name: API_SERVER_URL
+          value: "http://ambient-api-server:8000"
         - name: OC_USER
           value: "developer"
         - name: OC_EMAIL


### PR DESCRIPTION
## Summary

- Add `/api/ambient/v1/[...path]` catch-all Next.js API route that proxies all HTTP methods (GET, POST, PUT, PATCH, DELETE) to the `ambient-api-server` backend
- Add `API_SERVER_URL` env var configuration to `config.ts`, `env.ts`, and `.env.example` (default: `http://localhost:8000`)
- Support SSE/streaming responses (`text/event-stream`, `application/x-ndjson`) via `TransformStream` pipe-through pattern matching existing AG-UI events proxy
- Forward auth headers via `buildForwardHeadersAsync` for consistent authentication

## Test plan

- [x] `tsc --noEmit` passes with 0 errors
- [x] `npm run build` passes with 0 errors, 0 warnings
- [ ] Manual test: verify proxy forwards requests to ambient-api-server in a local dev environment
- [ ] Manual test: verify SSE streaming works through the proxy
- [ ] Manual test: verify 502 error handling when ambient-api-server is unavailable

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated ambient API server support with request forwarding and streaming response handling
  * Added `API_SERVER_URL` configuration variable with environment-specific defaults for the ambient API service
  * Updated deployment configurations across local development, E2E testing, and production environments
  * Support for multiple HTTP methods and batch response formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->