### PR TITLE
[codex] Fix skill frontmatter metadata

### DIFF
--- a/skills/integrations/grpc-dev/SKILL.md
+++ b/skills/integrations/grpc-dev/SKILL.md
@@ -1,8 +1,12 @@
-# Skill: grpc-dev
-
-**Activates when:** Working on gRPC streaming, AG-UI event flow, WatchSessionMessages, control plane ↔ runner protocol, or debugging gRPC connectivity.
-
 ---
+name: grpc-dev
+description: >
+  Use when working on gRPC streaming, AG-UI event flow,
+  WatchSessionMessages, the control-plane-to-runner protocol, or
+  debugging gRPC connectivity in Ambient.
+---
+
+# gRPC Development
 
 ## Architecture
 

--- a/skills/sessions/ambient-api-server/SKILL.md
+++ b/skills/sessions/ambient-api-server/SKILL.md
@@ -1,8 +1,12 @@
-# Skill: ambient-api-server
-
-**Activates when:** Working in `components/ambient-api-server/` or asked about API server, REST endpoints, gRPC, OpenAPI, or plugins.
-
 ---
+name: ambient-api-server
+description: >
+  Use when working in components/ambient-api-server/ or on the Ambient API
+  Server's REST endpoints, gRPC streams, OpenAPI generation, plugin resources,
+  auth, migrations, or tests.
+---
+
+# Ambient API Server
 
 ## What This Skill Knows
 


### PR DESCRIPTION
## Summary

- Add required YAML frontmatter to grpc-dev and ambient-api-server skills.
- Preserve the existing skill instructions while moving trigger text into the metadata description field.

## Root Cause

The two SKILL.md files started with Markdown headings instead of YAML frontmatter delimited by ---, so Codex skipped loading them as invalid skills.

## Validation

- python /Users/jeder/.agents/skills/skill-creator/scripts/quick_validate.py skills/integrations/grpc-dev
- python /Users/jeder/.agents/skills/skill-creator/scripts/quick_validate.py skills/sessions/ambient-api-server
- git diff --check
- pre-commit hooks run during commit and push

## Self-Review

- Scope is limited to the two invalid skill metadata files.
- No production code, frontend TypeScript, API endpoints, Kubernetes resources, or secrets changed.