### PR TITLE
feat(build): add org.opencontainers.image.revision OCI label to ambient-control-plane and ambient-mcp

### DIFF
--- a/components/ambient-control-plane/Dockerfile
+++ b/components/ambient-control-plane/Dockerfile
@@ -18,6 +18,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o ambient-control-plane 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
+ARG GIT_COMMIT=unknown
+
 WORKDIR /app
 
 COPY --from=builder /workspace/ambient-control-plane/ambient-control-plane /usr/local/bin/
@@ -32,4 +34,5 @@ LABEL name="ambient-control-plane" \
       vendor="Ambient" \
       version="0.0.1" \
       summary="Ambient Control Plane" \
-      description="Kubernetes reconciler for the Ambient Code Platform"
+      description="Kubernetes reconciler for the Ambient Code Platform" \
+      org.opencontainers.image.revision=$GIT_COMMIT

--- a/components/ambient-mcp/Dockerfile
+++ b/components/ambient-mcp/Dockerfile
@@ -19,6 +19,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o ambient-mcp .
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
+ARG GIT_COMMIT=unknown
+
 WORKDIR /app
 
 RUN microdnf install -y procps && microdnf clean all
@@ -26,6 +28,8 @@ RUN microdnf install -y procps && microdnf clean all
 COPY --from=builder /app/ambient-mcp .
 
 RUN chmod +x ./ambient-mcp && chmod 775 /app
+
+LABEL org.opencontainers.image.revision=$GIT_COMMIT
 
 USER 1001
 


### PR DESCRIPTION
## Summary

- Extends OCI label coverage from #1270 to the two Dockerfiles that were added to the build pipeline after that PR: `ambient-control-plane` and `ambient-mcp`
- Adds `ARG GIT_COMMIT=unknown` and `LABEL org.opencontainers.image.revision=$GIT_COMMIT` to the final image stage of both Dockerfiles
- No workflow changes needed — `components-build-deploy.yml` and `prod-release-deploy.yaml` already pass `GIT_COMMIT=${{ github.sha }}` for all components in the build matrix

## Test plan

- [ ] Verify `skopeo inspect docker://quay.io/ambient_code/vteam_control_plane:pr-<this-pr>` returns a valid SHA in `Labels["org.opencontainers.image.revision"]`
- [ ] Verify `skopeo inspect docker://quay.io/ambient_code/vteam_mcp:pr-<this-pr>` returns a valid SHA in `Labels["org.opencontainers.image.revision"]`
- [ ] Confirm the CI build job for both components succeeds

Closes: RHOAIENG-57243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker images now include source git revision metadata for improved image identification and tracking across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->