### PR TITLE
fix(runner): add health probes and improve INITIAL_PROMPT error logging

### DIFF
--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -1044,6 +1044,31 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 				Protocol:      corev1.ProtocolTCP,
 			}},
 
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/health",
+						Port: intstr.FromInt32(runnerPort),
+					},
+				},
+				InitialDelaySeconds: 3,
+				PeriodSeconds:       5,
+				TimeoutSeconds:      2,
+				FailureThreshold:    3,
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/health",
+						Port: intstr.FromInt32(runnerPort),
+					},
+				},
+				InitialDelaySeconds: 20,
+				PeriodSeconds:       30,
+				TimeoutSeconds:      5,
+				FailureThreshold:    3,
+			},
+
 			VolumeMounts: runnerVolumeMounts,
 
 			// Lifecycle hook to copy Google credentials from read-only secret mount to writable workspace

--- a/components/runners/ambient-runner/ambient_runner/app.py
+++ b/components/runners/ambient-runner/ambient_runner/app.py
@@ -258,14 +258,20 @@ def add_ambient_endpoints(
     # This prevents cross-session attacks where an attacker uses another session's runner URL.
     _agui_token = os.getenv("AGUI_TOKEN", "").strip()
     if _agui_token:
+
         @app.middleware("http")
         async def _require_session_token(request: Request, call_next):
             if request.url.path not in ("/health", "/healthz"):
                 provided = request.headers.get("X-Ambient-Session-Token", "")
                 # Use constant-time comparison to prevent timing attacks
-                if not provided or not _secrets_mod.compare_digest(provided, _agui_token):
-                    return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+                if not provided or not _secrets_mod.compare_digest(
+                    provided, _agui_token
+                ):
+                    return JSONResponse(
+                        status_code=401, content={"detail": "Unauthorized"}
+                    )
             return await call_next(request)
+
         logger.info("AG-UI token authentication enabled")
 
     # Core endpoints (always registered)
@@ -516,6 +522,7 @@ async def _push_initial_prompt_via_http(prompt: str, session_id: str) -> None:
     }
 
     backoff = _AUTO_PROMPT_INITIAL_DELAY
+    last_exc: Exception | None = None
     for attempt in range(1, _AUTO_PROMPT_MAX_RETRIES + 1):
         # Re-read token each attempt — volume mount may not be ready at first try
         bot_token = get_bot_token()
@@ -552,9 +559,14 @@ async def _push_initial_prompt_via_http(prompt: str, session_id: str) -> None:
                         )
                         return
         except Exception as e:
+            last_exc = e
             logger.warning(
-                f"INITIAL_PROMPT attempt {attempt}/{_AUTO_PROMPT_MAX_RETRIES} "
-                f"error: {e}, retrying in {backoff:.0f}s"
+                "INITIAL_PROMPT attempt %d/%d error: %s(%s), retrying in %.0fs",
+                attempt,
+                _AUTO_PROMPT_MAX_RETRIES,
+                type(e).__name__,
+                e,
+                backoff,
             )
 
         await asyncio.sleep(backoff)
@@ -562,7 +574,10 @@ async def _push_initial_prompt_via_http(prompt: str, session_id: str) -> None:
         payload["runId"] = str(uuid.uuid4())
 
     logger.error(
-        f"INITIAL_PROMPT auto-execution failed after {_AUTO_PROMPT_MAX_RETRIES} attempts"
+        "INITIAL_PROMPT auto-execution failed after %d attempts (last error: %s(%s))",
+        _AUTO_PROMPT_MAX_RETRIES,
+        type(last_exc).__name__ if last_exc is not None else "unknown",
+        last_exc if last_exc is not None else "",
     )
 
 


### PR DESCRIPTION
Runner pods had no K8s health probes, so the Service routed traffic before FastAPI finished starting. The backend's proxy requests (e.g., `GET /git/status`) hit a connection error and returned 503 "runner unavailable". Separately, INITIAL_PROMPT retry errors were undebuggable because exceptions like `asyncio.TimeoutError` have empty `str()` representations, producing log lines like `error: , retrying in 2s`.

**Readiness probe** (`/health`, 3s initial delay, 5s period) gates the Service so traffic only reaches the runner once it's actually serving. **Liveness probe** (`/health`, 20s initial delay, 30s period) restarts the pod if the runner becomes completely unresponsive. The 20s liveness delay accounts for gRPC listener setup (up to 10s) and MCP server connections during startup.

**Error logging** now includes `type(e).__name__` in retry warnings, so `TimeoutError()` or `ClientConnectorError(...)` appears instead of a blank string. The final failure log also reports the last exception.

## Test plan

- `go build ./...` and `go vet ./...` pass for operator
- 22/22 `test_app_initial_prompt.py` tests pass
- Deploy to cluster: `kubectl describe pod <runner>` should show both probes; pod should not become Ready until `/health` returns 200

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added health check monitoring to improve system resilience and reliability.

* **Bug Fixes**
  * Enhanced authentication validation security with improved token verification.
  * Improved diagnostic logging for connection failures and retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->