### PR TITLE
fix: create parent directory before moving workflow clone

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/endpoints/workflow.py
+++ b/components/runners/ambient-runner/ambient_runner/endpoints/workflow.py
@@ -139,7 +139,10 @@ async def clone_workflow_at_runtime(
             return False, ""
 
         if subpath:
-            subpath_full = temp_dir / subpath
+            subpath_full = (temp_dir / subpath).resolve()
+            if not subpath_full.is_relative_to(temp_dir):
+                logger.error(f"Subpath '{subpath}' escapes clone directory")
+                return False, ""
             if subpath_full.exists() and subpath_full.is_dir():
                 if workflow_final.exists():
                     shutil.rmtree(workflow_final)
@@ -149,10 +152,12 @@ async def clone_workflow_at_runtime(
                 logger.warning(f"Subpath '{subpath}' not found, using entire repo")
                 if workflow_final.exists():
                     shutil.rmtree(workflow_final)
+                workflow_final.parent.mkdir(parents=True, exist_ok=True)
                 shutil.move(str(temp_dir), str(workflow_final))
         else:
             if workflow_final.exists():
                 shutil.rmtree(workflow_final)
+            workflow_final.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(temp_dir), str(workflow_final))
 
         logger.info(f"Workflow '{workflow_name}' ready at {workflow_final}")

--- a/components/runners/state-sync/hydrate.sh
+++ b/components/runners/state-sync/hydrate.sh
@@ -340,11 +340,13 @@ if [ -n "$ACTIVE_WORKFLOW_GIT_URL" ] && [ "$ACTIVE_WORKFLOW_GIT_URL" != "null" ]
                 echo "  Available paths in repo:"
                 find "$WORKFLOW_TEMP" -maxdepth 3 -type d | head -10
                 echo "  Using entire repo instead"
+                mkdir -p "$(dirname "$WORKFLOW_FINAL")"
                 mv "$WORKFLOW_TEMP" "$WORKFLOW_FINAL"
                 echo "  ✓ Workflow ready at /workspace/workflows/${WORKFLOW_NAME}"
             fi
         else
             # No subpath - use entire repo
+            mkdir -p "$(dirname "$WORKFLOW_FINAL")"
             mv "$WORKFLOW_TEMP" "$WORKFLOW_FINAL"
             echo "  ✓ Workflow ready at /workspace/workflows/${WORKFLOW_NAME}"
         fi
@@ -467,9 +469,13 @@ else
     echo "No git repo state backup found"
 fi
 
-# Set permissions on repos after restore (repos may have been cloned or restored)
+# Set permissions on repos and workflows after restore
 chown -R 1001:0 /workspace/repos 2>/dev/null || true
 chmod -R 777 /workspace/repos 2>/dev/null || true
+if [ -d /workspace/workflows ]; then
+    chown -R 1001:0 /workspace/workflows 2>/dev/null || true
+    chmod -R 777 /workspace/workflows 2>/dev/null || true
+fi
 
 echo "========================================="
 echo "Workspace initialized successfully"


### PR DESCRIPTION
## Summary

- **mkdir -p fix**: The workflow clone code in both `hydrate.sh` (init container) and `workflow.py` (runtime endpoint) failed to create `/workspace/workflows/` before moving the cloned repo into it. The subpath-found branch already had `mkdir -p` but the subpath-fallback and no-subpath branches did not, causing `mv` / `shutil.move` to fail silently.
- **Path traversal fix** (workflow.py): Validates that the resolved subpath stays within the clone directory, preventing `../` traversal in user-supplied subpath input.
- **Permissions fix** (hydrate.sh): Adds `chown`/`chmod` for `/workspace/workflows` alongside the existing `/workspace/repos` permissions block, so the runner container (user 1001) can read cloned workflow files.

## Changed files

| File | Change |
|------|--------|
| `components/runners/state-sync/hydrate.sh` | Add `mkdir -p` before `mv` in subpath-fallback and no-subpath branches; add `chown`/`chmod` for `/workspace/workflows` |
| `components/runners/ambient-runner/ambient_runner/endpoints/workflow.py` | Add `mkdir -p` before `shutil.move` in subpath-fallback and no-subpath branches; add path traversal validation for subpath |

## Test plan

- [ ] Start a session with a custom workflow (no subpath) — workflow files should appear in `/workspace/workflows/<name>/`
- [ ] Start a session with a custom workflow + subpath — subpath extraction should work
- [ ] Verify subpath with `../` sequences is rejected with an error log
- [ ] Verify `/workspace/workflows/` has correct ownership (1001:0) after init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamically updating and switching active workflows at runtime without restarting the application.

* **Bug Fixes**
  * Enhanced security by preventing path traversal vulnerabilities in workflow repository handling.
  * Improved workflow directory restoration and permissions management during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->