### PR TITLE
fix(ambient-api-server): run as non-root and add OIDC secret placeholders

### DIFF
--- a/components/ambient-api-server/Dockerfile
+++ b/components/ambient-api-server/Dockerfile
@@ -37,6 +37,8 @@ COPY --from=builder /workspace/ambient-api-server /usr/local/bin/
 
 EXPOSE 8000
 
+USER 1001
+
 ENTRYPOINT ["/usr/local/bin/ambient-api-server", "serve"]
 
 LABEL name="ambient-api-server" \

--- a/components/manifests/base/platform/ambient-api-server-secrets.yml
+++ b/components/manifests/base/platform/ambient-api-server-secrets.yml
@@ -25,6 +25,8 @@ metadata:
 type: Opaque
 stringData:
   sentry.key: ""
+  clientId: ""
+  clientSecret: ""
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Add USER 1001 to the Dockerfile to satisfy restricted SecurityContext requirements.

Add empty clientId/clientSecret keys to the base ambient-api-server Secret so the ambient-control-plane pod can start in Kind where OIDC is not configured (token auth is used instead).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * API server runtime now runs as a non-root user in production.
  * Added clientId and clientSecret fields (empty by default) to the API server secrets for future credential configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->