### PR TITLE
feat(frontend): display workspace name in session UI views

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/sessions-sidebar.test.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/__tests__/sessions-sidebar.test.tsx
@@ -34,6 +34,10 @@ vi.mock('@/services/queries/use-project-access', () => ({
   useProjectAccess: () => ({ data: { userRole: 'admin' } }),
 }));
 
+vi.mock('@/services/queries/use-projects', () => ({
+  useProject: () => ({ data: { displayName: 'Test Workspace', name: 'test-project' } }),
+}));
+
 const mockCurrentUser = vi.fn(() => ({ data: { authenticated: true, userId: 'user-1', displayName: 'Test User' } }));
 vi.mock('@/services/queries/use-auth', () => ({
   useCurrentUser: () => mockCurrentUser(),

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/sessions-sidebar.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/sessions-sidebar.tsx
@@ -48,6 +48,7 @@ import {
   useContinueSession,
   useUpdateSessionDisplayName,
 } from "@/services/queries/use-sessions";
+import { useProject } from "@/services/queries/use-projects";
 import { useProjectAccess } from "@/services/queries/use-project-access";
 import { useCurrentUser } from "@/services/queries/use-auth";
 import { useVersion } from "@/services/queries/use-version";
@@ -92,6 +93,8 @@ export function SessionsSidebar({
   const router = useRouter();
   const pathname = usePathname();
   const { data: version } = useVersion();
+  const { data: project } = useProject(collapsed ? "" : projectName);
+  const workspaceName = project?.displayName || projectName;
   const [showAll, setShowAll] = useState(false);
   const { data, isLoading, isFetching, dataUpdatedAt, refetch } = useSessionsPaginated(
     collapsed ? "" : projectName,
@@ -315,8 +318,8 @@ export function SessionsSidebar({
               <ChevronLeft className="w-4 h-4 mr-2" />
               Workspaces
             </span>
-            <span className="text-xs font-semibold text-foreground truncate max-w-[60%]" title={projectName}>
-              {projectName}
+            <span className="text-xs font-semibold text-foreground truncate max-w-[60%]" title={workspaceName}>
+              {workspaceName}
             </span>
           </Button>
         </Link>

--- a/components/frontend/src/components/__tests__/session-details-modal.test.tsx
+++ b/components/frontend/src/components/__tests__/session-details-modal.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionDetailsModal } from '../session-details-modal';
+import type { AgenticSession } from '@/types/agentic-session';
+
+const mockUseProject = vi.fn(() => ({ data: undefined }));
+vi.mock('@/services/queries', () => ({
+  useProject: () => mockUseProject(),
+}));
+
+vi.mock('@/services/queries/use-sessions', () => ({
+  useSessionExport: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock('@/utils/session-helpers', () => ({
+  getPhaseColor: () => '',
+}));
+
+vi.mock('@/utils/export-chat', () => ({
+  triggerDownload: vi.fn(),
+}));
+
+const mockSession: AgenticSession = {
+  metadata: {
+    name: 'session-abc',
+    namespace: 'default',
+    creationTimestamp: '2026-01-01T00:00:00Z',
+    uid: 'uid-abc',
+  },
+  spec: {
+    llmSettings: { model: 'claude-3', temperature: 0, maxTokens: 4096 },
+    timeout: 3600,
+  },
+};
+
+describe('SessionDetailsModal — workspace name', () => {
+  const defaultProps = {
+    session: mockSession,
+    projectName: 'my-project',
+    open: true,
+    onOpenChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows displayName when available', () => {
+    mockUseProject.mockReturnValue({ data: { displayName: 'My Workspace Display', name: 'my-project' } });
+    render(<SessionDetailsModal {...defaultProps} />);
+    expect(screen.getByText('Workspace:')).toBeDefined();
+    expect(screen.getByText('My Workspace Display')).toBeDefined();
+  });
+
+  it('falls back to raw project name when displayName is empty', () => {
+    mockUseProject.mockReturnValue({ data: { displayName: '', name: 'my-project' } });
+    render(<SessionDetailsModal {...defaultProps} />);
+    expect(screen.getByText('Workspace:')).toBeDefined();
+    expect(screen.getByText('my-project')).toBeDefined();
+  });
+
+  it('falls back to raw project name when project data is not loaded', () => {
+    mockUseProject.mockReturnValue({ data: undefined });
+    render(<SessionDetailsModal {...defaultProps} />);
+    expect(screen.getByText('Workspace:')).toBeDefined();
+    expect(screen.getByText('my-project')).toBeDefined();
+  });
+});

--- a/components/frontend/src/components/session-details-modal.tsx
+++ b/components/frontend/src/components/session-details-modal.tsx
@@ -10,6 +10,7 @@ import type { AgenticSession } from '@/types/agentic-session';
 import { getPhaseColor } from '@/utils/session-helpers';
 import { toast } from 'sonner';
 import { useSessionExport } from '@/services/queries/use-sessions';
+import { useProject } from '@/services/queries';
 import { triggerDownload } from '@/utils/export-chat';
 
 type SessionDetailsModalProps = {
@@ -28,6 +29,8 @@ export function SessionDetailsModal({
   const [exportingAgui, setExportingAgui] = useState(false);
   const [exportingLegacy, setExportingLegacy] = useState(false);
   const sessionName = session.metadata?.name || '';
+  const { data: project } = useProject(projectName);
+  const workspaceName = project?.displayName || projectName;
 
   // Use React Query hook - only fetches when modal is open
   const { data: exportData, isLoading: loadingExport } = useSessionExport(
@@ -67,6 +70,11 @@ export function SessionDetailsModal({
 
         <div className="space-y-4">
           <div className="space-y-3">
+            <div className="flex items-start gap-3">
+              <span className="font-semibold text-foreground/80 min-w-[100px]">Workspace:</span>
+              <span className="text-foreground truncate">{workspaceName}</span>
+            </div>
+
             <div className="flex items-start gap-3">
               <span className="font-semibold text-foreground/80 min-w-[100px]">Status:</span>
               <Badge className={getPhaseColor(session.status?.phase || "Pending")}>

--- a/components/frontend/src/components/workspace-sections/__tests__/sessions-section.test.tsx
+++ b/components/frontend/src/components/workspace-sections/__tests__/sessions-section.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionsSection } from '../sessions-section';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockUseProject = vi.fn(() => ({ data: undefined }));
+vi.mock('@/services/queries', () => ({
+  useSessionsPaginated: () => ({ data: { items: [], totalCount: 0, hasMore: false }, isFetching: false, refetch: vi.fn() }),
+  useStopSession: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteSession: () => ({ mutate: vi.fn(), isPending: false }),
+  useContinueSession: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateSessionDisplayName: () => ({ mutate: vi.fn(), isPending: false }),
+  useRunnerTypes: () => ({ data: [] }),
+  useProject: () => mockUseProject(),
+}));
+
+vi.mock('@/services/queries/use-project-access', () => ({
+  useProjectAccess: () => ({ data: { userRole: 'admin' } }),
+}));
+
+vi.mock('@/services/queries/use-workspace', () => ({
+  useWorkspaceList: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@/hooks/use-debounce', () => ({
+  useDebounce: (value: string) => value,
+}));
+
+vi.mock('@/components/empty-state', () => ({
+  EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock('@/components/session-status-dot', () => ({
+  SessionStatusDot: ({ phase }: { phase: string }) => <span>{phase}</span>,
+}));
+
+vi.mock('@/components/agent-status-indicator', () => ({
+  AgentStatusIndicator: () => <span>status</span>,
+}));
+
+vi.mock('@/hooks/use-agent-status', () => ({
+  deriveAgentStatusFromPhase: () => 'idle',
+}));
+
+vi.mock('@/components/edit-session-name-dialog', () => ({
+  EditSessionNameDialog: () => null,
+}));
+
+vi.mock('@/lib/pagination', () => ({
+  getPageNumbers: () => [],
+}));
+
+vi.mock('date-fns', () => ({
+  formatDistanceToNow: () => '2 hours',
+}));
+
+describe('SessionsSection — workspace name', () => {
+  const defaultProps = { projectName: 'my-project' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows displayName in header when available', () => {
+    mockUseProject.mockReturnValue({ data: { displayName: 'My Project Workspace', name: 'my-project' } });
+    render(<SessionsSection {...defaultProps} />);
+    expect(screen.getByText(/My Project Workspace/)).toBeDefined();
+  });
+
+  it('falls back to raw project name when displayName is empty', () => {
+    mockUseProject.mockReturnValue({ data: { displayName: '', name: 'my-project' } });
+    render(<SessionsSection {...defaultProps} />);
+    expect(screen.getByText(/Workspace:.*my-project/)).toBeDefined();
+  });
+
+  it('falls back to raw project name when project data is not loaded', () => {
+    mockUseProject.mockReturnValue({ data: undefined });
+    render(<SessionsSection {...defaultProps} />);
+    expect(screen.getByText(/Workspace:.*my-project/)).toBeDefined();
+  });
+});

--- a/components/frontend/src/components/workspace-sections/sessions-section.tsx
+++ b/components/frontend/src/components/workspace-sections/sessions-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { Plus, RefreshCw, MoreVertical, Square, Trash2, ArrowRight, Brain, Search, Pencil, Clock, Cpu, MessageSquare, NotepadText, User } from 'lucide-react';
+import { Plus, RefreshCw, MoreVertical, Square, Trash2, ArrowRight, Brain, Search, Pencil, Clock, Cpu, MessageSquare, NotepadText, User, FolderOpen } from 'lucide-react';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
@@ -27,7 +27,7 @@ import { AgentStatusIndicator } from '@/components/agent-status-indicator';
 import { deriveAgentStatusFromPhase } from '@/hooks/use-agent-status';
 import { EditSessionNameDialog } from '@/components/edit-session-name-dialog';
 
-import { useSessionsPaginated, useStopSession, useDeleteSession, useContinueSession, useUpdateSessionDisplayName, useRunnerTypes } from '@/services/queries';
+import { useSessionsPaginated, useStopSession, useDeleteSession, useContinueSession, useUpdateSessionDisplayName, useRunnerTypes, useProject } from '@/services/queries';
 import { toast } from 'sonner';
 import { useWorkspaceList } from '@/services/queries/use-workspace';
 import { useProjectAccess } from '@/services/queries/use-project-access';
@@ -84,6 +84,9 @@ export function SessionsSection({ projectName }: SessionsSectionProps) {
   const canCreate = access?.userRole === 'edit' || access?.userRole === 'admin';
   const canDelete = access?.userRole === 'admin';
   const canModify = !!access?.userRole && access.userRole !== 'view';
+
+  const { data: project } = useProject(projectName);
+  const workspaceName = project?.displayName || projectName;
 
   // Runner type lookup for display names
   const { data: runnerTypes } = useRunnerTypes(projectName);
@@ -214,7 +217,7 @@ export function SessionsSection({ projectName }: SessionsSectionProps) {
           <div>
             <CardTitle>Sessions</CardTitle>
             <CardDescription>
-              Sessions scoped to this workspace
+              Workspace: {workspaceName}
             </CardDescription>
           </div>
           <div className="flex gap-2">
@@ -324,6 +327,10 @@ export function SessionsSection({ projectName }: SessionsSectionProps) {
                                   <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                                     <User className="h-3 w-3" />
                                     <span>{session.spec.userContext?.displayName || session.spec.userContext?.userId || '—'}</span>
+                                  </div>
+                                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                    <FolderOpen className="h-3 w-3" />
+                                    <span className="truncate">{workspaceName}</span>
                                   </div>
                                   {session.spec.initialPrompt && (
                                     <div className="flex items-start gap-1.5 text-xs text-muted-foreground pt-1">


### PR DESCRIPTION
## Summary

- Shows workspace/project display name (falls back to raw project name) in the **session list header** (`CardDescription` now reads "Workspace: <name>")
- Adds workspace name to **session table hover cards** (with `FolderOpen` icon, matching existing icon-row pattern)
- Adds **Workspace:** field to **session details modal** (above Status, following existing layout)
- Replaces raw `projectName` with resolved display name in the **sessions sidebar** nav button
- Guards sidebar `useProject` call against firing when the sidebar is collapsed (mirrors the existing `useSessionsPaginated` guard)
- Adds unit tests: workspace name in session list header, session details modal, and fallback to raw name when `displayName` is empty

## Test plan

- [x] Unit tests: `sessions-section.test.tsx` (3 new tests), `session-details-modal.test.tsx` (3 new tests)
- [x] Existing sidebar tests updated with `useProject` mock — all 18 tests pass
- [x] Full frontend unit suite passes (119 files, 1174 tests)
- [ ] E2E: workspace name visible on session page (RHOAIENG-56045 acceptance criterion)

Closes RHOAIENG-56045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace name is now displayed in the sessions sidebar, session details modal, and sessions section using project metadata, with fallback support when unavailable.
  * Session details modal includes a new "Workspace" field for enhanced context.

* **Tests**
  * Added comprehensive test coverage for workspace name display across session-related components, including fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->