### PR TITLE
fix(manifests): add NetworkPolicy allowing runner pods to reach ambient-code namespace

### DIFF
--- a/components/manifests/base/kustomization.yaml
+++ b/components/manifests/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - platform
 - ambient-control-plane-service.yml
 - ambient-control-plane-token-svc.yaml
+- runner-networkpolicy.yaml
 
 # Default images (can be overridden by overlays)
 images:

--- a/components/manifests/base/runner-networkpolicy.yaml
+++ b/components/manifests/base/runner-networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-runner-namespaces
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          app: ambient-code-runner


### PR DESCRIPTION
## Summary
- Adds a `NetworkPolicy` (`allow-from-runner-namespaces`) to the base kustomize manifests that permits ingress from runner pods (`app: ambient-code-runner`) in any namespace to the `ambient-code` namespace
- Fixes `INITIAL_PROMPT TimeoutError` caused by default-deny NetworkPolicies blocking cross-namespace traffic from runner pods to `backend-service`
- Already applied on the live `hcmais01ue1` cluster; this PR codifies the fix in manifests

## Context
This is a follow-up to PR #1546 (MCP sidecar TLS + BACKEND_URL fixes). The NetworkPolicy was applied on-cluster during incident response but was not included in the merged PR.

## Test plan
- [x] Verified on live cluster: runner pods can reach `backend-service` and `INITIAL_PROMPT` succeeds
- [ ] `kustomize build components/manifests/overlays/production` renders without errors
- [ ] Next production deploy includes the NetworkPolicy

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network security policy to restrict ingress traffic, allowing connections only from designated runner pods in their respective namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->