### PR TITLE
fix(sdk): extend generator to support typed action methods

### DIFF
--- a/components/ambient-sdk/generator/main.go
+++ b/components/ambient-sdk/generator/main.go
@@ -489,6 +489,7 @@ func loadTemplate(path string) (*template.Template, error) {
 	funcMap := template.FuncMap{
 		"snakeCase": toSnakeCase,
 		"lower":     strings.ToLower,
+		"upper":     strings.ToUpper,
 		"title": func(s string) string {
 			if s == "" {
 				return s

--- a/components/ambient-sdk/generator/model.go
+++ b/components/ambient-sdk/generator/model.go
@@ -18,8 +18,14 @@ type Resource struct {
 	HasDelete         bool
 	HasPatch          bool
 	HasStatusPatch    bool
-	Actions           []string
+	Actions           []Action
 	IsSubResource     bool
+}
+
+type Action struct {
+	Name       string
+	Method     string
+	ReturnType string
 }
 
 type Field struct {

--- a/components/ambient-sdk/generator/parser.go
+++ b/components/ambient-sdk/generator/parser.go
@@ -254,7 +254,7 @@ func extractResource(name, pathSegment string, doc *subSpecDoc) (*Resource, erro
 
 	hasDelete := checkHasDelete(doc.Paths, pathSegment)
 	hasPatch := checkHasPatch(doc.Paths, pathSegment)
-	actions := detectActions(doc.Paths, pathSegment)
+	actions := detectActions(doc.Paths, pathSegment, name)
 	parentPath := inferParentPath(pathSegment)
 	isSubResource := parentPath != ""
 
@@ -458,11 +458,11 @@ func checkHasDelete(paths map[string]interface{}, pathSegment string) bool {
 	return hasDelete
 }
 
-func detectActions(paths map[string]interface{}, pathSegment string) []string {
+func detectActions(paths map[string]interface{}, pathSegment string, resourceName string) []Action {
 	basePath := extractBasePath(paths)
 	fullCollection := basePath + "/" + pathSegment
-	knownActions := []string{"start", "stop"}
-	var found []string
+	knownActions := []string{"start", "stop", "suspend", "resume", "trigger", "runs"}
+	var found []Action
 	for _, action := range knownActions {
 		for path, val := range paths {
 			if !strings.HasPrefix(path, fullCollection+"/") {
@@ -475,13 +475,74 @@ func detectActions(paths map[string]interface{}, pathSegment string) []string {
 			if !ok {
 				continue
 			}
-			if _, hasPost := pathMap["post"]; hasPost {
-				found = append(found, action)
-				break
+
+			method, opMap := detectHTTPMethod(pathMap)
+			if method == "" {
+				continue
+			}
+
+			returnType := extractActionReturnType(opMap, resourceName)
+
+			found = append(found, Action{
+				Name:       action,
+				Method:     method,
+				ReturnType: returnType,
+			})
+			break
+		}
+	}
+	sort.Slice(found, func(i, j int) bool {
+		return found[i].Name < found[j].Name
+	})
+	return found
+}
+
+func detectHTTPMethod(pathMap map[string]interface{}) (string, map[string]interface{}) {
+	for _, method := range []string{"post", "get", "put", "patch", "delete"} {
+		if opVal, ok := pathMap[method]; ok {
+			if opMap, ok := opVal.(map[string]interface{}); ok {
+				return method, opMap
 			}
 		}
 	}
-	return found
+	return "", nil
+}
+
+func extractActionReturnType(opMap map[string]interface{}, resourceName string) string {
+	responses, ok := opMap["responses"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	for _, code := range []string{"200", "201"} {
+		resp, ok := responses[code].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		content, ok := resp["content"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		jsonContent, ok := content["application/json"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		schema, ok := jsonContent["schema"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		ref, ok := schema["$ref"].(string)
+		if !ok {
+			return ""
+		}
+		parts := strings.Split(ref, "/")
+		refName := parts[len(parts)-1]
+		if refName == resourceName {
+			return resourceName
+		}
+		return ""
+	}
+	return ""
 }
 
 var objectReferenceFields = map[string]bool{

--- a/components/ambient-sdk/generator/templates/go/client.go.tmpl
+++ b/components/ambient-sdk/generator/templates/go/client.go.tmpl
@@ -116,17 +116,31 @@ func (a *{{.Resource.Name}}API) UpdateStatus(ctx context.Context, id string, pat
 }
 {{end}}
 {{- range .Resource.Actions}}
-func (a *{{$.Resource.Name}}API) {{. | title}}(ctx context.Context, id string) (*types.{{$.Resource.Name}}, error) {
+{{- if .ReturnType}}
+func (a *{{$.Resource.Name}}API) {{.Name | title}}(ctx context.Context, id string) (*types.{{$.Resource.Name}}, error) {
 	var result types.{{$.Resource.Name}}
 {{- if $.Resource.IsSubResource}}
-	if err := a.client.do(ctx, http.MethodPost, a.basePath()+"/"+url.PathEscape(id)+"/{{.}}", nil, http.StatusOK, &result); err != nil {
+	if err := a.client.do(ctx, http.Method{{.Method | title}}, a.basePath()+"/"+url.PathEscape(id)+"/{{.Name}}", nil, http.StatusOK, &result); err != nil {
 {{- else}}
-	if err := a.client.do(ctx, http.MethodPost, "/{{$.Resource.PathSegment}}/"+url.PathEscape(id)+"/{{.}}", nil, http.StatusOK, &result); err != nil {
+	if err := a.client.do(ctx, http.Method{{.Method | title}}, "/{{$.Resource.PathSegment}}/"+url.PathEscape(id)+"/{{.Name}}", nil, http.StatusOK, &result); err != nil {
 {{- end}}
 		return nil, err
 	}
 	return &result, nil
 }
+{{- else}}
+func (a *{{$.Resource.Name}}API) {{.Name | title}}(ctx context.Context, id string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+{{- if $.Resource.IsSubResource}}
+	if err := a.client.do(ctx, http.Method{{.Method | title}}, a.basePath()+"/"+url.PathEscape(id)+"/{{.Name}}", nil, http.StatusOK, &result); err != nil {
+{{- else}}
+	if err := a.client.do(ctx, http.Method{{.Method | title}}, "/{{$.Resource.PathSegment}}/"+url.PathEscape(id)+"/{{.Name}}", nil, http.StatusOK, &result); err != nil {
+{{- end}}
+		return nil, err
+	}
+	return result, nil
+}
+{{- end}}
 {{end}}
 func (a *{{.Resource.Name}}API) ListAll(ctx context.Context, opts *types.ListOptions) *Iterator[types.{{.Resource.Name}}] {
 	return NewIterator(func(page int) (*types.{{.Resource.Name}}List, error) {

--- a/components/ambient-sdk/generator/templates/go/client.go.tmpl
+++ b/components/ambient-sdk/generator/templates/go/client.go.tmpl
@@ -117,8 +117,8 @@ func (a *{{.Resource.Name}}API) UpdateStatus(ctx context.Context, id string, pat
 {{end}}
 {{- range .Resource.Actions}}
 {{- if .ReturnType}}
-func (a *{{$.Resource.Name}}API) {{.Name | title}}(ctx context.Context, id string) (*types.{{$.Resource.Name}}, error) {
-	var result types.{{$.Resource.Name}}
+func (a *{{$.Resource.Name}}API) {{.Name | title}}(ctx context.Context, id string) (*types.{{.ReturnType}}, error) {
+	var result types.{{.ReturnType}}
 {{- if $.Resource.IsSubResource}}
 	if err := a.client.do(ctx, http.Method{{.Method | title}}, a.basePath()+"/"+url.PathEscape(id)+"/{{.Name}}", nil, http.StatusOK, &result); err != nil {
 {{- else}}

--- a/components/ambient-sdk/generator/templates/python/client.py.tmpl
+++ b/components/ambient-sdk/generator/templates/python/client.py.tmpl
@@ -80,13 +80,23 @@ class {{.Resource.Name}}API:
         return {{.Resource.Name}}.from_dict(resp)
 {{end}}
 {{- range .Resource.Actions}}
-    def {{.}}(self, resource_id: str) -> {{$.Resource.Name}}:
+{{- if .ReturnType}}
+    def {{.Name}}(self, resource_id: str) -> {{$.Resource.Name}}:
 {{- if $.Resource.IsSubResource}}
-        resp = self._client._request("POST", f"{self._base_path()}/{resource_id}/{{.}}")
+        resp = self._client._request("{{.Method | upper}}", f"{self._base_path()}/{resource_id}/{{.Name}}")
 {{- else}}
-        resp = self._client._request("POST", f"/{{$.Resource.PathSegment}}/{resource_id}/{{.}}")
+        resp = self._client._request("{{.Method | upper}}", f"/{{$.Resource.PathSegment}}/{resource_id}/{{.Name}}")
 {{- end}}
         return {{$.Resource.Name}}.from_dict(resp)
+{{- else}}
+    def {{.Name}}(self, resource_id: str) -> dict:
+{{- if $.Resource.IsSubResource}}
+        resp = self._client._request("{{.Method | upper}}", f"{self._base_path()}/{resource_id}/{{.Name}}")
+{{- else}}
+        resp = self._client._request("{{.Method | upper}}", f"/{{$.Resource.PathSegment}}/{resource_id}/{{.Name}}")
+{{- end}}
+        return resp
+{{- end}}
 {{end}}
     def list_all(self, size: int = 100, **kwargs: Any) -> Iterator[{{.Resource.Name}}]:
         page = 1

--- a/components/ambient-sdk/generator/templates/python/client.py.tmpl
+++ b/components/ambient-sdk/generator/templates/python/client.py.tmpl
@@ -81,13 +81,13 @@ class {{.Resource.Name}}API:
 {{end}}
 {{- range .Resource.Actions}}
 {{- if .ReturnType}}
-    def {{.Name}}(self, resource_id: str) -> {{$.Resource.Name}}:
+    def {{.Name}}(self, resource_id: str) -> {{.ReturnType}}:
 {{- if $.Resource.IsSubResource}}
         resp = self._client._request("{{.Method | upper}}", f"{self._base_path()}/{resource_id}/{{.Name}}")
 {{- else}}
         resp = self._client._request("{{.Method | upper}}", f"/{{$.Resource.PathSegment}}/{resource_id}/{{.Name}}")
 {{- end}}
-        return {{$.Resource.Name}}.from_dict(resp)
+        return {{.ReturnType}}.from_dict(resp)
 {{- else}}
     def {{.Name}}(self, resource_id: str) -> dict:
 {{- if $.Resource.IsSubResource}}

--- a/components/ambient-sdk/generator/templates/ts/client.ts.tmpl
+++ b/components/ambient-sdk/generator/templates/ts/client.ts.tmpl
@@ -72,11 +72,11 @@ export class {{.Resource.Name}}API {
   }
 {{end}}
 {{- range .Resource.Actions}}
-  async {{.}}(id: string, opts?: RequestOptions): Promise<{{$.Resource.Name}}> {
+  async {{.Name}}(id: string, opts?: RequestOptions): Promise<{{if .ReturnType}}{{.ReturnType}}{{else}}Record<string, unknown>{{end}}> {
 {{- if $.Resource.IsSubResource}}
-    return ambientFetch<{{$.Resource.Name}}>(this.config, 'POST', `${this.basePath()}/${id}/{{.}}`, undefined, opts);
+    return ambientFetch<{{if .ReturnType}}{{.ReturnType}}{{else}}Record<string, unknown>{{end}}>(this.config, '{{.Method | upper}}', `${this.basePath()}/${id}/{{.Name}}`, undefined, opts);
 {{- else}}
-    return ambientFetch<{{$.Resource.Name}}>(this.config, 'POST', `/{{$.Resource.PathSegment}}/${id}/{{.}}`, undefined, opts);
+    return ambientFetch<{{if .ReturnType}}{{.ReturnType}}{{else}}Record<string, unknown>{{end}}>(this.config, '{{.Method | upper}}', `/{{$.Resource.PathSegment}}/${id}/{{.Name}}`, undefined, opts);
 {{- end}}
   }
 {{end}}


### PR DESCRIPTION
## Summary

- Extends the SDK generator to detect and generate typed action methods (`suspend`, `resume`, `trigger`, `runs`) from the OpenAPI spec, in addition to existing `start`/`stop`
- Replaces the untyped `Actions []string` model with a typed `Action` struct containing `Name`, `Method` (HTTP verb), and `ReturnType` (resource type or empty for generic returns)
- Updates all three SDK templates (TypeScript, Go, Python) to use the action's actual HTTP method and conditionally type the return value — actions returning the parent resource get the typed return, others get `Record<string, unknown>` / `map[string]interface{}` / `dict`

## Changes

| File | What |
|------|------|
| `generator/model.go` | Add `Action` struct, change `Resource.Actions` from `[]string` to `[]Action` |
| `generator/parser.go` | Expand `knownActions`, extract HTTP method + return type from OpenAPI paths |
| `generator/main.go` | Add `upper` to template FuncMap |
| `templates/ts/client.ts.tmpl` | Use `{{.Method \| upper}}` and conditional `{{.ReturnType}}` |
| `templates/go/client.go.tmpl` | Branch on `.ReturnType` for typed vs generic return |
| `templates/python/client.py.tmpl` | Same branching pattern as Go |

## Context

This is a prerequisite for the v2 frontend adapters PR. The ScheduledSession OpenAPI spec defines 4 action endpoints (`suspend`, `resume`, `trigger`, `runs`) that the generator previously couldn't detect because `knownActions` was hardcoded to `["start", "stop"]`. Additionally, two of the new actions break the old assumption that every action is POST returning the parent resource type:
- `trigger` — POST, returns inline `{status: string}` (not a `$ref`)
- `runs` — GET (not POST), returns `SessionList` (cross-resource `$ref`)

## Test plan

- [ ] `cd components/ambient-sdk/generator && go build ./...` — generator compiles
- [ ] `make generate-sdk` — regenerate all three SDKs (user will do this locally)
- [ ] Inspect generated `ts-sdk/src/scheduled_session_api.ts` for `suspend()`, `resume()`, `trigger()`, `runs()` methods
- [ ] Verify existing `Session` start/stop actions produce identical output (backward compatible)
- [ ] `cd components/ambient-sdk/go-sdk && go build ./...` — Go SDK compiles with new action signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>