### PR TITLE
feat(frontend,backend): add custom workflow sources to session creation

### DIFF
--- a/components/backend/handlers/project_workflow_sources.go
+++ b/components/backend/handlers/project_workflow_sources.go
@@ -1,0 +1,149 @@
+package handlers
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WorkflowSource represents a custom workflow source repository.
+type WorkflowSource struct {
+	Name   string `json:"name"`
+	GitURL string `json:"gitUrl"`
+	Branch string `json:"branch,omitempty"`
+	Path   string `json:"path,omitempty"`
+}
+
+// WorkflowSourcesConfig is the request/response envelope for workflow sources.
+type WorkflowSourcesConfig struct {
+	Sources []WorkflowSource `json:"sources"`
+}
+
+// GetProjectWorkflowSources returns the custom workflow sources from the ProjectSettings CR.
+// GET /api/projects/:projectName/workflow-sources
+func GetProjectWorkflowSources(c *gin.Context) {
+	project := c.GetString("project")
+	_, k8sDyn := GetK8sClientsForRequest(c)
+	if k8sDyn == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or missing token"})
+		return
+	}
+
+	gvr := GetProjectSettingsResource()
+	ps, err := k8sDyn.Resource(gvr).Namespace(project).Get(context.TODO(), "projectsettings", v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// No project settings yet, return empty sources
+			c.JSON(http.StatusOK, WorkflowSourcesConfig{Sources: []WorkflowSource{}})
+			return
+		}
+		log.Printf("Failed to get project settings for %s: %v", project, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get project settings"})
+		return
+	}
+
+	spec, ok := ps.Object["spec"].(map[string]interface{})
+	if !ok {
+		c.JSON(http.StatusOK, WorkflowSourcesConfig{Sources: []WorkflowSource{}})
+		return
+	}
+
+	rawSources, ok := spec["workflowSources"].([]interface{})
+	if !ok {
+		c.JSON(http.StatusOK, WorkflowSourcesConfig{Sources: []WorkflowSource{}})
+		return
+	}
+
+	sources := make([]WorkflowSource, 0, len(rawSources))
+	for _, raw := range rawSources {
+		srcMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		src := WorkflowSource{}
+		if name, ok := srcMap["name"].(string); ok {
+			src.Name = name
+		}
+		if gitURL, ok := srcMap["gitUrl"].(string); ok {
+			src.GitURL = gitURL
+		}
+		if branch, ok := srcMap["branch"].(string); ok {
+			src.Branch = branch
+		}
+		if path, ok := srcMap["path"].(string); ok {
+			src.Path = path
+		}
+		sources = append(sources, src)
+	}
+
+	c.JSON(http.StatusOK, WorkflowSourcesConfig{Sources: sources})
+}
+
+// UpdateProjectWorkflowSources updates the custom workflow sources in the ProjectSettings CR.
+// PUT /api/projects/:projectName/workflow-sources
+func UpdateProjectWorkflowSources(c *gin.Context) {
+	project := c.GetString("project")
+	_, k8sDyn := GetK8sClientsForRequest(c)
+	if k8sDyn == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or missing token"})
+		return
+	}
+
+	var req WorkflowSourcesConfig
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	gvr := GetProjectSettingsResource()
+	ps, err := k8sDyn.Resource(gvr).Namespace(project).Get(context.TODO(), "projectsettings", v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Project settings not found"})
+			return
+		}
+		log.Printf("Failed to get project settings for %s: %v", project, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get project settings"})
+		return
+	}
+
+	spec, ok := ps.Object["spec"].(map[string]interface{})
+	if !ok {
+		spec = map[string]interface{}{}
+		ps.Object["spec"] = spec
+	}
+
+	// Build the workflowSources array
+	if len(req.Sources) > 0 {
+		sourcesArr := make([]interface{}, len(req.Sources))
+		for i, src := range req.Sources {
+			srcMap := map[string]interface{}{
+				"name":   src.Name,
+				"gitUrl": src.GitURL,
+			}
+			if src.Branch != "" {
+				srcMap["branch"] = src.Branch
+			}
+			if src.Path != "" {
+				srcMap["path"] = src.Path
+			}
+			sourcesArr[i] = srcMap
+		}
+		spec["workflowSources"] = sourcesArr
+	} else {
+		delete(spec, "workflowSources")
+	}
+
+	_, err = k8sDyn.Resource(gvr).Namespace(project).Update(context.TODO(), ps, v1.UpdateOptions{})
+	if err != nil {
+		log.Printf("Failed to update project settings workflow sources for %s: %v", project, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update workflow sources configuration"})
+		return
+	}
+
+	c.JSON(http.StatusOK, req)
+}

--- a/components/backend/handlers/project_workflow_sources.go
+++ b/components/backend/handlers/project_workflow_sources.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -97,6 +99,26 @@ func UpdateProjectWorkflowSources(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 		return
+	}
+
+	const maxWorkflowSources = 20
+	if len(req.Sources) > maxWorkflowSources {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Maximum %d workflow sources allowed", maxWorkflowSources)})
+		return
+	}
+	for i, src := range req.Sources {
+		if strings.TrimSpace(src.Name) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Source %d: name is required", i+1)})
+			return
+		}
+		if strings.TrimSpace(src.GitURL) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Source %d: gitUrl is required", i+1)})
+			return
+		}
+		if !strings.HasPrefix(src.GitURL, "https://") && !strings.HasPrefix(src.GitURL, "http://") && !strings.HasPrefix(src.GitURL, "git@") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Source %d: gitUrl must be a valid Git URL (https://, http://, or git@)", i+1)})
+			return
+		}
 	}
 
 	gvr := GetProjectSettingsResource()

--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -64,6 +64,10 @@ type ootbWorkflowsCache struct {
 var (
 	ootbCache    = &ootbWorkflowsCache{}
 	ootbCacheTTL = 5 * time.Minute // Cache OOTB workflows for 5 minutes
+
+	// customSourceCaches provides per-source caching for custom workflow sources.
+	// Key: "gitUrl|branch|path" -> *ootbWorkflowsCache
+	customSourceCaches sync.Map
 )
 
 // allowedSdkOptionKeys defines the SDK options that users are allowed to configure.
@@ -2549,6 +2553,7 @@ type OOTBWorkflow struct {
 	Branch      string `json:"branch"`
 	Path        string `json:"path,omitempty"`
 	Enabled     bool   `json:"enabled"`
+	Source      string `json:"source,omitempty"`
 }
 
 // ListOOTBWorkflows returns the list of out-of-the-box workflows dynamically discovered from GitHub
@@ -2575,12 +2580,21 @@ func ListOOTBWorkflows(c *gin.Context) {
 	// Build cache key from repo configuration
 	cacheKey := fmt.Sprintf("%s|%s|%s", ootbRepo, ootbBranch, ootbWorkflowsPath)
 
-	// Check cache first (read lock)
+	// Read project query param early - needed for both cache-hit and cache-miss paths
+	project := c.Query("project") // Optional query parameter
+
+	// Check OOTB cache first (read lock)
 	ootbCache.mu.RLock()
 	if ootbCache.cacheKey == cacheKey && time.Since(ootbCache.cachedAt) < ootbCacheTTL && len(ootbCache.workflows) > 0 {
-		workflows := ootbCache.workflows
+		workflows := make([]OOTBWorkflow, len(ootbCache.workflows))
+		copy(workflows, ootbCache.workflows)
 		ootbCache.mu.RUnlock()
-		log.Printf("ListOOTBWorkflows: returning %d cached workflows (age: %v)", len(workflows), time.Since(ootbCache.cachedAt).Round(time.Second))
+		log.Printf("ListOOTBWorkflows: returning %d cached OOTB workflows (age: %v)", len(workflows), time.Since(ootbCache.cachedAt).Round(time.Second))
+		// Append custom source workflows if project is specified
+		if project != "" {
+			customWorkflows := fetchCustomSourceWorkflows(c, project, "")
+			workflows = append(workflows, customWorkflows...)
+		}
 		c.JSON(http.StatusOK, gin.H{"workflows": workflows})
 		return
 	}
@@ -2590,7 +2604,6 @@ func ListOOTBWorkflows(c *gin.Context) {
 	// Try to get user's GitHub token (best effort - not required)
 	// This gives better rate limits (5000/hr vs 60/hr) and supports private repos
 	token := ""
-	project := c.Query("project") // Optional query parameter
 	if project != "" {
 		usrID, _ := c.Get("userID")
 		k8sClt, sessDyn := GetK8sClientsForRequest(c)
@@ -2689,6 +2702,7 @@ func ListOOTBWorkflows(c *gin.Context) {
 			Branch:      ootbBranch,
 			Path:        fmt.Sprintf("%s/%s", ootbWorkflowsPath, entryName),
 			Enabled:     true,
+			Source:      "ootb",
 		})
 	}
 
@@ -2700,7 +2714,179 @@ func ListOOTBWorkflows(c *gin.Context) {
 	ootbCache.mu.Unlock()
 
 	log.Printf("ListOOTBWorkflows: discovered %d workflows from %s (cached for %v)", len(workflows), ootbRepo, ootbCacheTTL)
+
+	// Append workflows from custom sources if project is specified
+	if project != "" {
+		customWorkflows := fetchCustomSourceWorkflows(c, project, token)
+		workflows = append(workflows, customWorkflows...)
+	}
+
 	c.JSON(http.StatusOK, gin.H{"workflows": workflows})
+}
+
+// fetchCustomSourceWorkflows reads custom workflow sources from the ProjectSettings CR
+// and discovers workflows from each source's GitHub repository.
+// Failures on individual sources are logged but do not block other sources.
+func fetchCustomSourceWorkflows(c *gin.Context, project, token string) []OOTBWorkflow {
+	_, k8sDyn := GetK8sClientsForRequest(c)
+	if k8sDyn == nil {
+		return nil
+	}
+
+	gvr := GetProjectSettingsResource()
+	ps, err := k8sDyn.Resource(gvr).Namespace(project).Get(context.TODO(), "projectsettings", v1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Printf("fetchCustomSourceWorkflows: failed to get project settings for %s: %v", project, err)
+		}
+		return nil
+	}
+
+	spec, ok := ps.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	rawSources, ok := spec["workflowSources"].([]interface{})
+	if !ok || len(rawSources) == 0 {
+		return nil
+	}
+
+	var allWorkflows []OOTBWorkflow
+
+	for srcIdx, raw := range rawSources {
+		srcMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		srcName, _ := srcMap["name"].(string)
+		srcGitURL, _ := srcMap["gitUrl"].(string)
+		if srcGitURL == "" {
+			log.Printf("fetchCustomSourceWorkflows: skipping source %d with empty gitUrl in project %s", srcIdx, project)
+			continue
+		}
+
+		srcBranch, _ := srcMap["branch"].(string)
+		if srcBranch == "" {
+			srcBranch = "main"
+		}
+
+		srcPath, _ := srcMap["path"].(string)
+		if srcPath == "" {
+			srcPath = "workflows"
+		}
+
+		workflows := fetchWorkflowsFromSource(c, srcIdx, srcName, srcGitURL, srcBranch, srcPath, token)
+		allWorkflows = append(allWorkflows, workflows...)
+	}
+
+	return allWorkflows
+}
+
+// fetchWorkflowsFromSource discovers workflows from a single custom source repository.
+// Uses per-source caching with 5-min TTL via customSourceCaches.
+func fetchWorkflowsFromSource(c *gin.Context, srcIdx int, srcName, srcGitURL, srcBranch, srcPath, token string) []OOTBWorkflow {
+	cacheKey := fmt.Sprintf("%s|%s|%s", srcGitURL, srcBranch, srcPath)
+
+	// Check per-source cache
+	if cached, ok := customSourceCaches.Load(cacheKey); ok {
+		entry := cached.(*ootbWorkflowsCache)
+		entry.mu.RLock()
+		if time.Since(entry.cachedAt) < ootbCacheTTL && len(entry.workflows) > 0 {
+			workflows := make([]OOTBWorkflow, len(entry.workflows))
+			copy(workflows, entry.workflows)
+			entry.mu.RUnlock()
+			log.Printf("fetchWorkflowsFromSource: returning %d cached workflows for source %q (age: %v)", len(workflows), srcName, time.Since(entry.cachedAt).Round(time.Second))
+			return workflows
+		}
+		entry.mu.RUnlock()
+	}
+
+	// Parse the source git URL
+	owner, repoName, err := git.ParseGitHubURL(srcGitURL)
+	if err != nil {
+		log.Printf("fetchWorkflowsFromSource: invalid git URL %q for source %q: %v", srcGitURL, srcName, err)
+		return nil
+	}
+
+	// List workflow directories from the source
+	entries, err := fetchGitHubDirectoryListing(c.Request.Context(), owner, repoName, srcBranch, srcPath, token)
+	if err != nil {
+		log.Printf("fetchWorkflowsFromSource: failed to list directory for source %q (%s): %v", srcName, srcGitURL, err)
+		// Return stale cache if available
+		if cached, ok := customSourceCaches.Load(cacheKey); ok {
+			entry := cached.(*ootbWorkflowsCache)
+			entry.mu.RLock()
+			if len(entry.workflows) > 0 {
+				workflows := make([]OOTBWorkflow, len(entry.workflows))
+				copy(workflows, entry.workflows)
+				entry.mu.RUnlock()
+				log.Printf("fetchWorkflowsFromSource: returning stale cached workflows for source %q due to error", srcName)
+				return workflows
+			}
+			entry.mu.RUnlock()
+		}
+		return nil
+	}
+
+	// Scan each subdirectory for ambient.json
+	var workflows []OOTBWorkflow
+	for _, entry := range entries {
+		entryType, _ := entry["type"].(string)
+		entryName, _ := entry["name"].(string)
+		if entryType != "dir" {
+			continue
+		}
+
+		// Try to fetch ambient.json from this workflow directory
+		ambientPath := fmt.Sprintf("%s/%s/.ambient/ambient.json", srcPath, entryName)
+		ambientData, fetchErr := fetchGitHubFileContent(c.Request.Context(), owner, repoName, srcBranch, ambientPath, token)
+
+		var ambientConfig struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Enabled     *bool  `json:"enabled,omitempty"`
+		}
+		if fetchErr == nil {
+			if parseErr := json.Unmarshal(ambientData, &ambientConfig); parseErr != nil {
+				log.Printf("fetchWorkflowsFromSource: failed to parse ambient.json for %s/%s: %v", srcName, entryName, parseErr)
+			}
+		}
+
+		// Skip workflows explicitly disabled in ambient.json
+		if ambientConfig.Enabled != nil && !*ambientConfig.Enabled {
+			log.Printf("fetchWorkflowsFromSource: skipping disabled workflow %s/%s", srcName, entryName)
+			continue
+		}
+
+		workflowName := ambientConfig.Name
+		if workflowName == "" {
+			workflowName = strings.ReplaceAll(entryName, "-", " ")
+			workflowName = strings.Title(workflowName)
+		}
+
+		workflows = append(workflows, OOTBWorkflow{
+			ID:          fmt.Sprintf("%d-%s", srcIdx, entryName),
+			Name:        workflowName,
+			Description: ambientConfig.Description,
+			GitURL:      srcGitURL,
+			Branch:      srcBranch,
+			Path:        fmt.Sprintf("%s/%s", srcPath, entryName),
+			Enabled:     true,
+			Source:      srcName,
+		})
+	}
+
+	// Update per-source cache
+	newEntry := &ootbWorkflowsCache{}
+	newEntry.workflows = workflows
+	newEntry.cachedAt = time.Now()
+	newEntry.cacheKey = cacheKey
+	customSourceCaches.Store(cacheKey, newEntry)
+
+	log.Printf("fetchWorkflowsFromSource: discovered %d workflows from source %q (%s, cached for %v)", len(workflows), srcName, srcGitURL, ootbCacheTTL)
+	return workflows
 }
 
 func DeleteSession(c *gin.Context) {

--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -2777,7 +2777,7 @@ func fetchCustomSourceWorkflows(c *gin.Context, project, token string) []OOTBWor
 			srcPath = "workflows"
 		}
 
-		workflows := fetchWorkflowsFromSource(c, srcIdx, srcName, srcGitURL, srcBranch, srcPath, token)
+		workflows := fetchWorkflowsFromSource(c, project, srcIdx, srcName, srcGitURL, srcBranch, srcPath, token)
 		allWorkflows = append(allWorkflows, workflows...)
 	}
 
@@ -2786,8 +2786,8 @@ func fetchCustomSourceWorkflows(c *gin.Context, project, token string) []OOTBWor
 
 // fetchWorkflowsFromSource discovers workflows from a single custom source repository.
 // Uses per-source caching with 5-min TTL via customSourceCaches.
-func fetchWorkflowsFromSource(c *gin.Context, srcIdx int, srcName, srcGitURL, srcBranch, srcPath, token string) []OOTBWorkflow {
-	cacheKey := fmt.Sprintf("%s|%s|%s", srcGitURL, srcBranch, srcPath)
+func fetchWorkflowsFromSource(c *gin.Context, project string, srcIdx int, srcName, srcGitURL, srcBranch, srcPath, token string) []OOTBWorkflow {
+	cacheKey := fmt.Sprintf("%s|%s|%s|%s", project, srcGitURL, srcBranch, srcPath)
 
 	// Check per-source cache
 	if cached, ok := customSourceCaches.Load(cacheKey); ok {

--- a/components/backend/routes.go
+++ b/components/backend/routes.go
@@ -129,6 +129,10 @@ func registerRoutes(r *gin.Engine) {
 			projectGroup.GET("/mcp-servers", handlers.GetProjectMCPServers)
 			projectGroup.PUT("/mcp-servers", handlers.UpdateProjectMCPServers)
 
+			// Project-level workflow source configuration
+			projectGroup.GET("/workflow-sources", handlers.GetProjectWorkflowSources)
+			projectGroup.PUT("/workflow-sources", handlers.UpdateProjectWorkflowSources)
+
 			projectGroup.GET("/secrets", handlers.ListNamespaceSecrets)
 			projectGroup.GET("/runner-secrets", handlers.ListRunnerSecrets)
 			projectGroup.PUT("/runner-secrets", handlers.UpdateRunnerSecrets)

--- a/components/frontend/src/components/create-session-dialog.tsx
+++ b/components/frontend/src/components/create-session-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo, useRef } from "react";
+import { Fragment, useEffect, useState, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -34,6 +34,8 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -153,6 +155,22 @@ export function CreateSessionDialog({
     // above will set the new provider's default model.
     form.resetField("model", { defaultValue: "" });
   };
+
+  const { ootbGroup, customGroups } = useMemo(() => {
+    const enabled = ootbWorkflows.filter(w => w.enabled);
+    const ootb = enabled.filter(w => !w.source || w.source === 'ootb').sort((a, b) => a.name.localeCompare(b.name));
+    const bySource = new Map<string, typeof enabled>();
+    for (const w of enabled) {
+      if (w.source && w.source !== 'ootb') {
+        const arr = bySource.get(w.source) ?? [];
+        arr.push(w);
+        bySource.set(w.source, arr);
+      }
+    }
+    const sorted = Array.from(bySource.entries()).sort(([a], [b]) => a.localeCompare(b));
+    for (const [, wfs] of sorted) wfs.sort((a, b) => a.name.localeCompare(b.name));
+    return { ootbGroup: ootb, customGroups: sorted };
+  }, [ootbWorkflows]);
 
   const selectedWorkflowDescription = useMemo(() => {
     if (selectedWorkflow === "none") return "A general chat session with no structured workflow.";
@@ -394,14 +412,29 @@ export function CreateSessionDialog({
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="none">General chat</SelectItem>
-                      {ootbWorkflows
-                        .filter(w => w.enabled)
-                        .sort((a, b) => a.name.localeCompare(b.name))
-                        .map((workflow) => (
-                          <SelectItem key={workflow.id} value={workflow.id}>
-                            {workflow.name}
-                          </SelectItem>
-                        ))}
+                      {ootbGroup.length > 0 && (
+                        <>
+                          <SelectSeparator />
+                          <SelectLabel>Built-in Workflows</SelectLabel>
+                          {ootbGroup.map((workflow) => (
+                            <SelectItem key={workflow.id} value={workflow.id}>
+                              {workflow.name}
+                            </SelectItem>
+                          ))}
+                        </>
+                      )}
+                      {customGroups.map(([source, workflows]) => (
+                        <Fragment key={source}>
+                          <SelectSeparator />
+                          <SelectLabel>{source}</SelectLabel>
+                          {workflows.map((workflow) => (
+                            <SelectItem key={workflow.id} value={workflow.id}>
+                              {workflow.name}
+                            </SelectItem>
+                          ))}
+                        </Fragment>
+                      ))}
+                      <SelectSeparator />
                       <SelectItem value="custom">Custom workflow...</SelectItem>
                     </SelectContent>
                   </Select>

--- a/components/frontend/src/components/workspace-sections/settings-section.tsx
+++ b/components/frontend/src/components/workspace-sections/settings-section.tsx
@@ -14,6 +14,8 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { toast } from "sonner";
 import { useProject, useUpdateProject } from "@/services/queries/use-projects";
 import { useSecretsValues, useUpdateSecrets, useIntegrationSecrets, useUpdateIntegrationSecrets } from "@/services/queries/use-secrets";
+import { useWorkflowSources, useUpdateWorkflowSources } from "@/services/queries/use-workflows";
+import type { WorkflowSource } from "@/types/workflow";
 import { useClusterInfo } from "@/hooks/use-cluster-info";
 import { FeatureFlagsSection } from "./feature-flags-section";
 import { ProjectMcpSection } from "./project-mcp-section";
@@ -46,6 +48,8 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
   const [s3SecretKey, setS3SecretKey] = useState<string>("");
   const [showS3SecretKey, setShowS3SecretKey] = useState<boolean>(false);
   const [s3Expanded, setS3Expanded] = useState<boolean>(false);
+  const [workflowSources, setWorkflowSources] = useState<WorkflowSource[]>([]);
+  const [workflowSourcesExpanded, setWorkflowSourcesExpanded] = useState<boolean>(false);
 
   // Derive runner API key definitions from the runner-types registry.
   // Falls back to a hardcoded list if the fetch fails.
@@ -96,6 +100,8 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
   const updateProjectMutation = useUpdateProject();
   const updateSecretsMutation = useUpdateSecrets();
   const updateIntegrationSecretsMutation = useUpdateIntegrationSecrets();
+  const { data: workflowSourcesData } = useWorkflowSources(projectName);
+  const updateWorkflowSourcesMutation = useUpdateWorkflowSources(projectName);
 
   // Sync project data to form
   useEffect(() => {
@@ -126,6 +132,36 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
       setSecrets(allSecretsArr.filter(s => !FIXED_KEYS.includes(s.key)));
     }
   }, [runnerSecrets, integrationSecrets, FIXED_KEYS, allRequiredSecrets]);
+
+  // Sync workflow sources from query
+  useEffect(() => {
+    if (workflowSourcesData?.sources) {
+      setWorkflowSources(workflowSourcesData.sources);
+    }
+  }, [workflowSourcesData]);
+
+  const addWorkflowSource = () => {
+    setWorkflowSources(prev => [...prev, { name: '', gitUrl: '', branch: '', path: '' }]);
+  };
+
+  const removeWorkflowSource = (idx: number) => {
+    setWorkflowSources(prev => prev.filter((_, i) => i !== idx));
+  };
+
+  const updateWorkflowSource = (idx: number, field: keyof WorkflowSource, value: string) => {
+    setWorkflowSources(prev => prev.map((s, i) => i === idx ? { ...s, [field]: value } : s));
+  };
+
+  const handleSaveWorkflowSources = () => {
+    const validSources = workflowSources.filter(s => s.name.trim() && s.gitUrl.trim());
+    updateWorkflowSourcesMutation.mutate(
+      { sources: validSources },
+      {
+        onSuccess: () => toast.success("Workflow sources saved successfully"),
+        onError: (error) => toast.error(error instanceof Error ? error.message : "Failed to save workflow sources"),
+      }
+    );
+  };
 
   const handleSave = () => {
     if (!project) return;
@@ -613,6 +649,77 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
                 </>
               )}
             </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Workflow Sources</CardTitle>
+          <CardDescription>
+            Configure custom Git repositories containing workflow definitions. Workflows from these repos will appear alongside built-in workflows when creating sessions.
+          </CardDescription>
+        </CardHeader>
+        <Separator />
+        <CardContent className="space-y-4">
+          <div className="border rounded-lg">
+            <button
+              type="button"
+              onClick={() => setWorkflowSourcesExpanded(!workflowSourcesExpanded)}
+              className="w-full flex items-center justify-between p-3 hover:bg-muted/50 transition-colors rounded-lg"
+              aria-expanded={workflowSourcesExpanded}
+              aria-controls="workflow-sources-panel"
+            >
+              <div className="flex items-center gap-2">
+                {workflowSourcesExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                <span className="font-semibold">Custom Workflow Repositories</span>
+                {workflowSources.length > 0 && <span className="text-xs text-muted-foreground">({workflowSources.length} configured)</span>}
+              </div>
+            </button>
+            {workflowSourcesExpanded && (
+              <div id="workflow-sources-panel" className="px-3 pb-3 space-y-3 border-t pt-3">
+                {workflowSources.map((source, idx) => (
+                  <div key={idx} className="space-y-3 p-3 border rounded-lg">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">Source {idx + 1}</span>
+                      <Button variant="ghost" size="sm" onClick={() => removeWorkflowSource(idx)}>
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1">
+                        <Label className="text-xs">Name *</Label>
+                        <Input value={source.name} onChange={(e) => updateWorkflowSource(idx, 'name', e.target.value)} placeholder="My Team Workflows" />
+                      </div>
+                      <div className="space-y-1">
+                        <Label className="text-xs">Git Repository URL *</Label>
+                        <Input value={source.gitUrl} onChange={(e) => updateWorkflowSource(idx, 'gitUrl', e.target.value)} placeholder="https://github.com/org/workflows.git" />
+                      </div>
+                      <div className="space-y-1">
+                        <Label className="text-xs">Branch</Label>
+                        <Input value={source.branch || ''} onChange={(e) => updateWorkflowSource(idx, 'branch', e.target.value)} placeholder="main" />
+                      </div>
+                      <div className="space-y-1">
+                        <Label className="text-xs">Path</Label>
+                        <Input value={source.path || ''} onChange={(e) => updateWorkflowSource(idx, 'path', e.target.value)} placeholder="workflows" />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+                <Button variant="outline" size="sm" onClick={addWorkflowSource}>
+                  <Plus className="w-4 h-4 mr-2" /> Add Workflow Source
+                </Button>
+                <div className="pt-2">
+                  <Button onClick={handleSaveWorkflowSources} disabled={updateWorkflowSourcesMutation.isPending} size="sm">
+                    {updateWorkflowSourcesMutation.isPending ? (
+                      <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Saving...</>
+                    ) : (
+                      <><Save className="w-4 h-4 mr-2" />Save Workflow Sources</>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/components/frontend/src/services/adapters/v1/workflows.ts
+++ b/components/frontend/src/services/adapters/v1/workflows.ts
@@ -7,6 +7,8 @@ export function createWorkflowsAdapter(api: WorkflowsApi): WorkflowsPort {
   return {
     listOOTBWorkflows: api.listOOTBWorkflows,
     getWorkflowMetadata: api.getWorkflowMetadata,
+    getWorkflowSources: api.getWorkflowSources,
+    updateWorkflowSources: api.updateWorkflowSources,
   }
 }
 

--- a/components/frontend/src/services/api/workflows.ts
+++ b/components/frontend/src/services/api/workflows.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "./client";
+import type { WorkflowSourcesConfig } from "@/types/workflow";
 
 export type OOTBWorkflow = {
   id: string;
@@ -8,6 +9,7 @@ export type OOTBWorkflow = {
   branch: string;
   path?: string;
   enabled: boolean;
+  source?: string;
 };
 
 export type ListOOTBWorkflowsResponse = {
@@ -58,4 +60,18 @@ export async function getWorkflowMetadata(
     `/projects/${projectName}/agentic-sessions/${sessionName}/workflow/metadata`
   );
   return response;
+}
+
+export async function getWorkflowSources(projectName: string): Promise<WorkflowSourcesConfig> {
+  return apiClient.get<WorkflowSourcesConfig>(`/projects/${projectName}/workflow-sources`);
+}
+
+export async function updateWorkflowSources(
+  projectName: string,
+  config: WorkflowSourcesConfig
+): Promise<WorkflowSourcesConfig> {
+  return apiClient.put<WorkflowSourcesConfig, WorkflowSourcesConfig>(
+    `/projects/${projectName}/workflow-sources`,
+    config
+  );
 }

--- a/components/frontend/src/services/ports/types.ts
+++ b/components/frontend/src/services/ports/types.ts
@@ -13,6 +13,7 @@ export type { WorkspaceItem, GitMergeStatus, GitStatus } from '@/services/api/wo
 export type { ProjectKey, CreateKeyRequest, CreateKeyResponse } from '@/services/api/keys'
 export type { Secret, SecretList, SecretsConfig } from '@/services/api/secrets'
 export type { OOTBWorkflow, WorkflowMetadataResponse, WorkflowCommand, WorkflowAgent, WorkflowConfig } from '@/services/api/workflows'
+export type { WorkflowSourcesConfig } from '@/types/workflow'
 export type { RunnerType, RunnerTypeAuth } from '@/services/api/runner-types'
 export type { FeatureToggle } from '@/services/api/feature-flags-admin'
 export type { LDAPUser, LDAPGroup } from '@/services/api/ldap'

--- a/components/frontend/src/services/ports/workflows.ts
+++ b/components/frontend/src/services/ports/workflows.ts
@@ -1,6 +1,8 @@
-import type { OOTBWorkflow, WorkflowMetadataResponse } from './types'
+import type { OOTBWorkflow, WorkflowMetadataResponse, WorkflowSourcesConfig } from './types'
 
 export type WorkflowsPort = {
   listOOTBWorkflows: (projectName?: string) => Promise<OOTBWorkflow[]>
   getWorkflowMetadata: (projectName: string, sessionName: string) => Promise<WorkflowMetadataResponse>
+  getWorkflowSources: (projectName: string) => Promise<WorkflowSourcesConfig>
+  updateWorkflowSources: (projectName: string, config: WorkflowSourcesConfig) => Promise<WorkflowSourcesConfig>
 }

--- a/components/frontend/src/services/queries/use-workflows.ts
+++ b/components/frontend/src/services/queries/use-workflows.ts
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { workflowsAdapter } from '../adapters/workflows';
 import type { WorkflowsPort } from '../ports/workflows';
+import type { WorkflowSourcesConfig } from '@/types/workflow';
 import { BACKEND_VERSION } from './query-keys';
 
 export const workflowKeys = {
@@ -8,6 +9,7 @@ export const workflowKeys = {
   ootb: (projectName?: string) => [...workflowKeys.all, 'ootb', projectName] as const,
   metadata: (projectName: string, sessionName: string) =>
     [...workflowKeys.all, 'metadata', projectName, sessionName] as const,
+  sources: (projectName: string) => [...workflowKeys.all, 'sources', projectName] as const,
 };
 
 export function useOOTBWorkflows(projectName?: string, port: WorkflowsPort = workflowsAdapter) {
@@ -33,5 +35,26 @@ export function useWorkflowMetadata(
     queryFn: () => port.getWorkflowMetadata(projectName, sessionName),
     enabled: enabled && !!projectName && !!sessionName,
     staleTime: 60 * 1000,
+  });
+}
+
+export function useWorkflowSources(projectName: string, port: WorkflowsPort = workflowsAdapter) {
+  return useQuery({
+    queryKey: workflowKeys.sources(projectName),
+    queryFn: () => port.getWorkflowSources(projectName),
+    enabled: !!projectName,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useUpdateWorkflowSources(projectName: string, port: WorkflowsPort = workflowsAdapter) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (config: WorkflowSourcesConfig) =>
+      port.updateWorkflowSources(projectName, config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: workflowKeys.sources(projectName) });
+      queryClient.invalidateQueries({ queryKey: workflowKeys.ootb(projectName) });
+    },
   });
 }

--- a/components/frontend/src/types/workflow.ts
+++ b/components/frontend/src/types/workflow.ts
@@ -44,3 +44,20 @@ export type WorkflowSelection = {
   branch: string;
   path?: string;
 };
+
+/**
+ * A custom workflow source — a Git repository containing workflow definitions.
+ */
+export type WorkflowSource = {
+  name: string;
+  gitUrl: string;
+  branch?: string;
+  path?: string;
+};
+
+/**
+ * Configuration containing the list of custom workflow sources for a project.
+ */
+export type WorkflowSourcesConfig = {
+  sources: WorkflowSource[];
+};

--- a/components/manifests/base/crds/projectsettings-crd.yaml
+++ b/components/manifests/base/crds/projectsettings-crd.yaml
@@ -82,6 +82,27 @@ spec:
                     description: "List of default MCP server names to disable for all sessions in this project"
                     items:
                       type: string
+              workflowSources:
+                type: array
+                description: "Custom workflow source repositories. Workflows from these repos appear alongside OOTB workflows in session creation."
+                items:
+                  type: object
+                  required:
+                  - name
+                  - gitUrl
+                  properties:
+                    name:
+                      type: string
+                      description: "Display name for this workflow source"
+                    gitUrl:
+                      type: string
+                      description: "Git repository URL containing workflow definitions"
+                    branch:
+                      type: string
+                      description: "Branch to read workflows from (defaults to main)"
+                    path:
+                      type: string
+                      description: "Subdirectory containing workflows (defaults to workflows)"
           status:
             type: object
             properties:


### PR DESCRIPTION
## Summary

Implements [#1549](https://github.com/ambient-code/platform/issues/1549) — Custom Workflow Sources for session creation.

Teams that invest heavily in custom workflows currently have to manually fill out git repo URL, branch, and path every time they want to start a session with a custom workflow. This PR allows users to configure "workflow sources" (git repos containing workflow definitions) at the workspace level, so those workflows appear in the session creation dropdown alongside built-in OOTB workflows.

## What Changed

### Backend (Go)

- **CRD extension** (`projectsettings-crd.yaml`): Added `workflowSources` array to the ProjectSettings spec with `name`, `gitUrl`, `branch`, and `path` fields
- **New API endpoints** (`project_workflow_sources.go`): `GET/PUT /api/projects/:projectName/workflow-sources` for managing workflow sources, following the existing `project_mcp.go` pattern
- **Extended `ListOOTBWorkflows`** (`sessions.go`): Aggregates workflows from both the OOTB repo and project-level custom sources, with per-source 5-min caching, graceful failure handling, and namespace-scoped cache keys
- **Input validation**: Max 20 sources per project, required name/gitUrl, git URL format validation
- **Route registration** (`routes.go`): New routes inside `projectGroup` for auth middleware coverage

### Frontend (Next.js/React)

- **Types** (`workflow.ts`): `WorkflowSource`, `WorkflowSourcesConfig` types; added optional `source` field to `OOTBWorkflow`
- **API layer** (`workflows.ts`): `getWorkflowSources()` and `updateWorkflowSources()` client functions
- **Port/adapter** wiring for the new API methods
- **React Query hooks** (`use-workflows.ts`): `useWorkflowSources` and `useUpdateWorkflowSources` with cache invalidation
- **Workspace settings UI** (`settings-section.tsx`): New "Workflow Sources" card with add/edit/remove source entries (name, git URL, branch, path)
- **Session creation dialog** (`create-session-dialog.tsx`): Workflows grouped by source using `SelectLabel` and `SelectSeparator` — built-in workflows separated from custom source groups

## Testing Performed

- Go backend builds with `go build ./...` and `go vet ./...` — no errors
- Frontend builds with `npm run build` — 0 errors, 0 warnings
- Code reviewed against CLAUDE.md conventions:
  - All handlers use `GetK8sClientsForRequest()` for user-scoped auth
  - No `any` types in TypeScript
  - No `panic()` in Go code
  - No tokens in log messages
  - Namespace-scoped cache keys to prevent cross-tenant leakage

## Screenshots

N/A — UI changes follow existing Shadcn design patterns (Card, Input, Button, Select with groups). The workflow selector now shows grouped items with section labels.

## Breaking Changes

None. The CRD extension is additive (new optional field). Existing sessions and workflows are unaffected. Workflow sources default to empty (no change in behavior without configuration).

Relates to #1549