### PR TITLE
feat: add NetworkPolicy to allow runner pod ingress

### DIFF
--- a/.tekton/ambient-code-ambient-api-server-main-pull-request.yaml
+++ b/.tekton/ambient-code-ambient-api-server-main-pull-request.yaml
@@ -1,0 +1,586 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "./components/ambient-api-server/***".pathChanged() || ".tekton/ambient-code-ambient-api-server-main-pull-request.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-ambient-api-server-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-ambient-api-server-main-on-pull-request
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/ambient-api-server
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-ambient-api-server-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-ambient-api-server-main-pull-request.yaml
+++ b/.tekton/ambient-code-ambient-api-server-main-pull-request.yaml
@@ -563,7 +563,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-ambient-api-server-main-pull-request.yaml
+++ b/.tekton/ambient-code-ambient-api-server-main-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./components/ambient-api-server/***".pathChanged() || ".tekton/ambient-code-ambient-api-server-main-pull-request.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/ambient-api-server/**".pathChanged() || ".tekton/ambient-code-ambient-api-server-main-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-ambient-api-server-main-push.yaml
+++ b/.tekton/ambient-code-ambient-api-server-main-push.yaml
@@ -1,0 +1,583 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "./components/ambient-api-server/***".pathChanged() || ".tekton/ambient-code-ambient-api-server-main-push.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-ambient-api-server-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-ambient-api-server-main-on-push
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/ambient-api-server
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-ambient-api-server-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-ambient-api-server-main-push.yaml
+++ b/.tekton/ambient-code-ambient-api-server-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./components/ambient-api-server/***".pathChanged() || ".tekton/ambient-code-ambient-api-server-main-push.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/ambient-api-server/**".pathChanged() || ".tekton/ambient-code-ambient-api-server-main-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-ambient-api-server-main-push.yaml
+++ b/.tekton/ambient-code-ambient-api-server-main-push.yaml
@@ -560,7 +560,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-ambient-runner-main-pull-request.yaml
+++ b/.tekton/ambient-code-ambient-runner-main-pull-request.yaml
@@ -1,0 +1,582 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "./components/runners/ambient-runner/***".pathChanged() || ".tekton/ambient-code-ambient-runner-main-pull-request.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-ambient-runner-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-ambient-runner-main-on-pull-request
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/runners/ambient-runner
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:9917d11f0a38c844184042d504b3d5605c009e6e43785fa113caae8b4c99b75e
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:5375e5b9f5efdb8b27ed981da7d481027a184047138232937992a7027c8bca93
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:ae3fa44f005054d4901d33413972227b5642d376968a67791535cdcc2e98473d
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-ambient-runner-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-ambient-runner-main-pull-request.yaml
+++ b/.tekton/ambient-code-ambient-runner-main-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./components/runners/ambient-runner/***".pathChanged() || ".tekton/ambient-code-ambient-runner-main-pull-request.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/runners/ambient-runner/**".pathChanged() || ".tekton/ambient-code-ambient-runner-main-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-ambient-runner-main-pull-request.yaml
+++ b/.tekton/ambient-code-ambient-runner-main-pull-request.yaml
@@ -559,7 +559,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-ambient-runner-main-push.yaml
+++ b/.tekton/ambient-code-ambient-runner-main-push.yaml
@@ -1,0 +1,579 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "./components/runners/ambient-runner/***".pathChanged() || ".tekton/ambient-code-ambient-runner-main-push.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-ambient-runner-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-ambient-runner-main-on-push
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/runners/ambient-runner
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:9917d11f0a38c844184042d504b3d5605c009e6e43785fa113caae8b4c99b75e
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:5375e5b9f5efdb8b27ed981da7d481027a184047138232937992a7027c8bca93
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:ae3fa44f005054d4901d33413972227b5642d376968a67791535cdcc2e98473d
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-ambient-runner-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-ambient-runner-main-push.yaml
+++ b/.tekton/ambient-code-ambient-runner-main-push.yaml
@@ -556,7 +556,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-ambient-runner-main-push.yaml
+++ b/.tekton/ambient-code-ambient-runner-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./components/runners/ambient-runner/***".pathChanged() || ".tekton/ambient-code-ambient-runner-main-push.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/runners/ambient-runner/**".pathChanged() || ".tekton/ambient-code-ambient-runner-main-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-backend-main-pull-request.yaml
+++ b/.tekton/ambient-code-backend-main-pull-request.yaml
@@ -1,0 +1,586 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "./components/backend/***".pathChanged() || ".tekton/ambient-code-backend-main-pull-request.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-backend-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-backend-main-on-pull-request
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/backend
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-backend-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-backend-main-pull-request.yaml
+++ b/.tekton/ambient-code-backend-main-pull-request.yaml
@@ -563,7 +563,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-backend-main-pull-request.yaml
+++ b/.tekton/ambient-code-backend-main-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./components/backend/***".pathChanged() || ".tekton/ambient-code-backend-main-pull-request.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/backend/**".pathChanged() || ".tekton/ambient-code-backend-main-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-backend-main-push.yaml
+++ b/.tekton/ambient-code-backend-main-push.yaml
@@ -1,0 +1,583 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "./components/backend/***".pathChanged() || ".tekton/ambient-code-backend-main-push.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-backend-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-backend-main-on-push
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/backend
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-backend-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-backend-main-push.yaml
+++ b/.tekton/ambient-code-backend-main-push.yaml
@@ -560,7 +560,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-backend-main-push.yaml
+++ b/.tekton/ambient-code-backend-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./components/backend/***".pathChanged() || ".tekton/ambient-code-backend-main-push.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/backend/**".pathChanged() || ".tekton/ambient-code-backend-main-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-frontend-main-pull-request.yaml
+++ b/.tekton/ambient-code-frontend-main-pull-request.yaml
@@ -1,0 +1,586 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "./components/frontend/***".pathChanged() || ".tekton/ambient-code-frontend-main-pull-request.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-frontend-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-frontend-main-on-pull-request
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/frontend
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-frontend-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-frontend-main-pull-request.yaml
+++ b/.tekton/ambient-code-frontend-main-pull-request.yaml
@@ -563,7 +563,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-frontend-main-pull-request.yaml
+++ b/.tekton/ambient-code-frontend-main-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./components/frontend/***".pathChanged() || ".tekton/ambient-code-frontend-main-pull-request.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/frontend/**".pathChanged() || ".tekton/ambient-code-frontend-main-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-frontend-main-push.yaml
+++ b/.tekton/ambient-code-frontend-main-push.yaml
@@ -1,0 +1,583 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "./components/frontend/***".pathChanged() || ".tekton/ambient-code-frontend-main-push.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-frontend-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-frontend-main-on-push
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/frontend
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-frontend-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-frontend-main-push.yaml
+++ b/.tekton/ambient-code-frontend-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./components/frontend/***".pathChanged() || ".tekton/ambient-code-frontend-main-push.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/frontend/**".pathChanged() || ".tekton/ambient-code-frontend-main-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-frontend-main-push.yaml
+++ b/.tekton/ambient-code-frontend-main-push.yaml
@@ -560,7 +560,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-operator-main-pull-request.yaml
+++ b/.tekton/ambient-code-operator-main-pull-request.yaml
@@ -1,0 +1,586 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "./components/operator/***".pathChanged() || ".tekton/ambient-code-operator-main-pull-request.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-operator-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-operator-main-on-pull-request
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/operator
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-operator-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-operator-main-pull-request.yaml
+++ b/.tekton/ambient-code-operator-main-pull-request.yaml
@@ -563,7 +563,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-operator-main-pull-request.yaml
+++ b/.tekton/ambient-code-operator-main-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./components/operator/***".pathChanged() || ".tekton/ambient-code-operator-main-pull-request.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/operator/**".pathChanged() || ".tekton/ambient-code-operator-main-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-operator-main-push.yaml
+++ b/.tekton/ambient-code-operator-main-push.yaml
@@ -1,0 +1,583 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "./components/operator/***".pathChanged() || ".tekton/ambient-code-operator-main-push.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-operator-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-operator-main-on-push
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/operator
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-operator-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-operator-main-push.yaml
+++ b/.tekton/ambient-code-operator-main-push.yaml
@@ -560,7 +560,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-operator-main-push.yaml
+++ b/.tekton/ambient-code-operator-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./components/operator/***".pathChanged() || ".tekton/ambient-code-operator-main-push.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/operator/**".pathChanged() || ".tekton/ambient-code-operator-main-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-public-api-main-pull-request.yaml
+++ b/.tekton/ambient-code-public-api-main-pull-request.yaml
@@ -1,0 +1,586 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "./components/public-api/***".pathChanged() || ".tekton/ambient-code-public-api-main-pull-request.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-public-api-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-public-api-main-on-pull-request
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/public-api
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-public-api-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-public-api-main-pull-request.yaml
+++ b/.tekton/ambient-code-public-api-main-pull-request.yaml
@@ -563,7 +563,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ambient-code-public-api-main-pull-request.yaml
+++ b/.tekton/ambient-code-public-api-main-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./components/public-api/***".pathChanged() || ".tekton/ambient-code-public-api-main-pull-request.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/public-api/**".pathChanged() || ".tekton/ambient-code-public-api-main-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-public-api-main-push.yaml
+++ b/.tekton/ambient-code-public-api-main-push.yaml
@@ -1,0 +1,583 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/ambient-code-platform?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "./components/public-api/***".pathChanged() || ".tekton/ambient-code-public-api-main-push.yaml".pathChanged()
+      || "Dockerfile".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ambient-code-main
+    appstudio.openshift.io/component: ambient-code-public-api-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ambient-code-public-api-main-on-push
+  namespace: hcm-eng-prod-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: components/public-api
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: docker
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      name: buildah-format
+      type: string
+    - default: "false"
+      description: Enable cache proxy configuration
+      name: enable-cache-proxy
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:2229dbc5e15acc0a6d8aec526465aeb0ad54e269c311ac3d0aba88013845e308
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:cad04a0f4464283714c23940ef6052753821eff7544ec282e2a4707aa264aaf3
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:3fa26d2c0768329c2df93c646bf5855245b74db7196ad55f83756ce22cd7f0f1
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:362f0475df00e7dfb5f15dea0481d1b68b287f60411718d70a23da3c059a5613
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:9397d3eb9f1cbebaa15e93256e0ca9eaca148baa674be72f07f4a00df63c4609
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:6045ed6f2d37cfdf75cb3f2bf88706839c276a59f892ae027a315456c2914cf3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ab60e90de028036be823e75343fdc205418edcfa7c4de569bb5f8ab833bc2037
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:de35caf2f090e3275cfd1019ea50d9662422e904fb4aebd6ea29fb53a1ad57f5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c314b4d5369d7961af51c865be28cd792d5f233aef94ecf035b3f84acde398bf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:3d8a6902ab7c5c2125be07263f395426342c5032b3abfd0140162ad838437bab
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:aa62b41861c09e2e59c69cc6e9a1f740bf0c81e6a1eb03f57f59dfda0f65840e
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ambient-code-public-api-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ambient-code-public-api-main-push.yaml
+++ b/.tekton/ambient-code-public-api-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./components/public-api/***".pathChanged() || ".tekton/ambient-code-public-api-main-push.yaml".pathChanged()
-      || "Dockerfile".pathChanged() )
+      == "main" && ( "components/public-api/**".pathChanged() || ".tekton/ambient-code-public-api-main-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ambient-code-main

--- a/.tekton/ambient-code-public-api-main-push.yaml
+++ b/.tekton/ambient-code-public-api-main-push.yaml
@@ -560,7 +560,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b2224a0442ac705e20a25b8609e1760321d9d86da7901fd0392a90102688e37d
         - name: kind
           value: task
         resolver: bundles

--- a/components/ambient-api-server/templates/db-template.yml
+++ b/components/ambient-api-server/templates/db-template.yml
@@ -14,7 +14,7 @@ parameters:
     description: The name of the OpenShift Service exposed for the database.
     displayName: Database Service Name
     required: true
-    value: ambient-api-server-db
+    value: ambient-code-rds
 
   - name: DATABASE_USER
     description: Username for PostgreSQL user that will be used for accessing the database.

--- a/components/manifests/README.md
+++ b/components/manifests/README.md
@@ -26,7 +26,7 @@ manifests/
 │   ├── platform/                          # Cluster-level resources
 │   │   ├── namespace.yaml
 │   │   ├── ambient-api-server-db.yml      # ambient-api-server PostgreSQL deployment
-│   │   └── ambient-api-server-secrets.yml # Secret template (values injected per-env)
+│   │   └── ambient-api-server-secrets.yml # Secret template (ambient-code-rds secret for DB)
 │   ├── crds/                              # Custom Resource Definitions
 │   │   ├── agenticsessions-crd.yaml
 │   │   └── projectsettings-crd.yaml
@@ -121,7 +121,7 @@ Components are opt-in kustomize modules included via the `components:` block in 
 |---|---|---|
 | `oauth-proxy` | Adds OpenShift OAuth proxy sidecar to frontend | `production` |
 | `postgresql-rhel` | Patches PostgreSQL to use `registry.redhat.io/rhel10/postgresql-16` | `production`, `local-dev` |
-| `ambient-api-server-db` | Same RHEL patch for the ambient-api-server's dedicated DB | `production`, `local-dev` |
+| `ambient-api-server-db` | RHEL patch for ambient-api-server DB (updates ambient-code-rds secret refs) | `production`, `local-dev` |
 | `postgresql-init-scripts` | ConfigMap + volume for DB init SQL (vanilla postgres only) | `kind`, `e2e` |
 
 ## Building and Validating

--- a/components/manifests/base/core/ambient-api-server-service.yml
+++ b/components/manifests/base/core/ambient-api-server-service.yml
@@ -146,7 +146,7 @@ spec:
       volumes:
         - name: db-secrets
           secret:
-            secretName: ambient-api-server-db
+            secretName: ambient-code-rds
         - name: app-secrets
           secret:
             secretName: ambient-api-server

--- a/components/manifests/base/core/operator-deployment.yaml
+++ b/components/manifests/base/core/operator-deployment.yaml
@@ -136,8 +136,9 @@ spec:
         # - name: DEFAULT_INACTIVITY_TIMEOUT
         #   value: "86400"  # Default inactivity timeout in seconds (24h). Set to 0 to disable.
         # OpenTelemetry configuration
-        - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: "otel-collector.ambient-code.svc:4317"  # Deploy OTel collector separately
+        # Disabled: OTel collector not deployed. Uncomment when collector is available.
+        # - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        #   value: "otel-collector.ambient-code.svc:4317"  # Deploy OTel collector separately
         - name: DEPLOYMENT_ENV
           value: "production"
         - name: VERSION

--- a/components/manifests/base/platform/ambient-api-server-db.yml
+++ b/components/manifests/base/platform/ambient-api-server-db.yml
@@ -65,17 +65,17 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: db.user
-                  name: ambient-api-server-db
+                  name: ambient-code-rds
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: db.password
-                  name: ambient-api-server-db
+                  name: ambient-code-rds
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
                   key: db.name
-                  name: ambient-api-server-db
+                  name: ambient-code-rds
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           volumeMounts:

--- a/components/manifests/base/platform/ambient-api-server-secrets.yml
+++ b/components/manifests/base/platform/ambient-api-server-secrets.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ambient-api-server-db
+  name: ambient-code-rds
   labels:
     app: ambient-api-server
     component: database

--- a/components/manifests/base/rbac/frontend-rbac.yaml
+++ b/components/manifests/base/rbac/frontend-rbac.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: frontend
   namespace: ambient-code
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.frontend: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"frontend"}}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -24,6 +26,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: ambient-frontend-auth
+subjects:
+- kind: ServiceAccount
+  name: frontend
+  namespace: ambient-code
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ambient-frontend-oauth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
   name: frontend

--- a/components/manifests/components/ambient-api-server-db/ambient-api-server-db-json-patch.yaml
+++ b/components/manifests/components/ambient-api-server-db/ambient-api-server-db-json-patch.yaml
@@ -11,17 +11,17 @@
   - name: POSTGRESQL_USER
     valueFrom:
       secretKeyRef:
-        name: ambient-api-server-db
+        name: ambient-code-rds
         key: db.user
   - name: POSTGRESQL_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: ambient-api-server-db
+        name: ambient-code-rds
         key: db.password
   - name: POSTGRESQL_DATABASE
     valueFrom:
       secretKeyRef:
-        name: ambient-api-server-db
+        name: ambient-code-rds
         key: db.name
 - op: replace
   path: /spec/template/spec/containers/0/volumeMounts

--- a/components/manifests/components/ambient-api-server-db/ambient-api-server-init-db-patch.yaml
+++ b/components/manifests/components/ambient-api-server-db/ambient-api-server-init-db-patch.yaml
@@ -41,20 +41,20 @@ spec:
         - name: PGHOST
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.host
         - name: PGUSER
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.user
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.password
         - name: PGDATABASE
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.name

--- a/components/manifests/components/ambient-api-server-db/kustomization.yaml
+++ b/components/manifests/components/ambient-api-server-db/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-# Requires: ambient-api-server-db Secret in the target namespace
+# Requires: ambient-code-rds Secret in the target namespace
 
 patches:
 - path: ambient-api-server-db-json-patch.yaml

--- a/components/manifests/components/oauth-proxy/frontend-oauth-deployment-patch.yaml
+++ b/components/manifests/components/oauth-proxy/frontend-oauth-deployment-patch.yaml
@@ -1,5 +1,6 @@
 # Patch for production frontend deployment
-# - Adds OAuth proxy sidecar for authentication
+# - Adds OAuth proxy sidecar for authentication using OpenShift OAuth
+# - Uses service account token for cookie secret (no vault secret needed)
 # - Overrides resource limits to prevent OOMKills (sawtooth memory pattern)
 apiVersion: apps/v1
 kind: Deployment
@@ -20,19 +21,18 @@ spec:
             cpu: 1000m
       # OAuth proxy sidecar
       - name: oauth-proxy
-        image: quay.io/openshift/origin-oauth-proxy:4.14
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.18.0-202506230505.p0.gcbd44ad.assembly.stream.el9
+        imagePullPolicy: IfNotPresent
         args:
-        - --http-address=:8443
-        - --https-address=
+        - --https-address=:8443
         - --provider=openshift
+        - --openshift-service-account=frontend
         - --upstream=http://localhost:3000
-        - --client-id=ambient-frontend
-        - --client-secret-file=/etc/oauth/config/client-secret
-        - --cookie-secret-file=/etc/oauth/config/cookie_secret
-        - --cookie-expire=23h0m0s
-        - --pass-access-token
-        - --scope=user:full
-        - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
+        - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - --upstream-timeout=5m
         - --skip-auth-regex=^/metrics
         ports:
         - containerPort: 8443
@@ -41,38 +41,33 @@ spec:
           httpGet:
             path: /oauth/healthz
             port: dashboard-ui
-            scheme: HTTP
-          initialDelaySeconds: 30
+            scheme: HTTPS
+          initialDelaySeconds: 10
           timeoutSeconds: 1
-          periodSeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /oauth/healthz
             port: dashboard-ui
-            scheme: HTTP
-          initialDelaySeconds: 5
+            scheme: HTTPS
+          initialDelaySeconds: 10
           timeoutSeconds: 1
-          periodSeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           failureThreshold: 3
         resources:
           requests:
-            memory: 256Mi
-            cpu: 50m
+            memory: 50Mi
+            cpu: 10m
           limits:
-            memory: 512Mi
+            memory: 200Mi
             cpu: 200m
         volumeMounts:
-        - mountPath: /etc/oauth/config
-          name: oauth-config
         - mountPath: /etc/tls/private
-          name: proxy-tls
+          name: frontend-proxy-tls
       volumes:
-      - name: oauth-config
+      - name: frontend-proxy-tls
         secret:
-          secretName: frontend-oauth-config
-      - name: proxy-tls
-        secret:
-          secretName: dashboard-proxy-tls
+          secretName: frontend-proxy-tls

--- a/components/manifests/components/oauth-proxy/frontend-oauth-deployment-patch.yaml
+++ b/components/manifests/components/oauth-proxy/frontend-oauth-deployment-patch.yaml
@@ -28,6 +28,7 @@ spec:
         - --provider=openshift
         - --openshift-service-account=frontend
         - --upstream=http://localhost:3000
+        - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token

--- a/components/manifests/components/oauth-proxy/frontend-oauth-deployment-patch.yaml
+++ b/components/manifests/components/oauth-proxy/frontend-oauth-deployment-patch.yaml
@@ -28,7 +28,6 @@ spec:
         - --provider=openshift
         - --openshift-service-account=frontend
         - --upstream=http://localhost:3000
-        - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token

--- a/components/manifests/components/oauth-proxy/frontend-oauth-service-patch.yaml
+++ b/components/manifests/components/oauth-proxy/frontend-oauth-service-patch.yaml
@@ -1,10 +1,12 @@
 # Patch to add OAuth port to frontend service
+# - Adds HTTPS port for OAuth proxy sidecar
+# - Uses service.alpha annotation for auto-generated TLS cert
 apiVersion: v1
 kind: Service
 metadata:
   name: frontend-service
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: dashboard-proxy-tls
+    service.alpha.openshift.io/serving-cert-secret-name: frontend-proxy-tls
 spec:
   ports:
   - port: 8443

--- a/components/manifests/overlays/app-interface/ambient-api-server-db-secret-patch.yaml
+++ b/components/manifests/overlays/app-interface/ambient-api-server-db-secret-patch.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ambient-api-server-db
+  name: ambient-code-rds
   labels:
     app: ambient-api-server
     component: database

--- a/components/manifests/overlays/app-interface/ambient-api-server-db-secret-patch.yaml
+++ b/components/manifests/overlays/app-interface/ambient-api-server-db-secret-patch.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ambient-api-server-db
+  labels:
+    app: ambient-api-server
+    component: database
+  annotations:
+    # External RDS credentials injected from Vault at runtime
+    qontract.recycle: "true"
+type: Opaque
+stringData:
+  # Placeholders - actual values injected from Vault at runtime
+  db.host: "VAULT_INJECTED"
+  db.port: "5432"
+  db.name: "ambient_code"
+  db.user: "VAULT_INJECTED"
+  db.password: "VAULT_INJECTED"

--- a/components/manifests/overlays/app-interface/ambient-api-server-db-secret-patch.yaml
+++ b/components/manifests/overlays/app-interface/ambient-api-server-db-secret-patch.yaml
@@ -7,7 +7,9 @@ metadata:
     app: ambient-api-server
     component: database
   annotations:
-    # External RDS credentials injected from Vault at runtime
+    # External RDS connection managed via Vault secrets from app-interface Phase 2
+    # These values will be injected by vault-secret-manager from Vault path:
+    # app-interface/data/ambient-code-platform/stage/rds-credentials
     qontract.recycle: "true"
 type: Opaque
 stringData:

--- a/components/manifests/overlays/app-interface/ambient-api-server-env-patch.yaml
+++ b/components/manifests/overlays/app-interface/ambient-api-server-env-patch.yaml
@@ -1,0 +1,13 @@
+# App-interface: set environment to stage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-api-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: api-server
+          env:
+            - name: AMBIENT_ENV
+              value: stage

--- a/components/manifests/overlays/app-interface/ambient-api-server-route.yaml
+++ b/components/manifests/overlays/app-interface/ambient-api-server-route.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ambient-api-server
+  labels:
+    app: ambient-api-server
+    component: api
+spec:
+  to:
+    kind: Service
+    name: ambient-api-server
+  port:
+    targetPort: api
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ambient-api-server-grpc
+  labels:
+    app: ambient-api-server
+    component: grpc
+spec:
+  to:
+    kind: Service
+    name: ambient-api-server
+  port:
+    targetPort: grpc
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/components/manifests/overlays/app-interface/ambient-api-server-service-ca-patch.yaml
+++ b/components/manifests/overlays/app-interface/ambient-api-server-service-ca-patch.yaml
@@ -1,0 +1,7 @@
+# OpenShift service-ca: auto-provision and rotate TLS certs for ambient-api-server
+apiVersion: v1
+kind: Service
+metadata:
+  name: ambient-api-server
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ambient-api-server-tls

--- a/components/manifests/overlays/app-interface/ambient-api-server-ssl-patch.yaml
+++ b/components/manifests/overlays/app-interface/ambient-api-server-ssl-patch.yaml
@@ -1,0 +1,52 @@
+# App-interface (stage): enable SSL for external RDS connection
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-api-server
+spec:
+  template:
+    spec:
+      # Migration init container: add SSL mode
+      initContainers:
+        - name: migration
+          command:
+            - /usr/local/bin/ambient-api-server
+            - migrate
+            - --db-host-file=/secrets/db/db.host
+            - --db-port-file=/secrets/db/db.port
+            - --db-user-file=/secrets/db/db.user
+            - --db-password-file=/secrets/db/db.password
+            - --db-name-file=/secrets/db/db.name
+            - --db-sslmode=require
+            - --alsologtostderr
+            - -v=4
+      # API server container: add SSL mode
+      containers:
+        - name: api-server
+          command:
+            - /usr/local/bin/ambient-api-server
+            - serve
+            - --db-host-file=/secrets/db/db.host
+            - --db-port-file=/secrets/db/db.port
+            - --db-user-file=/secrets/db/db.user
+            - --db-password-file=/secrets/db/db.password
+            - --db-name-file=/secrets/db/db.name
+            - --enable-jwt=true
+            - --enable-authz=false
+            - --jwk-cert-file=/configs/authentication/jwks.json
+            - --enable-https=false
+            - --api-server-bindaddress=:8000
+            - --metrics-server-bindaddress=:4433
+            - --health-check-server-bindaddress=:4434
+            - --db-sslmode=require
+            - --db-max-open-connections=50
+            - --enable-db-debug=false
+            - --enable-metrics-https=false
+            - --http-read-timeout=5s
+            - --http-write-timeout=30s
+            - --cors-allowed-origins=*
+            - --cors-allowed-headers=X-Ambient-Project
+            - --enable-grpc=true
+            - --grpc-server-bindaddress=:9000
+            - --alsologtostderr
+            - -v=4

--- a/components/manifests/overlays/app-interface/backend-route.yaml
+++ b/components/manifests/overlays/app-interface/backend-route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: backend-route
+  labels:
+    app: backend-api
+spec:
+  to:
+    kind: Service
+    name: backend-service
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/components/manifests/overlays/app-interface/kustomization.yaml
+++ b/components/manifests/overlays/app-interface/kustomization.yaml
@@ -1,0 +1,103 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: ambient-code-app-interface
+
+# Target namespace on hcmais01ue1 cluster
+namespace: ambient-code
+
+# Include base resources (CRDs, RBAC, core deployments, platform)
+resources:
+- ../../base
+- route.yaml
+- backend-route.yaml
+- public-api-route.yaml
+- ambient-api-server-route.yaml
+- operator-config-openshift.yaml
+
+# Patches to configure external resources
+patches:
+# Update operator to use Konflux runner image
+- path: operator-runner-image-patch.yaml
+  target:
+    kind: Deployment
+    name: agentic-operator
+# Scale down in-cluster databases to 0 (using external RDS from Phase 2)
+- target:
+    kind: Deployment
+    name: postgresql
+  patch: |-
+    - op: replace
+      path: /spec/replicas
+      value: 0
+- target:
+    kind: Deployment
+    name: ambient-api-server-db
+  patch: |-
+    - op: replace
+      path: /spec/replicas
+      value: 0
+
+# Scale down in-cluster MinIO to 0 (using external S3 from Phase 2)
+- target:
+    kind: Deployment
+    name: minio
+  patch: |-
+    - op: replace
+      path: /spec/replicas
+      value: 0
+
+# Scale down in-cluster Unleash to 0 (will configure external instance later)
+- target:
+    kind: Deployment
+    name: unleash
+  patch: |-
+    - op: replace
+      path: /spec/replicas
+      value: 0
+
+# Patch ambient-api-server-db secret to use external RDS (from Vault)
+- path: ambient-api-server-db-secret-patch.yaml
+  target:
+    kind: Secret
+    name: ambient-api-server-db
+
+# Konflux image overrides (redhat-services-prod)
+images:
+- name: quay.io/ambient_code/vteam_operator
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_operator:latest
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_backend
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_backend:latest
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_frontend
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_frontend:latest
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_public_api
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_public_api:latest
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_api_server
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_api_server:latest
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_claude_runner
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main
+  newTag: latest
+- name: quay.io/ambient_code/vteam_claude_runner:latest
+  newName: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main
+  newTag: latest

--- a/components/manifests/overlays/app-interface/kustomization.yaml
+++ b/components/manifests/overlays/app-interface/kustomization.yaml
@@ -16,6 +16,10 @@ resources:
 - ambient-api-server-route.yaml
 - operator-config-openshift.yaml
 
+# Components (optional features)
+components:
+- ../../components/oauth-proxy
+
 # Patches to configure external resources
 patches:
 # Update operator to use Konflux runner image
@@ -62,6 +66,20 @@ patches:
   target:
     kind: Secret
     name: ambient-code-rds
+
+# Ambient API Server: enable SSL for RDS, set environment, enable service-ca TLS
+- path: ambient-api-server-ssl-patch.yaml
+  target:
+    kind: Deployment
+    name: ambient-api-server
+- path: ambient-api-server-env-patch.yaml
+  target:
+    kind: Deployment
+    name: ambient-api-server
+- path: ambient-api-server-service-ca-patch.yaml
+  target:
+    kind: Service
+    name: ambient-api-server
 
 # Konflux image overrides (redhat-services-prod)
 images:

--- a/components/manifests/overlays/app-interface/kustomization.yaml
+++ b/components/manifests/overlays/app-interface/kustomization.yaml
@@ -57,11 +57,11 @@ patches:
       path: /spec/replicas
       value: 0
 
-# Patch ambient-api-server-db secret to use external RDS (from Vault)
+# Patch ambient-code-rds secret to use external RDS (from Vault)
 - path: ambient-api-server-db-secret-patch.yaml
   target:
     kind: Secret
-    name: ambient-api-server-db
+    name: ambient-code-rds
 
 # Konflux image overrides (redhat-services-prod)
 images:

--- a/components/manifests/overlays/app-interface/namespace-patch.yaml
+++ b/components/manifests/overlays/app-interface/namespace-patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ambient-code
+  labels:
+    environment: stage
+    service: ambient-code-platform

--- a/components/manifests/overlays/app-interface/namespace.yaml
+++ b/components/manifests/overlays/app-interface/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ambient-code
+  labels:
+    environment: stage
+    service: ambient-code-platform
+    name: ambient-code
+    app: vteam
+  annotations:
+    app.kubernetes.io/name: ambient-code
+    app.kubernetes.io/part-of: ambient-code

--- a/components/manifests/overlays/app-interface/operator-config-openshift.yaml
+++ b/components/manifests/overlays/app-interface/operator-config-openshift.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-config
+  labels:
+    app: agentic-operator
+    deployment-type: openshift
+data:
+  # Vertex AI Configuration - Enabled for standard OpenShift deployments
+  USE_VERTEX: "1"
+  CLOUD_ML_REGION: "global"
+  ANTHROPIC_VERTEX_PROJECT_ID: "ambient-code-platform"
+  GOOGLE_APPLICATION_CREDENTIALS: "/app/vertex/ambient-code-key.json"

--- a/components/manifests/overlays/app-interface/operator-runner-image-patch.yaml
+++ b/components/manifests/overlays/app-interface/operator-runner-image-patch.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentic-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: agentic-operator
+        env:
+        - name: AMBIENT_CODE_RUNNER_IMAGE
+          value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main:latest

--- a/components/manifests/overlays/app-interface/public-api-route.yaml
+++ b/components/manifests/overlays/app-interface/public-api-route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: public-api-route
+  labels:
+    app: public-api
+spec:
+  to:
+    kind: Service
+    name: public-api-service
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/components/manifests/overlays/app-interface/route.yaml
+++ b/components/manifests/overlays/app-interface/route.yaml
@@ -1,0 +1,20 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: frontend-route
+  labels:
+    app: frontend
+  annotations:
+    haproxy.router.openshift.io/balance: roundrobin
+    haproxy.router.openshift.io/disable_cookies: "true"
+spec:
+  to:
+    kind: Service
+    name: frontend-service
+    weight: 100
+  port:
+    targetPort: dashboard-ui
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/components/manifests/overlays/kind/api-server-db-security-patch.yaml
+++ b/components/manifests/overlays/kind/api-server-db-security-patch.yaml
@@ -22,17 +22,17 @@ spec:
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.user
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.password
         - name: POSTGRES_DB
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.name
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata

--- a/components/manifests/overlays/kind/api-server-no-jwt-patch.yaml
+++ b/components/manifests/overlays/kind/api-server-no-jwt-patch.yaml
@@ -3,7 +3,7 @@
   value:
   - name: db-secrets
     secret:
-      secretName: ambient-api-server-db
+      secretName: ambient-code-rds
   - name: app-secrets
     secret:
       secretName: ambient-api-server

--- a/components/manifests/overlays/local-dev/ambient-api-server-db-credentials-patch.yaml
+++ b/components/manifests/overlays/local-dev/ambient-api-server-db-credentials-patch.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ambient-api-server-db
+  name: ambient-code-rds
 stringData:
   db.host: vteam-ambient-api-server-db

--- a/components/manifests/overlays/local-dev/ambient-api-server-db-json-patch.yaml
+++ b/components/manifests/overlays/local-dev/ambient-api-server-db-json-patch.yaml
@@ -11,17 +11,17 @@
   - name: POSTGRESQL_USER
     valueFrom:
       secretKeyRef:
-        name: ambient-api-server-db
+        name: ambient-code-rds
         key: db.user
   - name: POSTGRESQL_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: ambient-api-server-db
+        name: ambient-code-rds
         key: db.password
   - name: POSTGRESQL_DATABASE
     valueFrom:
       secretKeyRef:
-        name: ambient-api-server-db
+        name: ambient-code-rds
         key: db.name
 - op: replace
   path: /spec/template/spec/containers/0/volumeMounts

--- a/components/manifests/overlays/local-dev/ambient-api-server-init-db-patch.yaml
+++ b/components/manifests/overlays/local-dev/ambient-api-server-init-db-patch.yaml
@@ -41,20 +41,20 @@ spec:
         - name: PGHOST
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.host
         - name: PGUSER
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.user
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.password
         - name: PGDATABASE
           valueFrom:
             secretKeyRef:
-              name: ambient-api-server-db
+              name: ambient-code-rds
               key: db.name

--- a/components/manifests/overlays/production/ambient-api-server-jwt-args-patch.yaml
+++ b/components/manifests/overlays/production/ambient-api-server-jwt-args-patch.yaml
@@ -33,9 +33,8 @@ spec:
             - --metrics-server-bindaddress=:4433
             - --health-check-server-bindaddress=:4434
             - --enable-health-check-https=true
-            # SSL disabled: PostgreSQL is in-cluster (same namespace, pod network only).
-            # Switch to --db-sslmode=require if using an external database.
-            - --db-sslmode=disable
+            # SSL required: Using external AWS RDS database
+            - --db-sslmode=require
             - --db-max-open-connections=50
             - --enable-db-debug=false
             - --enable-metrics-https=false

--- a/components/manifests/overlays/production/ambient-api-server-migration-ssl-patch.yaml
+++ b/components/manifests/overlays/production/ambient-api-server-migration-ssl-patch.yaml
@@ -1,0 +1,21 @@
+# Production: enable SSL for migration init container when using external RDS
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-api-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: migration
+          command:
+            - /usr/local/bin/ambient-api-server
+            - migrate
+            - --db-host-file=/secrets/db/db.host
+            - --db-port-file=/secrets/db/db.port
+            - --db-user-file=/secrets/db/db.user
+            - --db-password-file=/secrets/db/db.password
+            - --db-name-file=/secrets/db/db.name
+            - --db-sslmode=require
+            - --alsologtostderr
+            - -v=4

--- a/components/manifests/overlays/production/frontend-oauth-patch.yaml
+++ b/components/manifests/overlays/production/frontend-oauth-patch.yaml
@@ -21,6 +21,7 @@ spec:
         - --cookie-expire=23h0m0s
         - --pass-access-token
         - --scope=user:full
+        - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
         - --skip-auth-regex=^/metrics
         ports:
         - containerPort: 8443

--- a/components/manifests/overlays/production/frontend-oauth-patch.yaml
+++ b/components/manifests/overlays/production/frontend-oauth-patch.yaml
@@ -21,7 +21,6 @@ spec:
         - --cookie-expire=23h0m0s
         - --pass-access-token
         - --scope=user:full
-        - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
         - --skip-auth-regex=^/metrics
         ports:
         - containerPort: 8443

--- a/components/manifests/overlays/production/kustomization.yaml
+++ b/components/manifests/overlays/production/kustomization.yaml
@@ -46,6 +46,12 @@ patches:
     kind: Deployment
     name: ambient-api-server
     version: v1
+- path: ambient-api-server-migration-ssl-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: ambient-api-server
+    version: v1
 - path: ambient-api-server-service-ca-patch.yaml
   target:
     kind: Service

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -1,0 +1,1601 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ambient-code-operator
+  annotations:
+    description: "Ambient Code Platform - Platform components (CRDs, RBAC, Operator)"
+
+parameters:
+- name: IMAGE_TAG
+  description: "Image tag to deploy (auto-generated from git commit)"
+  required: true
+- name: IMAGE_OPERATOR
+  description: "Operator image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main"
+  required: true
+- name: IMAGE_AMBIENT_RUNNER
+  description: "Ambient Runner image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main"
+  required: true
+
+objects:
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ambient-code-platform
+  annotations:
+    description: "Ambient Code Platform - AI-powered development environment"
+
+parameters:
+- name: IMAGE_TAG
+  description: "Image tag to deploy (auto-generated from git commit)"
+  required: true
+- name: IMAGE_OPERATOR
+  description: "Operator image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main"
+  required: true
+- name: IMAGE_BACKEND
+  description: "Backend API image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main"
+  required: true
+- name: IMAGE_FRONTEND
+  description: "Frontend image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main"
+  required: true
+- name: IMAGE_PUBLIC_API
+  description: "Public API image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main"
+  required: true
+- name: IMAGE_AMBIENT_API_SERVER
+  description: "Ambient API Server image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main"
+  required: true
+- name: IMAGE_AMBIENT_RUNNER
+  description: "Ambient Runner image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main"
+  required: true
+
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    name: agenticsessions.vteam.ambient-code
+  spec:
+    group: vteam.ambient-code
+    names:
+      kind: AgenticSession
+      plural: agenticsessions
+      shortNames:
+      - as
+      singular: agenticsession
+    scope: Namespaced
+    versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                activeWorkflow:
+                  description: Active workflow configuration for dynamic workflow switching
+                  properties:
+                    branch:
+                      default: main
+                      description: Branch to clone
+                      type: string
+                    gitUrl:
+                      description: Git repository URL for the workflow
+                      type: string
+                    path:
+                      description: Optional path within repo (for repos with multiple
+                        workflows)
+                      type: string
+                  type: object
+                displayName:
+                  description: A descriptive display name for the agentic session generated
+                    from prompt and website
+                  type: string
+                environmentVariables:
+                  additionalProperties:
+                    type: string
+                  description: 'Key-value pairs injected as environment variables into
+                    all pod containers (init-hydrate, runner, state-sync). Reserved
+                    variables (SESSION_NAME, S3_ENDPOINT, S3_BUCKET, AWS_ACCESS_KEY_ID,
+                    AWS_SECRET_ACCESS_KEY, NAMESPACE, SYNC_INTERVAL) cannot be overridden
+                    in init-hydrate and state-sync containers. Common conventions: RUNNER_TYPE
+                    identifies the runner framework (e.g. "claude-agent-sdk", "gemini-cli"),
+                    RUNNER_STATE_DIR sets the framework state directory relative to
+                    /workspace (defaults to ".claude").'
+                  type: object
+                inactivityTimeout:
+                  description: Seconds of inactivity before auto-stopping a session.
+                    0 disables auto-shutdown. If omitted, falls back to project-level
+                    inactivityTimeoutSeconds, then 24h default.
+                  minimum: 0
+                  type: integer
+                initialPrompt:
+                  description: Initial prompt used only on first SDK invocation for
+                    brand new sessions (ignored on continuations or workflow restarts).
+                  type: string
+                llmSettings:
+                  description: LLM configuration settings
+                  properties:
+                    maxTokens:
+                      default: 4000
+                      type: integer
+                    model:
+                      default: claude-3-7-sonnet-latest
+                      type: string
+                    temperature:
+                      default: 0.7
+                      type: number
+                  type: object
+                repos:
+                  description: List of Git repositories to clone and work with
+                  items:
+                    properties:
+                      autoPush:
+                        default: false
+                        description: When true, automatically commit and push changes
+                          to this repository after session completion
+                        type: boolean
+                      branch:
+                        default: main
+                        description: Branch to checkout
+                        type: string
+                      url:
+                        description: Git repository URL
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  type: array
+                stopOnRunFinished:
+                  description: When true, automatically stop the session when the agent
+                    completes its run (RUN_FINISHED event). Useful for one-shot tasks
+                    triggered by automation.
+                  type: boolean
+                timeout:
+                  default: 300
+                  description: Timeout in seconds for the agentic session
+                  type: integer
+                userContext:
+                  description: Authenticated caller identity captured at creation time
+                    (used for authorization and audit)
+                  properties:
+                    displayName:
+                      description: Human-readable display name
+                      type: string
+                    groups:
+                      description: Group memberships of the user
+                      items:
+                        type: string
+                      type: array
+                    userId:
+                      description: Stable user identifier (from SSO, always overwritten
+                        from auth token)
+                      type: string
+                  type: object
+              type: object
+            status:
+              properties:
+                completionTime:
+                  description: Timestamp when the session reached a terminal phase.
+                  format: date-time
+                  type: string
+                conditions:
+                  description: Detailed condition set describing reconciliation progress.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                      reason:
+                        type: string
+                      status:
+                        enum:
+                        - "True"
+                        - "False"
+                        - Unknown
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    - status
+                    type: object
+                  type: array
+                lastActivityTime:
+                  description: Timestamp of last recorded AG-UI activity in this session.
+                  format: date-time
+                  type: string
+                observedGeneration:
+                  description: Spec generation that the operator has fully reconciled.
+                  format: int64
+                  type: integer
+                phase:
+                  default: Pending
+                  enum:
+                  - Pending
+                  - Creating
+                  - Running
+                  - Stopping
+                  - Stopped
+                  - Completed
+                  - Failed
+                  type: string
+                reconciledRepos:
+                  description: Current reconciliation state for each repository.
+                  items:
+                    properties:
+                      branch:
+                        description: 'DEPRECATED: Use currentActiveBranch instead'
+                        type: string
+                      branches:
+                        description: All local branches available in this repository
+                        items:
+                          type: string
+                        type: array
+                      clonedAt:
+                        format: date-time
+                        type: string
+                      currentActiveBranch:
+                        description: Currently checked out branch (polled from filesystem)
+                        type: string
+                      defaultBranch:
+                        description: Default branch of the remote repository (e.g.,
+                          main, master)
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        enum:
+                        - Cloning
+                        - Ready
+                        - Failed
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  type: array
+                reconciledWorkflow:
+                  description: Current reconciliation state for the active workflow.
+                  properties:
+                    appliedAt:
+                      format: date-time
+                      type: string
+                    branch:
+                      type: string
+                    gitUrl:
+                      type: string
+                    path:
+                      description: Optional path within the workflow repository
+                      type: string
+                    status:
+                      enum:
+                      - Cloning
+                      - Active
+                      - Failed
+                      type: string
+                  type: object
+                sdkRestartCount:
+                  description: Number of times the SDK has been restarted during this
+                    session.
+                  type: integer
+                sdkSessionId:
+                  description: SDK session identifier captured for resume support.
+                  type: string
+                startTime:
+                  description: Timestamp when the session runner started executing.
+                  format: date-time
+                  type: string
+                stoppedReason:
+                  description: Reason the session was stopped.
+                  enum:
+                  - user
+                  - inactivity
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  
+
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    name: projectsettings.vteam.ambient-code
+  spec:
+    group: vteam.ambient-code
+    names:
+      kind: ProjectSettings
+      plural: projectsettings
+      shortNames:
+      - ps
+      singular: projectsetting
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                groupAccess:
+                  description: Group access configuration creating RoleBindings
+                  items:
+                    properties:
+                      groupName:
+                        description: Name of the group to grant access
+                        type: string
+                      role:
+                        description: Role to assign to the group (admin/edit/view)
+                        enum:
+                        - admin
+                        - edit
+                        - view
+                        type: string
+                    required:
+                    - groupName
+                    - role
+                    type: object
+                  type: array
+                inactivityTimeoutSeconds:
+                  default: 86400
+                  description: Default inactivity timeout for sessions in this project
+                    (seconds). 0 disables. Overridden by session-level spec.inactivityTimeout.
+                  minimum: 0
+                  type: integer
+                repositories:
+                  description: Git repositories configured for this project
+                  items:
+                    properties:
+                      branch:
+                        description: Optional branch override (defaults to repository's
+                          default branch)
+                        type: string
+                      provider:
+                        description: Git hosting provider (auto-detected from URL if
+                          not specified)
+                        enum:
+                        - github
+                        - gitlab
+                        type: string
+                      url:
+                        description: Repository URL (HTTPS or SSH format)
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  type: array
+                runnerSecretsName:
+                  description: Name of the Kubernetes Secret in this namespace that
+                    stores runner configuration key/value pairs
+                  type: string
+              required:
+              - groupAccess
+              type: object
+            status:
+              properties:
+                groupBindingsCreated:
+                  description: Number of group RoleBindings successfully created
+                  minimum: 0
+                  type: integer
+                limitRangeReady:
+                  description: Whether the default LimitRange for CA bin-packing is
+                    provisioned
+                  type: boolean
+                scheduledSessionRBACReady:
+                  description: Whether RBAC for scheduled session triggers is provisioned
+                  type: boolean
+              type: object
+          type: object
+          x-kubernetes-validations:
+          - message: metadata.name must be 'projectsettings' (singleton per namespace)
+            rule: self.metadata.name == 'projectsettings'
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  
+
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: agentic-operator
+    namespace: ambient-code
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: agentic-operator
+  rules:
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions/status
+    verbs:
+    - update
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - projectsettings
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - projectsettings/status
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - deletecollection
+  - apiGroups:
+    - ""
+    resources:
+    - pods/log
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - get
+    - list
+    - create
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - get
+    - create
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts/token
+    verbs:
+    - create
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - roles
+    verbs:
+    - get
+    - create
+    - update
+    - delete
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - rolebindings
+    verbs:
+    - get
+    - create
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - limitranges
+    verbs:
+    - get
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - create
+    - delete
+    - update
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    name: agenticsessions-aggregate-to-admin
+  rules:
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions
+    verbs:
+    - '*'
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions/status
+    verbs:
+    - get
+    - update
+    - patch
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ambient-frontend-auth
+  rules:
+  - apiGroups:
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs:
+    - create
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ambient-namespace-viewer
+  rules:
+  - apiGroups:
+    - project.openshift.io
+    resources:
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ambient-project-admin
+  rules:
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - projectsettings
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - projectsettings/status
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts/token
+    verbs:
+    - create
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - roles
+    - rolebindings
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - pods/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - project.openshift.io
+    resources:
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - get
+    - list
+    - watch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+    - delete
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+    - watch
+    - delete
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ambient-project-edit
+  rules:
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - projectsettings
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - project.openshift.io
+    resources:
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resourceNames:
+    - ambient-runner-secrets
+    resources:
+    - secrets
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - watch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - pods/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - roles
+    - rolebindings
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts/token
+    verbs:
+    - create
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ambient-project-view
+  rules:
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions
+    - projectsettings
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions/status
+    - projectsettings/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - project.openshift.io
+    resources:
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - pods/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+    - watch
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: backend-api
+  rules:
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - agenticsessions/status
+    verbs:
+    - get
+    - update
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts/token
+    verbs:
+    - create
+  - apiGroups:
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs:
+    - create
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - roles
+    - rolebindings
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resourceNames:
+    - ambient-project-admin
+    - ambient-project-edit
+    - ambient-project-view
+    resources:
+    - clusterroles
+    verbs:
+    - bind
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - create
+    - update
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - project.openshift.io
+    resources:
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+  - apiGroups:
+    - batch
+    resources:
+    - cronjobs
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - deletecollection
+  - apiGroups:
+    - ""
+    resources:
+    - pods/log
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - get
+    - list
+    - create
+    - delete
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    - selfsubjectaccessreviews
+    verbs:
+    - create
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    name: projectsettings-aggregate-to-admin
+  rules:
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - projectsettings
+    verbs:
+    - '*'
+  - apiGroups:
+    - vteam.ambient-code
+    resources:
+    - projectsettings/status
+    verbs:
+    - get
+    - update
+    - patch
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: agentic-operator
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: agentic-operator
+  subjects:
+  - kind: ServiceAccount
+    name: agentic-operator
+    namespace: ambient-code
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ambient-frontend-auth
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: ambient-frontend-auth
+  subjects:
+  - kind: ServiceAccount
+    name: frontend
+    namespace: ambient-code
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ambient-users-can-list-projects
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: ambient-namespace-viewer
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+  
+
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: backend-api
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: backend-api
+  subjects:
+  - kind: ServiceAccount
+    name: backend-api
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  data:
+    agent-registry.json: |
+      [
+        {
+          "id": "claude-agent-sdk",
+          "displayName": "Claude Code",
+          "description": "Anthropic Claude with full coding capabilities",
+          "framework": "claude-agent-sdk",
+          "provider": "anthropic",
+          "container": {
+            "image": "${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}",
+            "port": 8001,
+            "env": {
+              "RUNNER_TYPE": "claude-agent-sdk",
+              "RUNNER_STATE_DIR": ".claude"
+            },
+            "resources": {
+              "requests": {"cpu": "500m", "memory": "512Mi"},
+              "limits": {"cpu": "2", "memory": "8Gi"}
+            }
+          },
+          "sandbox": {
+            "stateDir": ".claude",
+            "stateSyncImage": "quay.io/ambient_code/vteam_state_sync:latest",
+            "persistence": "s3",
+            "workspaceSize": "10Gi",
+            "terminationGracePeriod": 60,
+            "seed": {"cloneRepos": true, "hydrateState": true}
+          },
+          "auth": {
+            "requiredSecretKeys": ["ANTHROPIC_API_KEY"],
+            "secretKeyLogic": "any",
+            "vertexSupported": true
+          },
+          "featureGate": ""
+        },
+        {
+          "id": "gemini-cli",
+          "displayName": "Gemini CLI",
+          "description": "Google Gemini coding agent with built-in file, bash, and search tools",
+          "framework": "gemini-cli",
+          "provider": "google",
+          "container": {
+            "image": "${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}",
+            "port": 8001,
+            "env": {
+              "RUNNER_TYPE": "gemini-cli",
+              "RUNNER_STATE_DIR": ".gemini"
+            }
+          },
+          "sandbox": {
+            "stateDir": ".gemini",
+            "stateSyncImage": "quay.io/ambient_code/vteam_state_sync:latest",
+            "persistence": "s3",
+            "workspaceSize": "10Gi",
+            "terminationGracePeriod": 60,
+            "seed": {"cloneRepos": true, "hydrateState": true}
+          },
+          "auth": {
+            "requiredSecretKeys": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+            "secretKeyLogic": "any",
+            "vertexSupported": true
+          },
+          "featureGate": "runner.gemini-cli.enabled"
+        }
+      ]
+  kind: ConfigMap
+  metadata:
+    name: ambient-agent-registry
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  data:
+    models.json: |
+      {
+        "version": 2,
+        "defaultModel": "claude-sonnet-4-5",
+        "providerDefaults": {
+          "anthropic": "claude-sonnet-4-5",
+          "google": "gemini-2.5-flash"
+        },
+        "models": [
+          {
+            "id": "claude-sonnet-4-5",
+            "label": "Claude Sonnet 4.5",
+            "vertexId": "claude-sonnet-4-5@20250929",
+            "provider": "anthropic",
+            "available": true,
+            "featureGated": false
+          },
+          {
+            "id": "claude-opus-4-6",
+            "label": "Claude Opus 4.6",
+            "vertexId": "claude-opus-4-6@default",
+            "provider": "anthropic",
+            "available": true,
+            "featureGated": true
+          },
+          {
+            "id": "claude-opus-4-5",
+            "label": "Claude Opus 4.5",
+            "vertexId": "claude-opus-4-5@20251101",
+            "provider": "anthropic",
+            "available": true,
+            "featureGated": false
+          },
+          {
+            "id": "claude-haiku-4-5",
+            "label": "Claude Haiku 4.5",
+            "vertexId": "claude-haiku-4-5@20251001",
+            "provider": "anthropic",
+            "available": true,
+            "featureGated": false
+          },
+          {
+            "id": "claude-sonnet-4-6",
+            "label": "Claude Sonnet 4.6",
+            "vertexId": "claude-sonnet-4-6@default",
+            "provider": "anthropic",
+            "available": true,
+            "featureGated": true
+          },
+          {
+            "id": "gemini-2.5-flash",
+            "label": "Gemini 2.5 Flash",
+            "vertexId": "gemini-2.5-flash@default",
+            "provider": "google",
+            "available": true,
+            "featureGated": false
+          },
+          {
+            "id": "gemini-2.5-pro",
+            "label": "Gemini 2.5 Pro",
+            "vertexId": "gemini-2.5-pro@default",
+            "provider": "google",
+            "available": true,
+            "featureGated": true
+          },
+          {
+            "id": "gemini-2.5-flash-lite",
+            "label": "Gemini 2.5 Flash Lite",
+            "vertexId": "gemini-2.5-flash-lite@default",
+            "provider": "google",
+            "available": true,
+            "featureGated": true
+          },
+          {
+            "id": "gemini-2.5-flash-preview-04-17",
+            "label": "Gemini 2.5 Flash Preview 04.17",
+            "vertexId": "gemini-2.5-flash-preview-04-17@default",
+            "provider": "google",
+            "available": false,
+            "featureGated": true
+          },
+          {
+            "id": "gemini-3.1-flash-image-preview",
+            "label": "Gemini 3.1 Flash Image Preview",
+            "vertexId": "gemini-3.1-flash-image-preview@default",
+            "provider": "google",
+            "available": false,
+            "featureGated": true
+          }
+        ]
+      }
+  kind: ConfigMap
+  metadata:
+    name: ambient-models
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  data:
+    ANTHROPIC_VERTEX_PROJECT_ID: ambient-code-platform
+    CLOUD_ML_REGION: global
+    GOOGLE_APPLICATION_CREDENTIALS: /app/vertex/ambient-code-key.json
+    USE_VERTEX: "1"
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: agentic-operator
+      deployment-type: openshift
+    name: operator-config
+    namespace: ambient-code
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: agentic-operator
+    name: agentic-operator
+    namespace: ambient-code
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: agentic-operator
+    template:
+      metadata:
+        labels:
+          app: agentic-operator
+      spec:
+        containers:
+        - args:
+          - --max-concurrent-reconciles=10
+          - --health-probe-bind-address=:8081
+          - --leader-elect=false
+          env:
+          - name: AMBIENT_CODE_RUNNER_IMAGE
+            value: ${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}
+          - name: MAX_CONCURRENT_RECONCILES
+            value: "10"
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: BACKEND_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: BACKEND_API_URL
+            value: http://backend-service:8080/api
+          - name: IMAGE_PULL_POLICY
+            value: IfNotPresent
+          - name: USE_VERTEX
+            valueFrom:
+              configMapKeyRef:
+                key: USE_VERTEX
+                name: operator-config
+                optional: true
+          - name: CLOUD_ML_REGION
+            valueFrom:
+              configMapKeyRef:
+                key: CLOUD_ML_REGION
+                name: operator-config
+                optional: true
+          - name: ANTHROPIC_VERTEX_PROJECT_ID
+            valueFrom:
+              configMapKeyRef:
+                key: ANTHROPIC_VERTEX_PROJECT_ID
+                name: operator-config
+                optional: true
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            valueFrom:
+              configMapKeyRef:
+                key: GOOGLE_APPLICATION_CREDENTIALS
+                name: operator-config
+                optional: true
+          - name: LANGFUSE_ENABLED
+            valueFrom:
+              secretKeyRef:
+                key: LANGFUSE_ENABLED
+                name: ambient-admin-langfuse-secret
+                optional: true
+          - name: LANGFUSE_HOST
+            valueFrom:
+              secretKeyRef:
+                key: LANGFUSE_HOST
+                name: ambient-admin-langfuse-secret
+                optional: true
+          - name: LANGFUSE_PUBLIC_KEY
+            valueFrom:
+              secretKeyRef:
+                key: LANGFUSE_PUBLIC_KEY
+                name: ambient-admin-langfuse-secret
+                optional: true
+          - name: LANGFUSE_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                key: LANGFUSE_SECRET_KEY
+                name: ambient-admin-langfuse-secret
+                optional: true
+          - name: GOOGLE_OAUTH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: GOOGLE_OAUTH_CLIENT_ID
+                name: google-workflow-app-secret
+                optional: true
+          - name: GOOGLE_OAUTH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: GOOGLE_OAUTH_CLIENT_SECRET
+                name: google-workflow-app-secret
+                optional: true
+          - name: STATE_SYNC_IMAGE
+            value: quay.io/ambient_code/vteam_state_sync:latest
+          - name: S3_ENDPOINT
+            value: http://minio.ambient-code.svc:9000
+          - name: S3_BUCKET
+            value: ambient-sessions
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: otel-collector.ambient-code.svc:4317
+          - name: DEPLOYMENT_ENV
+            value: production
+          - name: VERSION
+            value: latest
+          image: ${IMAGE_OPERATOR}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: agentic-operator
+          ports:
+          - containerPort: 8081
+            name: health
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+          - mountPath: /config/models
+            name: model-manifest
+            readOnly: true
+          - mountPath: /config/registry
+            name: agent-registry
+            readOnly: true
+        restartPolicy: Always
+        serviceAccountName: agentic-operator
+        volumes:
+        - configMap:
+            name: ambient-models
+            optional: true
+          name: model-manifest
+        - configMap:
+            name: ambient-agent-registry
+            optional: true
+          name: agent-registry
+  
+

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -1,62 +1,23 @@
----
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: ambient-code-operator
   annotations:
-    description: "Ambient Code Platform - Platform components (CRDs, RBAC, Operator)"
-
+    description: Ambient Code Platform - Platform components (CRDs, RBAC, Operator)
 parameters:
 - name: IMAGE_TAG
-  description: "Image tag to deploy (auto-generated from git commit)"
+  description: Image tag to deploy (auto-generated from git commit)
   required: true
 - name: IMAGE_OPERATOR
-  description: "Operator image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main"
+  description: Operator image
+  value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main
   required: true
 - name: IMAGE_AMBIENT_RUNNER
-  description: "Ambient Runner image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main"
+  description: Ambient Runner image
+  value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main
   required: true
-
 objects:
-apiVersion: template.openshift.io/v1
-kind: Template
-metadata:
-  name: ambient-code-platform
-  annotations:
-    description: "Ambient Code Platform - AI-powered development environment"
-
-parameters:
-- name: IMAGE_TAG
-  description: "Image tag to deploy (auto-generated from git commit)"
-  required: true
-- name: IMAGE_OPERATOR
-  description: "Operator image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main"
-  required: true
-- name: IMAGE_BACKEND
-  description: "Backend API image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main"
-  required: true
-- name: IMAGE_FRONTEND
-  description: "Frontend image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main"
-  required: true
-- name: IMAGE_PUBLIC_API
-  description: "Public API image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main"
-  required: true
-- name: IMAGE_AMBIENT_API_SERVER
-  description: "Ambient API Server image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main"
-  required: true
-- name: IMAGE_AMBIENT_RUNNER
-  description: "Ambient Runner image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main"
-  required: true
-
-  apiVersion: apiextensions.k8s.io/v1
+- apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
   metadata:
     name: agenticsessions.vteam.ambient-code
@@ -87,35 +48,23 @@ parameters:
                       description: Git repository URL for the workflow
                       type: string
                     path:
-                      description: Optional path within repo (for repos with multiple
-                        workflows)
+                      description: Optional path within repo (for repos with multiple workflows)
                       type: string
                   type: object
                 displayName:
-                  description: A descriptive display name for the agentic session generated
-                    from prompt and website
+                  description: A descriptive display name for the agentic session generated from prompt and website
                   type: string
                 environmentVariables:
                   additionalProperties:
                     type: string
-                  description: 'Key-value pairs injected as environment variables into
-                    all pod containers (init-hydrate, runner, state-sync). Reserved
-                    variables (SESSION_NAME, S3_ENDPOINT, S3_BUCKET, AWS_ACCESS_KEY_ID,
-                    AWS_SECRET_ACCESS_KEY, NAMESPACE, SYNC_INTERVAL) cannot be overridden
-                    in init-hydrate and state-sync containers. Common conventions: RUNNER_TYPE
-                    identifies the runner framework (e.g. "claude-agent-sdk", "gemini-cli"),
-                    RUNNER_STATE_DIR sets the framework state directory relative to
-                    /workspace (defaults to ".claude").'
+                  description: 'Key-value pairs injected as environment variables into all pod containers (init-hydrate, runner, state-sync). Reserved variables (SESSION_NAME, S3_ENDPOINT, S3_BUCKET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, NAMESPACE, SYNC_INTERVAL) cannot be overridden in init-hydrate and state-sync containers. Common conventions: RUNNER_TYPE identifies the runner framework (e.g. "claude-agent-sdk", "gemini-cli"), RUNNER_STATE_DIR sets the framework state directory relative to /workspace (defaults to ".claude").'
                   type: object
                 inactivityTimeout:
-                  description: Seconds of inactivity before auto-stopping a session.
-                    0 disables auto-shutdown. If omitted, falls back to project-level
-                    inactivityTimeoutSeconds, then 24h default.
+                  description: Seconds of inactivity before auto-stopping a session. 0 disables auto-shutdown. If omitted, falls back to project-level inactivityTimeoutSeconds, then 24h default.
                   minimum: 0
                   type: integer
                 initialPrompt:
-                  description: Initial prompt used only on first SDK invocation for
-                    brand new sessions (ignored on continuations or workflow restarts).
+                  description: Initial prompt used only on first SDK invocation for brand new sessions (ignored on continuations or workflow restarts).
                   type: string
                 llmSettings:
                   description: LLM configuration settings
@@ -136,8 +85,7 @@ parameters:
                     properties:
                       autoPush:
                         default: false
-                        description: When true, automatically commit and push changes
-                          to this repository after session completion
+                        description: When true, automatically commit and push changes to this repository after session completion
                         type: boolean
                       branch:
                         default: main
@@ -151,17 +99,14 @@ parameters:
                     type: object
                   type: array
                 stopOnRunFinished:
-                  description: When true, automatically stop the session when the agent
-                    completes its run (RUN_FINISHED event). Useful for one-shot tasks
-                    triggered by automation.
+                  description: When true, automatically stop the session when the agent completes its run (RUN_FINISHED event). Useful for one-shot tasks triggered by automation.
                   type: boolean
                 timeout:
                   default: 300
                   description: Timeout in seconds for the agentic session
                   type: integer
                 userContext:
-                  description: Authenticated caller identity captured at creation time
-                    (used for authorization and audit)
+                  description: Authenticated caller identity captured at creation time (used for authorization and audit)
                   properties:
                     displayName:
                       description: Human-readable display name
@@ -172,8 +117,7 @@ parameters:
                         type: string
                       type: array
                     userId:
-                      description: Stable user identifier (from SSO, always overwritten
-                        from auth token)
+                      description: Stable user identifier (from SSO, always overwritten from auth token)
                       type: string
                   type: object
               type: object
@@ -199,8 +143,8 @@ parameters:
                         type: string
                       status:
                         enum:
-                        - "True"
-                        - "False"
+                        - 'True'
+                        - 'False'
                         - Unknown
                         type: string
                       type:
@@ -248,8 +192,7 @@ parameters:
                         description: Currently checked out branch (polled from filesystem)
                         type: string
                       defaultBranch:
-                        description: Default branch of the remote repository (e.g.,
-                          main, master)
+                        description: Default branch of the remote repository (e.g., main, master)
                         type: string
                       name:
                         type: string
@@ -284,8 +227,7 @@ parameters:
                       type: string
                   type: object
                 sdkRestartCount:
-                  description: Number of times the SDK has been restarted during this
-                    session.
+                  description: Number of times the SDK has been restarted during this session.
                   type: integer
                 sdkSessionId:
                   description: SDK session identifier captured for resume support.
@@ -306,9 +248,7 @@ parameters:
       storage: true
       subresources:
         status: {}
-  
-
-  apiVersion: apiextensions.k8s.io/v1
+- apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
   metadata:
     name: projectsettings.vteam.ambient-code
@@ -353,8 +293,7 @@ parameters:
                   type: array
                 inactivityTimeoutSeconds:
                   default: 86400
-                  description: Default inactivity timeout for sessions in this project
-                    (seconds). 0 disables. Overridden by session-level spec.inactivityTimeout.
+                  description: Default inactivity timeout for sessions in this project (seconds). 0 disables. Overridden by session-level spec.inactivityTimeout.
                   minimum: 0
                   type: integer
                 repositories:
@@ -362,12 +301,10 @@ parameters:
                   items:
                     properties:
                       branch:
-                        description: Optional branch override (defaults to repository's
-                          default branch)
+                        description: Optional branch override (defaults to repository's default branch)
                         type: string
                       provider:
-                        description: Git hosting provider (auto-detected from URL if
-                          not specified)
+                        description: Git hosting provider (auto-detected from URL if not specified)
                         enum:
                         - github
                         - gitlab
@@ -380,8 +317,7 @@ parameters:
                     type: object
                   type: array
                 runnerSecretsName:
-                  description: Name of the Kubernetes Secret in this namespace that
-                    stores runner configuration key/value pairs
+                  description: Name of the Kubernetes Secret in this namespace that stores runner configuration key/value pairs
                   type: string
               required:
               - groupAccess
@@ -393,8 +329,7 @@ parameters:
                   minimum: 0
                   type: integer
                 limitRangeReady:
-                  description: Whether the default LimitRange for CA bin-packing is
-                    provisioned
+                  description: Whether the default LimitRange for CA bin-packing is provisioned
                   type: boolean
                 scheduledSessionRBACReady:
                   description: Whether RBAC for scheduled session triggers is provisioned
@@ -408,16 +343,12 @@ parameters:
       storage: true
       subresources:
         status: {}
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: agentic-operator
     namespace: ambient-code
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: agentic-operator
@@ -455,7 +386,7 @@ parameters:
     verbs:
     - update
   - apiGroups:
-    - ""
+    - ''
     resources:
     - namespaces
     verbs:
@@ -473,7 +404,7 @@ parameters:
     - create
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - pods
     verbs:
@@ -484,13 +415,13 @@ parameters:
     - delete
     - deletecollection
   - apiGroups:
-    - ""
+    - ''
     resources:
     - pods/log
     verbs:
     - get
   - apiGroups:
-    - ""
+    - ''
     resources:
     - persistentvolumeclaims
     verbs:
@@ -499,7 +430,7 @@ parameters:
     - create
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - services
     verbs:
@@ -518,7 +449,7 @@ parameters:
     - watch
     - create
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts
     verbs:
@@ -526,7 +457,7 @@ parameters:
     - create
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts/token
     verbs:
@@ -549,20 +480,20 @@ parameters:
     - create
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - limitranges
     verbs:
     - get
     - create
   - apiGroups:
-    - ""
+    - ''
     resources:
     - configmaps
     verbs:
     - get
   - apiGroups:
-    - ""
+    - ''
     resources:
     - secrets
     verbs:
@@ -570,13 +501,11 @@ parameters:
     - create
     - delete
     - update
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     labels:
-      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     name: agenticsessions-aggregate-to-admin
   rules:
   - apiGroups:
@@ -593,9 +522,7 @@ parameters:
     - get
     - update
     - patch
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: ambient-frontend-auth
@@ -612,9 +539,7 @@ parameters:
     - subjectaccessreviews
     verbs:
     - create
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: ambient-namespace-viewer
@@ -627,9 +552,7 @@ parameters:
     - get
     - list
     - watch
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: ambient-project-admin
@@ -677,7 +600,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - secrets
     - configmaps
@@ -690,7 +613,7 @@ parameters:
     - patch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts
     verbs:
@@ -702,7 +625,7 @@ parameters:
     - patch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts/token
     verbs:
@@ -733,7 +656,7 @@ parameters:
     - patch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - pods
     - pods/log
@@ -742,7 +665,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - events
     verbs:
@@ -758,7 +681,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - persistentvolumeclaims
     verbs:
@@ -767,7 +690,7 @@ parameters:
     - watch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - services
     verbs:
@@ -784,9 +707,7 @@ parameters:
     - list
     - watch
     - delete
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: ambient-project-edit
@@ -827,13 +748,13 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - configmaps
     verbs:
     - get
   - apiGroups:
-    - ""
+    - ''
     resourceNames:
     - ambient-runner-secrets
     resources:
@@ -841,7 +762,7 @@ parameters:
     verbs:
     - get
   - apiGroups:
-    - ""
+    - ''
     resources:
     - secrets
     verbs:
@@ -856,7 +777,7 @@ parameters:
     - watch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - pods
     - pods/log
@@ -865,7 +786,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - events
     verbs:
@@ -873,7 +794,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - persistentvolumeclaims
     verbs:
@@ -881,7 +802,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - services
     verbs:
@@ -897,7 +818,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts
     verbs:
@@ -919,14 +840,12 @@ parameters:
     - patch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts/token
     verbs:
     - create
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: ambient-project-view
@@ -966,7 +885,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - pods
     - pods/log
@@ -975,7 +894,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - events
     verbs:
@@ -983,7 +902,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - persistentvolumeclaims
     - services
@@ -999,9 +918,7 @@ parameters:
     - get
     - list
     - watch
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: backend-api
@@ -1027,7 +944,7 @@ parameters:
     - update
     - patch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts
     verbs:
@@ -1037,7 +954,7 @@ parameters:
     - update
     - patch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - serviceaccounts/token
     verbs:
@@ -1071,7 +988,7 @@ parameters:
     verbs:
     - bind
   - apiGroups:
-    - ""
+    - ''
     resources:
     - secrets
     verbs:
@@ -1082,7 +999,7 @@ parameters:
     - patch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - configmaps
     verbs:
@@ -1091,7 +1008,7 @@ parameters:
     - update
     - patch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - namespaces
     verbs:
@@ -1134,7 +1051,7 @@ parameters:
     - patch
     - delete
   - apiGroups:
-    - ""
+    - ''
     resources:
     - pods
     verbs:
@@ -1145,13 +1062,13 @@ parameters:
     - delete
     - deletecollection
   - apiGroups:
-    - ""
+    - ''
     resources:
     - pods/log
     verbs:
     - get
   - apiGroups:
-    - ""
+    - ''
     resources:
     - persistentvolumeclaims
     verbs:
@@ -1159,7 +1076,7 @@ parameters:
     - list
     - watch
   - apiGroups:
-    - ""
+    - ''
     resources:
     - services
     verbs:
@@ -1174,13 +1091,11 @@ parameters:
     - selfsubjectaccessreviews
     verbs:
     - create
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     labels:
-      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     name: projectsettings-aggregate-to-admin
   rules:
   - apiGroups:
@@ -1197,9 +1112,7 @@ parameters:
     - get
     - update
     - patch
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: agentic-operator
@@ -1211,9 +1124,7 @@ parameters:
   - kind: ServiceAccount
     name: agentic-operator
     namespace: ambient-code
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: ambient-frontend-auth
@@ -1225,9 +1136,7 @@ parameters:
   - kind: ServiceAccount
     name: frontend
     namespace: ambient-code
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: ambient-users-can-list-projects
@@ -1239,9 +1148,7 @@ parameters:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  
-
-  apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: backend-api
@@ -1253,186 +1160,30 @@ parameters:
   - kind: ServiceAccount
     name: backend-api
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   data:
-    agent-registry.json: |
-      [
-        {
-          "id": "claude-agent-sdk",
-          "displayName": "Claude Code",
-          "description": "Anthropic Claude with full coding capabilities",
-          "framework": "claude-agent-sdk",
-          "provider": "anthropic",
-          "container": {
-            "image": "${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}",
-            "port": 8001,
-            "env": {
-              "RUNNER_TYPE": "claude-agent-sdk",
-              "RUNNER_STATE_DIR": ".claude"
-            },
-            "resources": {
-              "requests": {"cpu": "500m", "memory": "512Mi"},
-              "limits": {"cpu": "2", "memory": "8Gi"}
-            }
-          },
-          "sandbox": {
-            "stateDir": ".claude",
-            "stateSyncImage": "quay.io/ambient_code/vteam_state_sync:latest",
-            "persistence": "s3",
-            "workspaceSize": "10Gi",
-            "terminationGracePeriod": 60,
-            "seed": {"cloneRepos": true, "hydrateState": true}
-          },
-          "auth": {
-            "requiredSecretKeys": ["ANTHROPIC_API_KEY"],
-            "secretKeyLogic": "any",
-            "vertexSupported": true
-          },
-          "featureGate": ""
-        },
-        {
-          "id": "gemini-cli",
-          "displayName": "Gemini CLI",
-          "description": "Google Gemini coding agent with built-in file, bash, and search tools",
-          "framework": "gemini-cli",
-          "provider": "google",
-          "container": {
-            "image": "${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}",
-            "port": 8001,
-            "env": {
-              "RUNNER_TYPE": "gemini-cli",
-              "RUNNER_STATE_DIR": ".gemini"
-            }
-          },
-          "sandbox": {
-            "stateDir": ".gemini",
-            "stateSyncImage": "quay.io/ambient_code/vteam_state_sync:latest",
-            "persistence": "s3",
-            "workspaceSize": "10Gi",
-            "terminationGracePeriod": 60,
-            "seed": {"cloneRepos": true, "hydrateState": true}
-          },
-          "auth": {
-            "requiredSecretKeys": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
-            "secretKeyLogic": "any",
-            "vertexSupported": true
-          },
-          "featureGate": "runner.gemini-cli.enabled"
-        }
-      ]
+    agent-registry.json: "[\n  {\n    \"id\": \"claude-agent-sdk\",\n    \"displayName\": \"Claude Code\",\n    \"description\": \"Anthropic Claude with full coding capabilities\",\n    \"framework\": \"claude-agent-sdk\",\n    \"provider\": \"anthropic\",\n    \"container\": {\n      \"image\": \"${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}\",\n      \"port\": 8001,\n      \"env\": {\n        \"RUNNER_TYPE\": \"claude-agent-sdk\",\n        \"RUNNER_STATE_DIR\": \".claude\"\n      },\n      \"resources\": {\n        \"requests\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"},\n        \"limits\": {\"cpu\": \"2\", \"memory\": \"8Gi\"}\n      }\n    },\n    \"sandbox\": {\n      \"stateDir\": \".claude\",\n      \"stateSyncImage\": \"quay.io/ambient_code/vteam_state_sync:latest\",\n      \"persistence\": \"s3\",\n      \"workspaceSize\": \"10Gi\",\n      \"terminationGracePeriod\": 60,\n      \"seed\": {\"cloneRepos\": true, \"hydrateState\": true}\n    },\n    \"auth\": {\n      \"requiredSecretKeys\"\
+      : [\"ANTHROPIC_API_KEY\"],\n      \"secretKeyLogic\": \"any\",\n      \"vertexSupported\": true\n    },\n    \"featureGate\": \"\"\n  },\n  {\n    \"id\": \"gemini-cli\",\n    \"displayName\": \"Gemini CLI\",\n    \"description\": \"Google Gemini coding agent with built-in file, bash, and search tools\",\n    \"framework\": \"gemini-cli\",\n    \"provider\": \"google\",\n    \"container\": {\n      \"image\": \"${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}\",\n      \"port\": 8001,\n      \"env\": {\n        \"RUNNER_TYPE\": \"gemini-cli\",\n        \"RUNNER_STATE_DIR\": \".gemini\"\n      }\n    },\n    \"sandbox\": {\n      \"stateDir\": \".gemini\",\n      \"stateSyncImage\": \"quay.io/ambient_code/vteam_state_sync:latest\",\n      \"persistence\": \"s3\",\n      \"workspaceSize\": \"10Gi\",\n      \"terminationGracePeriod\": 60,\n      \"seed\": {\"cloneRepos\": true, \"hydrateState\": true}\n    },\n    \"auth\": {\n      \"requiredSecretKeys\": [\"GEMINI_API_KEY\", \"GOOGLE_API_KEY\"\
+      ],\n      \"secretKeyLogic\": \"any\",\n      \"vertexSupported\": true\n    },\n    \"featureGate\": \"runner.gemini-cli.enabled\"\n  }\n]\n"
   kind: ConfigMap
   metadata:
     name: ambient-agent-registry
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   data:
-    models.json: |
-      {
-        "version": 2,
-        "defaultModel": "claude-sonnet-4-5",
-        "providerDefaults": {
-          "anthropic": "claude-sonnet-4-5",
-          "google": "gemini-2.5-flash"
-        },
-        "models": [
-          {
-            "id": "claude-sonnet-4-5",
-            "label": "Claude Sonnet 4.5",
-            "vertexId": "claude-sonnet-4-5@20250929",
-            "provider": "anthropic",
-            "available": true,
-            "featureGated": false
-          },
-          {
-            "id": "claude-opus-4-6",
-            "label": "Claude Opus 4.6",
-            "vertexId": "claude-opus-4-6@default",
-            "provider": "anthropic",
-            "available": true,
-            "featureGated": true
-          },
-          {
-            "id": "claude-opus-4-5",
-            "label": "Claude Opus 4.5",
-            "vertexId": "claude-opus-4-5@20251101",
-            "provider": "anthropic",
-            "available": true,
-            "featureGated": false
-          },
-          {
-            "id": "claude-haiku-4-5",
-            "label": "Claude Haiku 4.5",
-            "vertexId": "claude-haiku-4-5@20251001",
-            "provider": "anthropic",
-            "available": true,
-            "featureGated": false
-          },
-          {
-            "id": "claude-sonnet-4-6",
-            "label": "Claude Sonnet 4.6",
-            "vertexId": "claude-sonnet-4-6@default",
-            "provider": "anthropic",
-            "available": true,
-            "featureGated": true
-          },
-          {
-            "id": "gemini-2.5-flash",
-            "label": "Gemini 2.5 Flash",
-            "vertexId": "gemini-2.5-flash@default",
-            "provider": "google",
-            "available": true,
-            "featureGated": false
-          },
-          {
-            "id": "gemini-2.5-pro",
-            "label": "Gemini 2.5 Pro",
-            "vertexId": "gemini-2.5-pro@default",
-            "provider": "google",
-            "available": true,
-            "featureGated": true
-          },
-          {
-            "id": "gemini-2.5-flash-lite",
-            "label": "Gemini 2.5 Flash Lite",
-            "vertexId": "gemini-2.5-flash-lite@default",
-            "provider": "google",
-            "available": true,
-            "featureGated": true
-          },
-          {
-            "id": "gemini-2.5-flash-preview-04-17",
-            "label": "Gemini 2.5 Flash Preview 04.17",
-            "vertexId": "gemini-2.5-flash-preview-04-17@default",
-            "provider": "google",
-            "available": false,
-            "featureGated": true
-          },
-          {
-            "id": "gemini-3.1-flash-image-preview",
-            "label": "Gemini 3.1 Flash Image Preview",
-            "vertexId": "gemini-3.1-flash-image-preview@default",
-            "provider": "google",
-            "available": false,
-            "featureGated": true
-          }
-        ]
-      }
+    models.json: "{\n  \"version\": 2,\n  \"defaultModel\": \"claude-sonnet-4-5\",\n  \"providerDefaults\": {\n    \"anthropic\": \"claude-sonnet-4-5\",\n    \"google\": \"gemini-2.5-flash\"\n  },\n  \"models\": [\n    {\n      \"id\": \"claude-sonnet-4-5\",\n      \"label\": \"Claude Sonnet 4.5\",\n      \"vertexId\": \"claude-sonnet-4-5@20250929\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-opus-4-6\",\n      \"label\": \"Claude Opus 4.6\",\n      \"vertexId\": \"claude-opus-4-6@default\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"claude-opus-4-5\",\n      \"label\": \"Claude Opus 4.5\",\n      \"vertexId\": \"claude-opus-4-5@20251101\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-haiku-4-5\",\n      \"label\": \"Claude Haiku\
+      \ 4.5\",\n      \"vertexId\": \"claude-haiku-4-5@20251001\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-sonnet-4-6\",\n      \"label\": \"Claude Sonnet 4.6\",\n      \"vertexId\": \"claude-sonnet-4-6@default\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash\",\n      \"label\": \"Gemini 2.5 Flash\",\n      \"vertexId\": \"gemini-2.5-flash@default\",\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"gemini-2.5-pro\",\n      \"label\": \"Gemini 2.5 Pro\",\n      \"vertexId\": \"gemini-2.5-pro@default\",\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash-lite\",\n      \"label\": \"Gemini 2.5 Flash Lite\",\n      \"vertexId\": \"gemini-2.5-flash-lite@default\"\
+      ,\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash-preview-04-17\",\n      \"label\": \"Gemini 2.5 Flash Preview 04.17\",\n      \"vertexId\": \"gemini-2.5-flash-preview-04-17@default\",\n      \"provider\": \"google\",\n      \"available\": false,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-3.1-flash-image-preview\",\n      \"label\": \"Gemini 3.1 Flash Image Preview\",\n      \"vertexId\": \"gemini-3.1-flash-image-preview@default\",\n      \"provider\": \"google\",\n      \"available\": false,\n      \"featureGated\": true\n    }\n  ]\n}\n"
   kind: ConfigMap
   metadata:
     name: ambient-models
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   data:
     ANTHROPIC_VERTEX_PROJECT_ID: ambient-code-platform
     CLOUD_ML_REGION: global
     GOOGLE_APPLICATION_CREDENTIALS: /app/vertex/ambient-code-key.json
-    USE_VERTEX: "1"
+    USE_VERTEX: '1'
   kind: ConfigMap
   metadata:
     labels:
@@ -1440,9 +1191,7 @@ parameters:
       deployment-type: openshift
     name: operator-config
     namespace: ambient-code
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -1468,7 +1217,7 @@ parameters:
           - name: AMBIENT_CODE_RUNNER_IMAGE
             value: ${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}
           - name: MAX_CONCURRENT_RECONCILES
-            value: "10"
+            value: '10'
           - name: NAMESPACE
             valueFrom:
               fieldRef:
@@ -1597,5 +1346,3 @@ parameters:
             name: ambient-agent-registry
             optional: true
           name: agent-registry
-  
-

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -1296,8 +1296,9 @@ objects:
             value: http://minio.ambient-code.svc:9000
           - name: S3_BUCKET
             value: ambient-sessions
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: otel-collector.ambient-code.svc:4317
+          # Disabled: OTel collector not deployed. Uncomment when collector is available.
+          # - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          #   value: otel-collector.ambient-code.svc:4317
           - name: DEPLOYMENT_ENV
             value: production
           - name: VERSION

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -3,7 +3,8 @@ kind: Template
 metadata:
   name: ambient-code-operator
   annotations:
-    description: Ambient Code Platform - Platform components (CRDs, RBAC, Operator)
+    description: Ambient Code Platform - Operator and CRDs
+    tags: ambient-code,operator
 parameters:
 - name: IMAGE_TAG
   description: Image tag to deploy (auto-generated from git commit)
@@ -11,11 +12,9 @@ parameters:
 - name: IMAGE_OPERATOR
   description: Operator image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main
-  required: true
 - name: IMAGE_AMBIENT_RUNNER
-  description: Ambient Runner image
+  description: Ambient runner image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main
-  required: true
 objects:
 - apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
@@ -347,6 +346,30 @@ objects:
   kind: ServiceAccount
   metadata:
     name: agentic-operator
+    namespace: ambient-code
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: ambient-api-server
+    name: ambient-api-server
+    namespace: ambient-code
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: backend-api
+    namespace: ambient-code
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: frontend
+    namespace: ambient-code
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: public-api
+    name: public-api
     namespace: ambient-code
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
@@ -1162,18 +1185,34 @@ objects:
     namespace: ambient-code
 - apiVersion: v1
   data:
-    agent-registry.json: "[\n  {\n    \"id\": \"claude-agent-sdk\",\n    \"displayName\": \"Claude Code\",\n    \"description\": \"Anthropic Claude with full coding capabilities\",\n    \"framework\": \"claude-agent-sdk\",\n    \"provider\": \"anthropic\",\n    \"container\": {\n      \"image\": \"${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}\",\n      \"port\": 8001,\n      \"env\": {\n        \"RUNNER_TYPE\": \"claude-agent-sdk\",\n        \"RUNNER_STATE_DIR\": \".claude\"\n      },\n      \"resources\": {\n        \"requests\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"},\n        \"limits\": {\"cpu\": \"2\", \"memory\": \"8Gi\"}\n      }\n    },\n    \"sandbox\": {\n      \"stateDir\": \".claude\",\n      \"stateSyncImage\": \"quay.io/ambient_code/vteam_state_sync:latest\",\n      \"persistence\": \"s3\",\n      \"workspaceSize\": \"10Gi\",\n      \"terminationGracePeriod\": 60,\n      \"seed\": {\"cloneRepos\": true, \"hydrateState\": true}\n    },\n    \"auth\": {\n      \"requiredSecretKeys\"\
-      : [\"ANTHROPIC_API_KEY\"],\n      \"secretKeyLogic\": \"any\",\n      \"vertexSupported\": true\n    },\n    \"featureGate\": \"\"\n  },\n  {\n    \"id\": \"gemini-cli\",\n    \"displayName\": \"Gemini CLI\",\n    \"description\": \"Google Gemini coding agent with built-in file, bash, and search tools\",\n    \"framework\": \"gemini-cli\",\n    \"provider\": \"google\",\n    \"container\": {\n      \"image\": \"${IMAGE_AMBIENT_RUNNER}:${IMAGE_TAG}\",\n      \"port\": 8001,\n      \"env\": {\n        \"RUNNER_TYPE\": \"gemini-cli\",\n        \"RUNNER_STATE_DIR\": \".gemini\"\n      }\n    },\n    \"sandbox\": {\n      \"stateDir\": \".gemini\",\n      \"stateSyncImage\": \"quay.io/ambient_code/vteam_state_sync:latest\",\n      \"persistence\": \"s3\",\n      \"workspaceSize\": \"10Gi\",\n      \"terminationGracePeriod\": 60,\n      \"seed\": {\"cloneRepos\": true, \"hydrateState\": true}\n    },\n    \"auth\": {\n      \"requiredSecretKeys\": [\"GEMINI_API_KEY\", \"GOOGLE_API_KEY\"\
-      ],\n      \"secretKeyLogic\": \"any\",\n      \"vertexSupported\": true\n    },\n    \"featureGate\": \"runner.gemini-cli.enabled\"\n  }\n]\n"
+    agent-registry.json: "[\n  {\n    \"id\": \"claude-agent-sdk\",\n    \"displayName\": \"Claude Code\",\n    \"description\": \"Anthropic Claude with full coding capabilities\",\n    \"framework\": \"claude-agent-sdk\",\n    \"provider\": \"anthropic\",\n    \"container\": {\n      \"image\": \"quay.io/ambient_code/vteam_claude_runner:latest\",\n      \"port\": 8001,\n      \"env\": {\n        \"RUNNER_TYPE\": \"claude-agent-sdk\",\n        \"RUNNER_STATE_DIR\": \".claude\"\n      },\n      \"resources\": {\n        \"requests\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"},\n        \"limits\": {\"cpu\": \"2\", \"memory\": \"8Gi\"}\n      }\n    },\n    \"sandbox\": {\n      \"stateDir\": \".claude\",\n      \"stateSyncImage\": \"quay.io/ambient_code/vteam_state_sync:latest\",\n      \"persistence\": \"s3\",\n      \"workspaceSize\": \"10Gi\",\n      \"terminationGracePeriod\": 60,\n      \"seed\": {\"cloneRepos\": true, \"hydrateState\": true}\n    },\n    \"auth\": {\n      \"requiredSecretKeys\": [\"ANTHROPIC_API_KEY\"],\n      \"secretKeyLogic\": \"any\",\n      \"vertexSupported\": true\n    },\n    \"featureGate\": \"\"\n  },\n  {\n    \"id\": \"gemini-cli\",\n    \"displayName\": \"Gemini CLI\",\n    \"description\": \"Google Gemini coding agent with built-in file, bash, and search tools\",\n    \"framework\": \"gemini-cli\",\n    \"provider\": \"google\",\n    \"container\": {\n      \"image\": \"quay.io/ambient_code/vteam_claude_runner:latest\",\n      \"port\": 8001,\n      \"env\": {\n        \"RUNNER_TYPE\": \"gemini-cli\",\n        \"RUNNER_STATE_DIR\": \".gemini\"\n      }\n    },\n    \"sandbox\": {\n      \"stateDir\": \".gemini\",\n      \"stateSyncImage\": \"quay.io/ambient_code/vteam_state_sync:latest\",\n      \"persistence\": \"s3\",\n      \"workspaceSize\": \"10Gi\",\n      \"terminationGracePeriod\": 60,\n      \"seed\": {\"cloneRepos\": true, \"hydrateState\": true}\n    },\n    \"auth\": {\n      \"requiredSecretKeys\": [\"GEMINI_API_KEY\", \"GOOGLE_API_KEY\"],\n      \"secretKeyLogic\": \"any\",\n      \"vertexSupported\": true\n    },\n    \"featureGate\": \"runner.gemini-cli.enabled\"\n  }\n]\n"
   kind: ConfigMap
   metadata:
     name: ambient-agent-registry
     namespace: ambient-code
 - apiVersion: v1
   data:
-    models.json: "{\n  \"version\": 2,\n  \"defaultModel\": \"claude-sonnet-4-5\",\n  \"providerDefaults\": {\n    \"anthropic\": \"claude-sonnet-4-5\",\n    \"google\": \"gemini-2.5-flash\"\n  },\n  \"models\": [\n    {\n      \"id\": \"claude-sonnet-4-5\",\n      \"label\": \"Claude Sonnet 4.5\",\n      \"vertexId\": \"claude-sonnet-4-5@20250929\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-opus-4-6\",\n      \"label\": \"Claude Opus 4.6\",\n      \"vertexId\": \"claude-opus-4-6@default\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"claude-opus-4-5\",\n      \"label\": \"Claude Opus 4.5\",\n      \"vertexId\": \"claude-opus-4-5@20251101\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-haiku-4-5\",\n      \"label\": \"Claude Haiku\
-      \ 4.5\",\n      \"vertexId\": \"claude-haiku-4-5@20251001\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-sonnet-4-6\",\n      \"label\": \"Claude Sonnet 4.6\",\n      \"vertexId\": \"claude-sonnet-4-6@default\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash\",\n      \"label\": \"Gemini 2.5 Flash\",\n      \"vertexId\": \"gemini-2.5-flash@default\",\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"gemini-2.5-pro\",\n      \"label\": \"Gemini 2.5 Pro\",\n      \"vertexId\": \"gemini-2.5-pro@default\",\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash-lite\",\n      \"label\": \"Gemini 2.5 Flash Lite\",\n      \"vertexId\": \"gemini-2.5-flash-lite@default\"\
-      ,\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash-preview-04-17\",\n      \"label\": \"Gemini 2.5 Flash Preview 04.17\",\n      \"vertexId\": \"gemini-2.5-flash-preview-04-17@default\",\n      \"provider\": \"google\",\n      \"available\": false,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-3.1-flash-image-preview\",\n      \"label\": \"Gemini 3.1 Flash Image Preview\",\n      \"vertexId\": \"gemini-3.1-flash-image-preview@default\",\n      \"provider\": \"google\",\n      \"available\": false,\n      \"featureGated\": true\n    }\n  ]\n}\n"
+    acl.yml: "- claim: email\n  pattern: ^.*@(redhat\\.com|ambient\\.code)$\n"
+    jwks.json: '{"keys":[]}
+
+      '
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: auth
+    name: ambient-api-server-auth
+    namespace: ambient-code
+- apiVersion: v1
+  data:
+    flags.json: "{\n  \"flags\": [\n    {\n      \"name\": \"runner.gemini-cli.enabled\",\n      \"description\": \"Enable Gemini CLI runner type for session creation\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"ldap.autocomplete.enabled\",\n      \"description\": \"Enable LDAP user and group autocomplete for workspace sharing\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"scheduled-session.reuse.enabled\",\n      \"description\": \"Enable reuse last session option for scheduled sessions\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"jira-write\",\n      \"description\": \"Allow Jira MCP server to perform write operations in new sessions\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    }\n  ]\n}\n"
+  kind: ConfigMap
+  metadata:
+    name: ambient-flags
+    namespace: ambient-code
+- apiVersion: v1
+  data:
+    models.json: "{\n  \"version\": 2,\n  \"defaultModel\": \"claude-sonnet-4-5\",\n  \"providerDefaults\": {\n    \"anthropic\": \"claude-sonnet-4-5\",\n    \"google\": \"gemini-2.5-flash\"\n  },\n  \"models\": [\n    {\n      \"id\": \"claude-sonnet-4-5\",\n      \"label\": \"Claude Sonnet 4.5\",\n      \"vertexId\": \"claude-sonnet-4-5@20250929\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-opus-4-6\",\n      \"label\": \"Claude Opus 4.6\",\n      \"vertexId\": \"claude-opus-4-6@default\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"claude-opus-4-5\",\n      \"label\": \"Claude Opus 4.5\",\n      \"vertexId\": \"claude-opus-4-5@20251101\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-haiku-4-5\",\n      \"label\": \"Claude Haiku 4.5\",\n      \"vertexId\": \"claude-haiku-4-5@20251001\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"claude-sonnet-4-6\",\n      \"label\": \"Claude Sonnet 4.6\",\n      \"vertexId\": \"claude-sonnet-4-6@default\",\n      \"provider\": \"anthropic\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash\",\n      \"label\": \"Gemini 2.5 Flash\",\n      \"vertexId\": \"gemini-2.5-flash@default\",\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": false\n    },\n    {\n      \"id\": \"gemini-2.5-pro\",\n      \"label\": \"Gemini 2.5 Pro\",\n      \"vertexId\": \"gemini-2.5-pro@default\",\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash-lite\",\n      \"label\": \"Gemini 2.5 Flash Lite\",\n      \"vertexId\": \"gemini-2.5-flash-lite@default\",\n      \"provider\": \"google\",\n      \"available\": true,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-2.5-flash-preview-04-17\",\n      \"label\": \"Gemini 2.5 Flash Preview 04.17\",\n      \"vertexId\": \"gemini-2.5-flash-preview-04-17@default\",\n      \"provider\": \"google\",\n      \"available\": false,\n      \"featureGated\": true\n    },\n    {\n      \"id\": \"gemini-3.1-flash-image-preview\",\n      \"label\": \"Gemini 3.1 Flash Image Preview\",\n      \"vertexId\": \"gemini-3.1-flash-image-preview@default\",\n      \"provider\": \"google\",\n      \"available\": false,\n      \"featureGated\": true\n    }\n  ]\n}\n"
   kind: ConfigMap
   metadata:
     name: ambient-models
@@ -1296,9 +1335,6 @@ objects:
             value: http://minio.ambient-code.svc:9000
           - name: S3_BUCKET
             value: ambient-sessions
-          # Disabled: OTel collector not deployed. Uncomment when collector is available.
-          # - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          #   value: otel-collector.ambient-code.svc:4317
           - name: DEPLOYMENT_ENV
             value: production
           - name: VERSION

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -3,17 +3,14 @@ kind: Template
 metadata:
   name: ambient-code-operator
   annotations:
-    description: Ambient Code Platform - Operator and CRDs
-    tags: ambient-code,operator
+    description: Ambient Code Platform - Operator
 parameters:
 - name: IMAGE_TAG
-  description: Image tag to deploy (auto-generated from git commit)
+  description: Image tag
   required: true
 - name: IMAGE_OPERATOR
-  description: Operator image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main
 - name: IMAGE_AMBIENT_RUNNER
-  description: Ambient runner image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main
 objects:
 - apiVersion: apiextensions.k8s.io/v1
@@ -362,6 +359,8 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.frontend: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"frontend"}}'
     name: frontend
     namespace: ambient-code
 - apiVersion: v1
@@ -1155,6 +1154,18 @@ objects:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
     name: ambient-frontend-auth
+  subjects:
+  - kind: ServiceAccount
+    name: frontend
+    namespace: ambient-code
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ambient-frontend-oauth-delegator
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:auth-delegator
   subjects:
   - kind: ServiceAccount
     name: frontend

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -12,6 +12,8 @@ parameters:
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-operator-main
 - name: IMAGE_AMBIENT_RUNNER
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-runner-main
+- name: ANTHROPIC_VERTEX_PROJECT_ID
+  value: itpc-gcp-hcm-pe-eng-claude
 objects:
 - apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
@@ -1262,7 +1264,7 @@ objects:
     namespace: ambient-code
 - apiVersion: v1
   data:
-    ANTHROPIC_VERTEX_PROJECT_ID: ambient-code-platform
+    ANTHROPIC_VERTEX_PROJECT_ID: ${ANTHROPIC_VERTEX_PROJECT_ID}
     CLOUD_ML_REGION: global
     GOOGLE_APPLICATION_CREDENTIALS: /app/vertex/itpc-gcp-hcm-pe-eng.json
     USE_VERTEX: '1'

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -1113,6 +1113,23 @@ objects:
     - selfsubjectaccessreviews
     verbs:
     - create
+  # MLflow experiment tracking permissions (namespace-scoped CRDs)
+  # Required to grant MLflow access to session runner service accounts
+  # Sessions need these permissions to log experiments/runs to MLflow tracking server
+  # Uses Kubeflow MLflow Operator CRDs for Kubernetes-native RBAC authentication
+  - apiGroups:
+    - mlflow.kubeflow.org
+    resources:
+    - experiments
+    - runs
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -523,6 +523,23 @@ objects:
     - create
     - delete
     - update
+  # MLflow experiment tracking permissions (namespace-scoped CRDs)
+  # Required to grant MLflow access to session runner service accounts
+  # Sessions need these permissions to log experiments/runs to MLflow tracking server
+  # Uses Kubeflow MLflow Operator CRDs for Kubernetes-native RBAC authentication
+  - apiGroups:
+    - mlflow.kubeflow.org
+    resources:
+    - experiments
+    - runs
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -540,6 +540,16 @@ objects:
     - update
     - patch
     - delete
+  # NetworkPolicy permissions for isolating runner pods
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - create
+    - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -1275,6 +1275,23 @@ objects:
       deployment-type: openshift
     name: operator-config
     namespace: ambient-code
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-runner-namespaces
+    namespace: ${NAMESPACE}
+  spec:
+    podSelector:
+      matchLabels:
+        app: backend-api
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            app: ambient-code-runner
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -1161,18 +1161,6 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
-    name: ambient-frontend-oauth-delegator
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: system:auth-delegator
-  subjects:
-  - kind: ServiceAccount
-    name: frontend
-    namespace: ambient-code
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
     name: ambient-users-can-list-projects
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -1232,7 +1232,7 @@ objects:
   data:
     ANTHROPIC_VERTEX_PROJECT_ID: ambient-code-platform
     CLOUD_ML_REGION: global
-    GOOGLE_APPLICATION_CREDENTIALS: /app/vertex/ambient-code-key.json
+    GOOGLE_APPLICATION_CREDENTIALS: /app/vertex/itpc-gcp-hcm-pe-eng.json
     USE_VERTEX: '1'
   kind: ConfigMap
   metadata:

--- a/components/manifests/templates/template-operator.yaml
+++ b/components/manifests/templates/template-operator.yaml
@@ -360,7 +360,7 @@ objects:
   kind: ServiceAccount
   metadata:
     annotations:
-      serviceaccounts.openshift.io/oauth-redirectreference.frontend: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"frontend"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.frontend: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"frontend-route"}}'
     name: frontend
     namespace: ambient-code
 - apiVersion: v1

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -96,24 +96,6 @@ objects:
   kind: Service
   metadata:
     labels:
-      app: ambient-api-server
-      component: database
-    name: ambient-api-server-db
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: postgresql
-      port: 5432
-      protocol: TCP
-      targetPort: 5432
-    selector:
-      app: ambient-api-server
-      component: database
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
       app: backend-api
     name: backend-service
     namespace: ambient-code
@@ -152,42 +134,6 @@ objects:
   kind: Service
   metadata:
     labels:
-      app: minio
-    name: minio
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: api
-      port: 9000
-      protocol: TCP
-      targetPort: 9000
-    - name: console
-      port: 9001
-      protocol: TCP
-      targetPort: 9001
-    selector:
-      app: minio
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: postgresql
-      app.kubernetes.io/name: postgresql
-    name: postgresql
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: postgresql
-      port: 5432
-      targetPort: postgresql
-    selector:
-      app: postgresql
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
       app: public-api
     name: public-api-service
     namespace: ambient-code
@@ -199,22 +145,6 @@ objects:
       targetPort: http
     selector:
       app: public-api
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: unleash
-      app.kubernetes.io/name: unleash
-    name: unleash
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: http
-      port: 4242
-      targetPort: 4242
-    selector:
-      app: unleash
     type: ClusterIP
 - apiVersion: v1
   kind: LimitRange
@@ -261,19 +191,6 @@ objects:
     resources:
       requests:
         storage: 5Gi
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    labels:
-      app: minio
-    name: minio-data
-    namespace: ambient-code
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 500Gi
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -433,77 +350,6 @@ objects:
         - configMap:
             name: ambient-api-server-auth
           name: auth-config
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: ambient-api-server
-      component: database
-    name: ambient-api-server-db
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: ambient-api-server
-        component: database
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          app: ambient-api-server
-          component: database
-      spec:
-        containers:
-        - env:
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                key: db.user
-                name: ambient-code-rds
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: db.password
-                name: ambient-code-rds
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                key: db.name
-                name: ambient-code-rds
-          - name: PGDATA
-            value: /var/lib/postgresql/data/pgdata
-          image: postgres:16
-          livenessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
-          name: postgresql
-          ports:
-          - containerPort: 5432
-            name: postgresql
-          readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-          volumeMounts:
-          - mountPath: /var/lib/postgresql/data
-            name: ambient-api-server-db-data
-        volumes:
-        - name: ambient-api-server-db-data
-          persistentVolumeClaim:
-            claimName: ambient-api-server-db-data
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -905,157 +751,6 @@ objects:
   kind: Deployment
   metadata:
     labels:
-      app: minio
-    name: minio
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: minio
-    template:
-      metadata:
-        labels:
-          app: minio
-      spec:
-        containers:
-        - args:
-          - server
-          - /data
-          - --console-address
-          - :9001
-          env:
-          - name: MINIO_ROOT_USER
-            valueFrom:
-              secretKeyRef:
-                key: root-user
-                name: minio-credentials
-          - name: MINIO_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: root-password
-                name: minio-credentials
-          image: quay.io/minio/minio:latest
-          livenessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /minio/health/live
-              port: 9000
-            initialDelaySeconds: 60
-            periodSeconds: 15
-            timeoutSeconds: 5
-          name: minio
-          ports:
-          - containerPort: 9000
-            name: api
-            protocol: TCP
-          - containerPort: 9001
-            name: console
-            protocol: TCP
-          readinessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /minio/health/ready
-              port: 9000
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 6000m
-              memory: 12Gi
-            requests:
-              cpu: 3000m
-              memory: 6Gi
-          volumeMounts:
-          - mountPath: /data
-            name: data
-        volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: minio-data
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: postgresql
-      app.kubernetes.io/component: database
-      app.kubernetes.io/name: postgresql
-    name: postgresql
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: postgresql
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          app: postgresql
-          app.kubernetes.io/name: postgresql
-      spec:
-        containers:
-        - env:
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                key: db.user
-                name: postgresql-credentials
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: db.password
-                name: postgresql-credentials
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                key: db.name
-                name: postgresql-credentials
-          - name: PGDATA
-            value: /var/lib/postgresql/data/pgdata
-          image: postgres:16
-          livenessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
-          name: postgresql
-          ports:
-          - containerPort: 5432
-            name: postgresql
-          readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
-          volumeMounts:
-          - mountPath: /var/lib/postgresql/data
-            name: data
-        volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: postgresql-data
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
       app: public-api
     name: public-api
     namespace: ambient-code
@@ -1117,86 +812,6 @@ objects:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
         serviceAccountName: public-api
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: unleash
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: unleash
-    name: unleash
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: unleash
-    template:
-      metadata:
-        labels:
-          app: unleash
-          app.kubernetes.io/name: unleash
-      spec:
-        containers:
-        - env:
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                key: database-url
-                name: unleash-credentials
-          - name: DATABASE_SSL
-            valueFrom:
-              secretKeyRef:
-                key: database-ssl
-                name: unleash-credentials
-          - name: LOG_LEVEL
-            value: info
-          - name: INIT_ADMIN_API_TOKENS
-            valueFrom:
-              secretKeyRef:
-                key: admin-api-token
-                name: unleash-credentials
-          - name: INIT_CLIENT_API_TOKENS
-            valueFrom:
-              secretKeyRef:
-                key: client-api-token
-                name: unleash-credentials
-          - name: INIT_FRONTEND_API_TOKENS
-            valueFrom:
-              secretKeyRef:
-                key: frontend-api-token
-                name: unleash-credentials
-          - name: UNLEASH_DEFAULT_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: default-admin-password
-                name: unleash-credentials
-          image: unleashorg/unleash-server:5.11.3
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 4242
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 5
-          name: unleash
-          ports:
-          - containerPort: 4242
-            name: http
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 4242
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
 - apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -1,0 +1,1392 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ambient-code-services
+  annotations:
+    description: "Ambient Code Platform - Application services"
+
+parameters:
+- name: IMAGE_TAG
+  description: "Image tag to deploy (auto-generated from git commit)"
+  required: true
+- name: IMAGE_BACKEND
+  description: "Backend API image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main"
+  required: true
+- name: IMAGE_FRONTEND
+  description: "Frontend image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main"
+  required: true
+- name: IMAGE_PUBLIC_API
+  description: "Public API image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main"
+  required: true
+- name: IMAGE_AMBIENT_API_SERVER
+  description: "Ambient API Server image"
+  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main"
+  required: true
+
+objects:
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: ambient-api-server
+    name: ambient-api-server
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: backend-api
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: frontend
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: public-api
+    name: public-api
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  data:
+    acl.yml: |
+      - claim: email
+        pattern: ^.*@(redhat\.com|ambient\.code)$
+    jwks.json: |
+      {"keys":[]}
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: auth
+    name: ambient-api-server-auth
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  data:
+    flags.json: |
+      {
+        "flags": [
+          {
+            "name": "runner.gemini-cli.enabled",
+            "description": "Enable Gemini CLI runner type for session creation",
+            "tags": [
+              {
+                "type": "scope",
+                "value": "workspace"
+              }
+            ]
+          },
+          {
+            "name": "ldap.autocomplete.enabled",
+            "description": "Enable LDAP user and group autocomplete for workspace sharing",
+            "tags": [
+              {
+                "type": "scope",
+                "value": "workspace"
+              }
+            ]
+          },
+          {
+            "name": "scheduled-session.reuse.enabled",
+            "description": "Enable reuse last session option for scheduled sessions",
+            "tags": [
+              {
+                "type": "scope",
+                "value": "workspace"
+              }
+            ]
+          },
+          {
+            "name": "jira-write",
+            "description": "Allow Jira MCP server to perform write operations in new sessions",
+            "tags": [
+              {
+                "type": "scope",
+                "value": "workspace"
+              }
+            ]
+          }
+        ]
+      }
+  kind: ConfigMap
+  metadata:
+    name: ambient-flags
+    namespace: ambient-code
+  
+
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: api
+    name: ambient-api-server
+    namespace: ambient-code
+  stringData:
+    sentry.key: ""
+  type: Opaque
+  
+
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-api-server-db
+    namespace: ambient-code
+  stringData:
+    db.host: VAULT_INJECTED
+    db.name: ambient_code
+    db.password: VAULT_INJECTED
+    db.port: "5432"
+    db.user: VAULT_INJECTED
+  type: Opaque
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes the ambient-api-server REST API
+    labels:
+      app: ambient-api-server
+      component: api
+    name: ambient-api-server
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: api
+      port: 8000
+      protocol: TCP
+      targetPort: 8000
+    - name: grpc
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: metrics
+      port: 4433
+      protocol: TCP
+      targetPort: 4433
+    - name: health
+      port: 4434
+      protocol: TCP
+      targetPort: 4434
+    selector:
+      app: ambient-api-server
+      component: api
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-api-server-db
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: postgresql
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      app: ambient-api-server
+      component: database
+    type: ClusterIP
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: backend-api
+    name: backend-service
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    selector:
+      app: backend-api
+    type: ClusterIP
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: frontend
+    name: frontend-service
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: http
+      port: 3000
+      protocol: TCP
+      targetPort: http
+    selector:
+      app: frontend
+    type: ClusterIP
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: minio
+    name: minio
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: api
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: console
+      port: 9001
+      protocol: TCP
+      targetPort: 9001
+    selector:
+      app: minio
+    type: ClusterIP
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: postgresql
+      app.kubernetes.io/name: postgresql
+    name: postgresql
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+    selector:
+      app: postgresql
+    type: ClusterIP
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: public-api
+    name: public-api-service
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: http
+      port: 8081
+      protocol: TCP
+      targetPort: http
+    selector:
+      app: public-api
+    type: ClusterIP
+  
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: unleash
+      app.kubernetes.io/name: unleash
+    name: unleash
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: http
+      port: 4242
+      targetPort: 4242
+    selector:
+      app: unleash
+    type: ClusterIP
+  
+
+  apiVersion: v1
+  kind: LimitRange
+  metadata:
+    labels:
+      ambient-code.io/managed: "true"
+      app.kubernetes.io/managed-by: ambient-code
+    name: ambient-default-limits
+    namespace: ambient-code
+  spec:
+    limits:
+    - default:
+        cpu: "2"
+        memory: 4Gi
+      defaultRequest:
+        cpu: 250m
+        memory: 256Mi
+      type: Container
+  
+
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-api-server-db-data
+    namespace: ambient-code
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  
+
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: backend-api
+      component: state-storage
+    name: backend-state-pvc
+    namespace: ambient-code
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+  
+
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: minio
+    name: minio-data
+    namespace: ambient-code
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 500Gi
+  
+
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: postgresql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/name: postgresql
+    name: postgresql-data
+    namespace: ambient-code
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: api
+    name: ambient-api-server
+    namespace: ambient-code
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ambient-api-server
+        component: api
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: ambient-api-server
+          component: api
+      spec:
+        containers:
+        - command:
+          - /usr/local/bin/ambient-api-server
+          - serve
+          - --db-host-file=/secrets/db/db.host
+          - --db-port-file=/secrets/db/db.port
+          - --db-user-file=/secrets/db/db.user
+          - --db-password-file=/secrets/db/db.password
+          - --db-name-file=/secrets/db/db.name
+          - --enable-jwt=true
+          - --enable-authz=false
+          - --jwk-cert-file=/configs/authentication/jwks.json
+          - --enable-https=false
+          - --api-server-bindaddress=:8000
+          - --metrics-server-bindaddress=:4433
+          - --health-check-server-bindaddress=:4434
+          - --db-sslmode=disable
+          - --db-max-open-connections=50
+          - --enable-db-debug=false
+          - --enable-metrics-https=false
+          - --http-read-timeout=5s
+          - --http-write-timeout=30s
+          - --cors-allowed-origins=*
+          - --cors-allowed-headers=X-Ambient-Project
+          - --enable-grpc=true
+          - --grpc-server-bindaddress=:9000
+          - --alsologtostderr
+          - -v=4
+          env:
+          - name: AMBIENT_ENV
+            value: development
+          image: ${IMAGE_AMBIENT_API_SERVER}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /api/ambient
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          name: api-server
+          ports:
+          - containerPort: 8000
+            name: api
+            protocol: TCP
+          - containerPort: 4433
+            name: metrics
+            protocol: TCP
+          - containerPort: 4434
+            name: health
+            protocol: TCP
+          - containerPort: 9000
+            name: grpc
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              httpHeaders:
+              - name: User-Agent
+                value: Probe
+              path: /healthcheck
+              port: 4434
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 200m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+          volumeMounts:
+          - mountPath: /secrets/db
+            name: db-secrets
+          - mountPath: /secrets/service
+            name: app-secrets
+          - mountPath: /configs/authentication
+            name: auth-config
+        initContainers:
+        - command:
+          - /usr/local/bin/ambient-api-server
+          - migrate
+          - --db-host-file=/secrets/db/db.host
+          - --db-port-file=/secrets/db/db.port
+          - --db-user-file=/secrets/db/db.user
+          - --db-password-file=/secrets/db/db.password
+          - --db-name-file=/secrets/db/db.name
+          - --alsologtostderr
+          - -v=4
+          image: ${IMAGE_AMBIENT_API_SERVER}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          name: migration
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+          volumeMounts:
+          - mountPath: /secrets/db
+            name: db-secrets
+        serviceAccountName: ambient-api-server
+        volumes:
+        - name: db-secrets
+          secret:
+            secretName: ambient-api-server-db
+        - name: app-secrets
+          secret:
+            secretName: ambient-api-server
+        - configMap:
+            name: ambient-api-server-auth
+          name: auth-config
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-api-server-db
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: ambient-api-server
+        component: database
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: ambient-api-server
+          component: database
+      spec:
+        containers:
+        - env:
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ambient-api-server-db
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ambient-api-server-db
+          - name: POSTGRES_DB
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ambient-api-server-db
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+          image: postgres:16
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            name: postgresql
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+          - mountPath: /var/lib/postgresql/data
+            name: ambient-api-server-db-data
+        volumes:
+        - name: ambient-api-server-db-data
+          persistentVolumeClaim:
+            claimName: ambient-api-server-db-data
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: backend-api
+    name: backend-api
+    namespace: ambient-code
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: backend-api
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: backend-api
+          role: backend
+      spec:
+        containers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PORT
+            value: "8080"
+          - name: STATE_BASE_DIR
+            value: /workspace
+          - name: SPEC_KIT_REPO
+            value: ambient-code/spec-kit-rh
+          - name: SPEC_KIT_VERSION
+            value: main
+          - name: SPEC_KIT_TEMPLATE
+            value: spec-kit-template-claude-sh
+          - name: IMAGE_PULL_POLICY
+            valueFrom:
+              configMapKeyRef:
+                key: IMAGE_PULL_POLICY
+                name: operator-config
+                optional: true
+          - name: GITHUB_APP_ID
+            valueFrom:
+              secretKeyRef:
+                key: GITHUB_APP_ID
+                name: github-app-secret
+                optional: true
+          - name: GITHUB_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                key: GITHUB_PRIVATE_KEY
+                name: github-app-secret
+                optional: true
+          - name: GITHUB_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: GITHUB_CLIENT_ID
+                name: github-app-secret
+                optional: true
+          - name: GITHUB_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: GITHUB_CLIENT_SECRET
+                name: github-app-secret
+                optional: true
+          - name: GITHUB_STATE_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: GITHUB_STATE_SECRET
+                name: github-app-secret
+                optional: true
+          - name: GOOGLE_OAUTH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: GOOGLE_OAUTH_CLIENT_ID
+                name: google-workflow-app-secret
+                optional: true
+          - name: GOOGLE_OAUTH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: GOOGLE_OAUTH_CLIENT_SECRET
+                name: google-workflow-app-secret
+                optional: true
+          - name: OAUTH_STATE_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: OAUTH_STATE_SECRET
+                name: google-workflow-app-secret
+                optional: true
+          - name: BACKEND_URL
+            valueFrom:
+              secretKeyRef:
+                key: BACKEND_URL
+                name: google-workflow-app-secret
+                optional: true
+          - name: OPERATOR_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: OPERATOR_IMAGE
+                name: operator-config
+                optional: true
+          - name: OOTB_WORKFLOWS_REPO
+            value: https://github.com/ambient-code/workflows.git
+          - name: OOTB_WORKFLOWS_BRANCH
+            value: main
+          - name: OOTB_WORKFLOWS_PATH
+            value: workflows
+          - name: USE_VERTEX
+            valueFrom:
+              configMapKeyRef:
+                key: USE_VERTEX
+                name: operator-config
+                optional: true
+          - name: CLOUD_ML_REGION
+            valueFrom:
+              configMapKeyRef:
+                key: CLOUD_ML_REGION
+                name: operator-config
+                optional: true
+          - name: ANTHROPIC_VERTEX_PROJECT_ID
+            valueFrom:
+              configMapKeyRef:
+                key: ANTHROPIC_VERTEX_PROJECT_ID
+                name: operator-config
+                optional: true
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            valueFrom:
+              configMapKeyRef:
+                key: GOOGLE_APPLICATION_CREDENTIALS
+                name: operator-config
+                optional: true
+          - name: LDAP_SRV_DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                key: LDAP_SRV_DOMAIN
+                name: ldap-config
+                optional: true
+          - name: LDAP_URL
+            valueFrom:
+              configMapKeyRef:
+                key: LDAP_URL
+                name: ldap-config
+                optional: true
+          - name: LDAP_BASE_DN
+            valueFrom:
+              configMapKeyRef:
+                key: LDAP_BASE_DN
+                name: ldap-config
+                optional: true
+          - name: LDAP_GROUP_BASE_DN
+            valueFrom:
+              configMapKeyRef:
+                key: LDAP_GROUP_BASE_DN
+                name: ldap-config
+                optional: true
+          - name: LDAP_BIND_DN
+            valueFrom:
+              configMapKeyRef:
+                key: LDAP_BIND_DN
+                name: ldap-config
+                optional: true
+          - name: LDAP_BIND_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: LDAP_BIND_PASSWORD
+                name: ldap-credentials
+                optional: true
+          - name: LDAP_CA_CERT_PATH
+            valueFrom:
+              configMapKeyRef:
+                key: LDAP_CA_CERT_PATH
+                name: ldap-config
+                optional: true
+          - name: UNLEASH_URL
+            valueFrom:
+              secretKeyRef:
+                key: unleash-url
+                name: unleash-credentials
+                optional: true
+          - name: UNLEASH_CLIENT_KEY
+            valueFrom:
+              secretKeyRef:
+                key: client-api-token
+                name: unleash-credentials
+                optional: true
+          - name: UNLEASH_ADMIN_URL
+            valueFrom:
+              secretKeyRef:
+                key: unleash-admin-url
+                name: unleash-credentials
+                optional: true
+          - name: UNLEASH_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: admin-api-token
+                name: unleash-credentials
+                optional: true
+          - name: UNLEASH_PROJECT
+            valueFrom:
+              secretKeyRef:
+                key: unleash-project
+                name: unleash-credentials
+                optional: true
+          - name: UNLEASH_ENVIRONMENT
+            valueFrom:
+              secretKeyRef:
+                key: unleash-environment
+                name: unleash-credentials
+                optional: true
+          image: ${IMAGE_BACKEND}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          name: backend-api
+          ports:
+          - containerPort: 8080
+            name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1536Mi
+            requests:
+              cpu: 200m
+              memory: 512Mi
+          volumeMounts:
+          - mountPath: /workspace
+            name: backend-state
+          - mountPath: /app/vertex
+            name: vertex-credentials
+            readOnly: true
+          - mountPath: /config/models
+            name: model-manifest
+            readOnly: true
+          - mountPath: /config/flags
+            name: flags-config
+            readOnly: true
+          - mountPath: /config/registry
+            name: agent-registry
+            readOnly: true
+          - mountPath: /etc/pki/custom-ca
+            name: ldap-ca-cert
+            readOnly: true
+        serviceAccountName: backend-api
+        volumes:
+        - name: backend-state
+          persistentVolumeClaim:
+            claimName: backend-state-pvc
+        - name: vertex-credentials
+          secret:
+            optional: true
+            secretName: ambient-vertex
+        - configMap:
+            name: ambient-models
+            optional: true
+          name: model-manifest
+        - configMap:
+            name: ambient-flags
+            optional: true
+          name: flags-config
+        - configMap:
+            name: ambient-agent-registry
+            optional: true
+          name: agent-registry
+        - configMap:
+            name: ldap-ca-cert
+            optional: true
+          name: ldap-ca-cert
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: frontend
+    name: frontend
+    namespace: ambient-code
+  spec:
+    selector:
+      matchLabels:
+        app: frontend
+    template:
+      metadata:
+        labels:
+          app: frontend
+      spec:
+        containers:
+        - env:
+          - name: BACKEND_URL
+            value: http://backend-service:8080/api
+          - name: NODE_ENV
+            value: production
+          - name: GITHUB_APP_SLUG
+            value: ambient-code
+          - name: UNLEASH_URL
+            valueFrom:
+              secretKeyRef:
+                key: unleash-url
+                name: unleash-credentials
+                optional: true
+          - name: UNLEASH_CLIENT_KEY
+            valueFrom:
+              secretKeyRef:
+                key: client-api-token
+                name: unleash-credentials
+                optional: true
+          image: ${IMAGE_FRONTEND}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          name: frontend
+          ports:
+          - containerPort: 3000
+            name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+        serviceAccountName: frontend
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: minio
+    name: minio
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: minio
+    template:
+      metadata:
+        labels:
+          app: minio
+      spec:
+        containers:
+        - args:
+          - server
+          - /data
+          - --console-address
+          - :9001
+          env:
+          - name: MINIO_ROOT_USER
+            valueFrom:
+              secretKeyRef:
+                key: root-user
+                name: minio-credentials
+          - name: MINIO_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: root-password
+                name: minio-credentials
+          image: quay.io/minio/minio:latest
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+          name: minio
+          ports:
+          - containerPort: 9000
+            name: api
+            protocol: TCP
+          - containerPort: 9001
+            name: console
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 6000m
+              memory: 12Gi
+            requests:
+              cpu: 3000m
+              memory: 6Gi
+          volumeMounts:
+          - mountPath: /data
+            name: data
+        volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-data
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: postgresql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/name: postgresql
+    name: postgresql
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: postgresql
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: postgresql
+          app.kubernetes.io/name: postgresql
+      spec:
+        containers:
+        - env:
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: postgresql-credentials
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: postgresql-credentials
+          - name: POSTGRES_DB
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: postgresql-credentials
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+          image: postgres:16
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            name: postgresql
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+          - mountPath: /var/lib/postgresql/data
+            name: data
+        volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgresql-data
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: public-api
+    name: public-api
+    namespace: ambient-code
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: public-api
+    template:
+      metadata:
+        labels:
+          app: public-api
+          role: api-gateway
+      spec:
+        containers:
+        - env:
+          - name: PORT
+            value: "8081"
+          - name: BACKEND_URL
+            value: http://backend-service:8080
+          - name: GIN_MODE
+            value: release
+          - name: BACKEND_TIMEOUT
+            value: 30s
+          - name: RATE_LIMIT_RPS
+            value: "100"
+          - name: RATE_LIMIT_BURST
+            value: "200"
+          image: ${IMAGE_PUBLIC_API}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: public-api
+          ports:
+          - containerPort: 8081
+            name: http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+        serviceAccountName: public-api
+  
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: unleash
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: unleash
+    name: unleash
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: unleash
+    template:
+      metadata:
+        labels:
+          app: unleash
+          app.kubernetes.io/name: unleash
+      spec:
+        containers:
+        - env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                key: database-url
+                name: unleash-credentials
+          - name: DATABASE_SSL
+            valueFrom:
+              secretKeyRef:
+                key: database-ssl
+                name: unleash-credentials
+          - name: LOG_LEVEL
+            value: info
+          - name: INIT_ADMIN_API_TOKENS
+            valueFrom:
+              secretKeyRef:
+                key: admin-api-token
+                name: unleash-credentials
+          - name: INIT_CLIENT_API_TOKENS
+            valueFrom:
+              secretKeyRef:
+                key: client-api-token
+                name: unleash-credentials
+          - name: INIT_FRONTEND_API_TOKENS
+            valueFrom:
+              secretKeyRef:
+                key: frontend-api-token
+                name: unleash-credentials
+          - name: UNLEASH_DEFAULT_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: default-admin-password
+                name: unleash-credentials
+          image: unleashorg/unleash-server:5.11.3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4242
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: unleash
+          ports:
+          - containerPort: 4242
+            name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4242
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+  
+
+  apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    labels:
+      app: public-api
+    name: public-api-pdb
+    namespace: ambient-code
+  spec:
+    minAvailable: 1
+    selector:
+      matchLabels:
+        app: public-api
+  
+
+  apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: api
+    name: ambient-api-server
+    namespace: ambient-code
+  spec:
+    port:
+      targetPort: api
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: reencrypt
+    to:
+      kind: Service
+      name: ambient-api-server
+  
+
+  apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: grpc
+    name: ambient-api-server-grpc
+    namespace: ambient-code
+  spec:
+    port:
+      targetPort: grpc
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: reencrypt
+    to:
+      kind: Service
+      name: ambient-api-server
+  
+
+  apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: backend-api
+    name: backend-route
+    namespace: ambient-code
+  spec:
+    port:
+      targetPort: http
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: backend-service
+      weight: 100
+    wildcardPolicy: None
+  
+
+  apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      haproxy.router.openshift.io/balance: roundrobin
+      haproxy.router.openshift.io/disable_cookies: "true"
+    labels:
+      app: frontend
+    name: frontend-route
+    namespace: ambient-code
+  spec:
+    port:
+      targetPort: dashboard-ui
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: frontend-service
+      weight: 100
+    wildcardPolicy: None
+  
+
+  apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: public-api
+    name: public-api-route
+    namespace: ambient-code
+  spec:
+    port:
+      targetPort: http
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: public-api-service
+      weight: 100
+    wildcardPolicy: None
+  
+

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -232,7 +232,8 @@ objects:
           - --api-server-bindaddress=:8000
           - --metrics-server-bindaddress=:4433
           - --health-check-server-bindaddress=:4434
-          - --db-sslmode=disable
+          # SSL required: Using external AWS RDS database
+          - --db-sslmode=require
           - --db-max-open-connections=50
           - --enable-db-debug=false
           - --enable-metrics-https=false
@@ -309,6 +310,7 @@ objects:
           - --db-user-file=/secrets/db/db.user
           - --db-password-file=/secrets/db/db.password
           - --db-name-file=/secrets/db/db.name
+          - --db-sslmode=require
           - --alsologtostderr
           - -v=4
           image: ${IMAGE_AMBIENT_API_SERVER}:${IMAGE_TAG}

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -3,7 +3,8 @@ kind: Template
 metadata:
   name: ambient-code-services
   annotations:
-    description: Ambient Code Platform - Application services
+    description: Ambient Code Platform - Application Services
+    tags: ambient-code,services
 parameters:
 - name: IMAGE_TAG
   description: Image tag to deploy (auto-generated from git commit)
@@ -11,65 +12,26 @@ parameters:
 - name: IMAGE_BACKEND
   description: Backend API image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main
-  required: true
 - name: IMAGE_FRONTEND
   description: Frontend image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main
-  required: true
 - name: IMAGE_PUBLIC_API
   description: Public API image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main
-  required: true
 - name: IMAGE_AMBIENT_API_SERVER
   description: Ambient API Server image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main
-  required: true
 objects:
 - apiVersion: v1
-  kind: ServiceAccount
+  kind: Namespace
   metadata:
+    annotations:
+      app.kubernetes.io/name: ambient-code
+      app.kubernetes.io/part-of: ambient-code
     labels:
-      app: ambient-api-server
-    name: ambient-api-server
-    namespace: ambient-code
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: backend-api
-    namespace: ambient-code
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: frontend
-    namespace: ambient-code
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    labels:
-      app: public-api
-    name: public-api
-    namespace: ambient-code
-- apiVersion: v1
-  data:
-    acl.yml: "- claim: email\n  pattern: ^.*@(redhat\\.com|ambient\\.code)$\n"
-    jwks.json: '{"keys":[]}
-
-      '
-  kind: ConfigMap
-  metadata:
-    labels:
-      app: ambient-api-server
-      component: auth
-    name: ambient-api-server-auth
-    namespace: ambient-code
-- apiVersion: v1
-  data:
-    flags.json: "{\n  \"flags\": [\n    {\n      \"name\": \"runner.gemini-cli.enabled\",\n      \"description\": \"Enable Gemini CLI runner type for session creation\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"ldap.autocomplete.enabled\",\n      \"description\": \"Enable LDAP user and group autocomplete for workspace sharing\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"scheduled-session.reuse.enabled\",\n      \"description\": \"Enable reuse last session option for scheduled sessions\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"jira-write\",\n      \"description\": \"Allow Jira MCP server to perform write operations in new sessions\",\n      \"tags\": [\n      \
-      \  {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    }\n  ]\n}\n"
-  kind: ConfigMap
-  metadata:
-    name: ambient-flags
-    namespace: ambient-code
+      app: vteam
+      name: ambient-code
+    name: ambient-code
 - apiVersion: v1
   kind: Secret
   metadata:
@@ -82,10 +44,28 @@ objects:
     sentry.key: ''
   type: Opaque
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      qontract.recycle: 'true'
+    labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-code-rds
+    namespace: ambient-code
+  stringData:
+    db.host: VAULT_INJECTED
+    db.name: ambient_code
+    db.password: VAULT_INJECTED
+    db.port: '5432'
+    db.user: VAULT_INJECTED
+  type: Opaque
+- apiVersion: v1
   kind: Service
   metadata:
     annotations:
       description: Exposes the ambient-api-server REST API
+      service.beta.openshift.io/serving-cert-secret-name: ambient-api-server-tls
     labels:
       app: ambient-api-server
       component: api
@@ -116,6 +96,24 @@ objects:
   kind: Service
   metadata:
     labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-api-server-db
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: postgresql
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      app: ambient-api-server
+      component: database
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
       app: backend-api
     name: backend-service
     namespace: ambient-code
@@ -131,18 +129,60 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: dashboard-proxy-tls
     labels:
       app: frontend
     name: frontend-service
     namespace: ambient-code
   spec:
     ports:
+    - name: dashboard-ui
+      port: 8443
+      protocol: TCP
+      targetPort: dashboard-ui
     - name: http
       port: 3000
       protocol: TCP
       targetPort: http
     selector:
       app: frontend
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: minio
+    name: minio
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: api
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: console
+      port: 9001
+      protocol: TCP
+      targetPort: 9001
+    selector:
+      app: minio
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: postgresql
+      app.kubernetes.io/name: postgresql
+    name: postgresql
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+    selector:
+      app: postgresql
     type: ClusterIP
 - apiVersion: v1
   kind: Service
@@ -159,6 +199,22 @@ objects:
       targetPort: http
     selector:
       app: public-api
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: unleash
+      app.kubernetes.io/name: unleash
+    name: unleash
+    namespace: ambient-code
+  spec:
+    ports:
+    - name: http
+      port: 4242
+      targetPort: 4242
+    selector:
+      app: unleash
     type: ClusterIP
 - apiVersion: v1
   kind: LimitRange
@@ -181,6 +237,20 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-api-server-db-data
+    namespace: ambient-code
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
       app: backend-api
       component: state-storage
     name: backend-state-pvc
@@ -191,6 +261,34 @@ objects:
     resources:
       requests:
         storage: 5Gi
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: minio
+    name: minio-data
+    namespace: ambient-code
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 500Gi
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: postgresql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/name: postgresql
+    name: postgresql-data
+    namespace: ambient-code
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -232,7 +330,6 @@ objects:
           - --api-server-bindaddress=:8000
           - --metrics-server-bindaddress=:4433
           - --health-check-server-bindaddress=:4434
-          # SSL required: Using external AWS RDS database
           - --db-sslmode=require
           - --db-max-open-connections=50
           - --enable-db-debug=false
@@ -247,7 +344,7 @@ objects:
           - -v=4
           env:
           - name: AMBIENT_ENV
-            value: development
+            value: stage
           image: ${IMAGE_AMBIENT_API_SERVER}:${IMAGE_TAG}
           imagePullPolicy: Always
           livenessProbe:
@@ -336,6 +433,77 @@ objects:
         - configMap:
             name: ambient-api-server-auth
           name: auth-config
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ambient-api-server
+      component: database
+    name: ambient-api-server-db
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: ambient-api-server
+        component: database
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: ambient-api-server
+          component: database
+      spec:
+        containers:
+        - env:
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ambient-code-rds
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ambient-code-rds
+          - name: POSTGRES_DB
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ambient-code-rds
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+          image: postgres:16
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            name: postgresql
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+          - mountPath: /var/lib/postgresql/data
+            name: ambient-api-server-db-data
+        volumes:
+        - name: ambient-api-server-db-data
+          persistentVolumeClaim:
+            claimName: ambient-api-server-db-data
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -670,12 +838,220 @@ objects:
             periodSeconds: 5
           resources:
             limits:
+              cpu: 1000m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 512Mi
+        - args:
+          - --http-address=:8443
+          - --https-address=
+          - --provider=openshift
+          - --upstream=http://localhost:3000
+          - --client-id=ambient-frontend
+          - --client-secret-file=/etc/oauth/config/client-secret
+          - --cookie-secret-file=/etc/oauth/config/cookie_secret
+          - --cookie-expire=23h0m0s
+          - --pass-access-token
+          - --scope=user:full
+          - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
+          - --skip-auth-regex=^/metrics
+          image: quay.io/openshift/origin-oauth-proxy:4.14
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /oauth/healthz
+              port: dashboard-ui
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: oauth-proxy
+          ports:
+          - containerPort: 8443
+            name: dashboard-ui
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /oauth/healthz
+              port: dashboard-ui
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 256Mi
+          volumeMounts:
+          - mountPath: /etc/oauth/config
+            name: oauth-config
+          - mountPath: /etc/tls/private
+            name: proxy-tls
+        serviceAccountName: frontend
+        volumes:
+        - name: oauth-config
+          secret:
+            secretName: frontend-oauth-config
+        - name: proxy-tls
+          secret:
+            secretName: dashboard-proxy-tls
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: minio
+    name: minio
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: minio
+    template:
+      metadata:
+        labels:
+          app: minio
+      spec:
+        containers:
+        - args:
+          - server
+          - /data
+          - --console-address
+          - :9001
+          env:
+          - name: MINIO_ROOT_USER
+            valueFrom:
+              secretKeyRef:
+                key: root-user
+                name: minio-credentials
+          - name: MINIO_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: root-password
+                name: minio-credentials
+          image: quay.io/minio/minio:latest
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+          name: minio
+          ports:
+          - containerPort: 9000
+            name: api
+            protocol: TCP
+          - containerPort: 9001
+            name: console
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 6000m
+              memory: 12Gi
+            requests:
+              cpu: 3000m
+              memory: 6Gi
+          volumeMounts:
+          - mountPath: /data
+            name: data
+        volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-data
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: postgresql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/name: postgresql
+    name: postgresql
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: postgresql
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: postgresql
+          app.kubernetes.io/name: postgresql
+      spec:
+        containers:
+        - env:
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: postgresql-credentials
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: postgresql-credentials
+          - name: POSTGRES_DB
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: postgresql-credentials
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+          image: postgres:16
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            name: postgresql
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
               cpu: 500m
               memory: 512Mi
             requests:
               cpu: 100m
               memory: 256Mi
-        serviceAccountName: frontend
+          volumeMounts:
+          - mountPath: /var/lib/postgresql/data
+            name: data
+        volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgresql-data
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -741,6 +1117,86 @@ objects:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
         serviceAccountName: public-api
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: unleash
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: unleash
+    name: unleash
+    namespace: ambient-code
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: unleash
+    template:
+      metadata:
+        labels:
+          app: unleash
+          app.kubernetes.io/name: unleash
+      spec:
+        containers:
+        - env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                key: database-url
+                name: unleash-credentials
+          - name: DATABASE_SSL
+            valueFrom:
+              secretKeyRef:
+                key: database-ssl
+                name: unleash-credentials
+          - name: LOG_LEVEL
+            value: info
+          - name: INIT_ADMIN_API_TOKENS
+            valueFrom:
+              secretKeyRef:
+                key: admin-api-token
+                name: unleash-credentials
+          - name: INIT_CLIENT_API_TOKENS
+            valueFrom:
+              secretKeyRef:
+                key: client-api-token
+                name: unleash-credentials
+          - name: INIT_FRONTEND_API_TOKENS
+            valueFrom:
+              secretKeyRef:
+                key: frontend-api-token
+                name: unleash-credentials
+          - name: UNLEASH_DEFAULT_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: default-admin-password
+                name: unleash-credentials
+          image: unleashorg/unleash-server:5.11.3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4242
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: unleash
+          ports:
+          - containerPort: 4242
+            name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4242
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
 - apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -1,72 +1,60 @@
----
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: ambient-code-services
   annotations:
-    description: "Ambient Code Platform - Application services"
-
+    description: Ambient Code Platform - Application services
 parameters:
 - name: IMAGE_TAG
-  description: "Image tag to deploy (auto-generated from git commit)"
+  description: Image tag to deploy (auto-generated from git commit)
   required: true
 - name: IMAGE_BACKEND
-  description: "Backend API image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main"
+  description: Backend API image
+  value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main
   required: true
 - name: IMAGE_FRONTEND
-  description: "Frontend image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main"
+  description: Frontend image
+  value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main
   required: true
 - name: IMAGE_PUBLIC_API
-  description: "Public API image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main"
+  description: Public API image
+  value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main
   required: true
 - name: IMAGE_AMBIENT_API_SERVER
-  description: "Ambient API Server image"
-  value: "quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main"
+  description: Ambient API Server image
+  value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main
   required: true
-
 objects:
-  apiVersion: v1
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
       app: ambient-api-server
     name: ambient-api-server
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: backend-api
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: frontend
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
       app: public-api
     name: public-api
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   data:
-    acl.yml: |
-      - claim: email
-        pattern: ^.*@(redhat\.com|ambient\.code)$
-    jwks.json: |
-      {"keys":[]}
+    acl.yml: "- claim: email\n  pattern: ^.*@(redhat\\.com|ambient\\.code)$\n"
+    jwks.json: '{"keys":[]}
+
+      '
   kind: ConfigMap
   metadata:
     labels:
@@ -74,62 +62,15 @@ objects:
       component: auth
     name: ambient-api-server-auth
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   data:
-    flags.json: |
-      {
-        "flags": [
-          {
-            "name": "runner.gemini-cli.enabled",
-            "description": "Enable Gemini CLI runner type for session creation",
-            "tags": [
-              {
-                "type": "scope",
-                "value": "workspace"
-              }
-            ]
-          },
-          {
-            "name": "ldap.autocomplete.enabled",
-            "description": "Enable LDAP user and group autocomplete for workspace sharing",
-            "tags": [
-              {
-                "type": "scope",
-                "value": "workspace"
-              }
-            ]
-          },
-          {
-            "name": "scheduled-session.reuse.enabled",
-            "description": "Enable reuse last session option for scheduled sessions",
-            "tags": [
-              {
-                "type": "scope",
-                "value": "workspace"
-              }
-            ]
-          },
-          {
-            "name": "jira-write",
-            "description": "Allow Jira MCP server to perform write operations in new sessions",
-            "tags": [
-              {
-                "type": "scope",
-                "value": "workspace"
-              }
-            ]
-          }
-        ]
-      }
+    flags.json: "{\n  \"flags\": [\n    {\n      \"name\": \"runner.gemini-cli.enabled\",\n      \"description\": \"Enable Gemini CLI runner type for session creation\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"ldap.autocomplete.enabled\",\n      \"description\": \"Enable LDAP user and group autocomplete for workspace sharing\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"scheduled-session.reuse.enabled\",\n      \"description\": \"Enable reuse last session option for scheduled sessions\",\n      \"tags\": [\n        {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    },\n    {\n      \"name\": \"jira-write\",\n      \"description\": \"Allow Jira MCP server to perform write operations in new sessions\",\n      \"tags\": [\n      \
+      \  {\n          \"type\": \"scope\",\n          \"value\": \"workspace\"\n        }\n      ]\n    }\n  ]\n}\n"
   kind: ConfigMap
   metadata:
     name: ambient-flags
     namespace: ambient-code
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Secret
   metadata:
     labels:
@@ -138,15 +79,13 @@ objects:
     name: ambient-api-server
     namespace: ambient-code
   stringData:
-    sentry.key: ""
+    sentry.key: ''
   type: Opaque
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Secret
   metadata:
     annotations:
-      qontract.recycle: "true"
+      qontract.recycle: 'true'
     labels:
       app: ambient-api-server
       component: database
@@ -156,12 +95,10 @@ objects:
     db.host: VAULT_INJECTED
     db.name: ambient_code
     db.password: VAULT_INJECTED
-    db.port: "5432"
+    db.port: '5432'
     db.user: VAULT_INJECTED
   type: Opaque
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     annotations:
@@ -192,9 +129,7 @@ objects:
     selector:
       app: ambient-api-server
       component: api
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -212,9 +147,7 @@ objects:
       app: ambient-api-server
       component: database
     type: ClusterIP
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -230,9 +163,7 @@ objects:
     selector:
       app: backend-api
     type: ClusterIP
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -248,9 +179,7 @@ objects:
     selector:
       app: frontend
     type: ClusterIP
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -270,9 +199,7 @@ objects:
     selector:
       app: minio
     type: ClusterIP
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -288,9 +215,7 @@ objects:
     selector:
       app: postgresql
     type: ClusterIP
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -306,9 +231,7 @@ objects:
     selector:
       app: public-api
     type: ClusterIP
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -324,28 +247,24 @@ objects:
     selector:
       app: unleash
     type: ClusterIP
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: LimitRange
   metadata:
     labels:
-      ambient-code.io/managed: "true"
+      ambient-code.io/managed: 'true'
       app.kubernetes.io/managed-by: ambient-code
     name: ambient-default-limits
     namespace: ambient-code
   spec:
     limits:
     - default:
-        cpu: "2"
+        cpu: '2'
         memory: 4Gi
       defaultRequest:
         cpu: 250m
         memory: 256Mi
       type: Container
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     labels:
@@ -359,9 +278,7 @@ objects:
     resources:
       requests:
         storage: 1Gi
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     labels:
@@ -375,9 +292,7 @@ objects:
     resources:
       requests:
         storage: 5Gi
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     labels:
@@ -390,9 +305,7 @@ objects:
     resources:
       requests:
         storage: 500Gi
-  
-
-  apiVersion: v1
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     labels:
@@ -407,9 +320,7 @@ objects:
     resources:
       requests:
         storage: 10Gi
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -552,9 +463,7 @@ objects:
         - configMap:
             name: ambient-api-server-auth
           name: auth-config
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -625,9 +534,7 @@ objects:
         - name: ambient-api-server-db-data
           persistentVolumeClaim:
             claimName: ambient-api-server-db-data
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -654,7 +561,7 @@ objects:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: PORT
-            value: "8080"
+            value: '8080'
           - name: STATE_BASE_DIR
             value: /workspace
           - name: SPEC_KIT_REPO
@@ -857,7 +764,7 @@ objects:
             periodSeconds: 5
           resources:
             limits:
-              cpu: "1"
+              cpu: '1'
               memory: 1536Mi
             requests:
               cpu: 200m
@@ -905,9 +812,7 @@ objects:
             name: ldap-ca-cert
             optional: true
           name: ldap-ca-cert
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -969,9 +874,7 @@ objects:
               cpu: 100m
               memory: 256Mi
         serviceAccountName: frontend
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -1044,9 +947,7 @@ objects:
         - name: data
           persistentVolumeClaim:
             claimName: minio-data
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -1124,9 +1025,7 @@ objects:
         - name: data
           persistentVolumeClaim:
             claimName: postgresql-data
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -1147,7 +1046,7 @@ objects:
         containers:
         - env:
           - name: PORT
-            value: "8081"
+            value: '8081'
           - name: BACKEND_URL
             value: http://backend-service:8080
           - name: GIN_MODE
@@ -1155,9 +1054,9 @@ objects:
           - name: BACKEND_TIMEOUT
             value: 30s
           - name: RATE_LIMIT_RPS
-            value: "100"
+            value: '100'
           - name: RATE_LIMIT_BURST
-            value: "200"
+            value: '200'
           image: ${IMAGE_PUBLIC_API}:${IMAGE_TAG}
           imagePullPolicy: Always
           livenessProbe:
@@ -1191,9 +1090,7 @@ objects:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
         serviceAccountName: public-api
-  
-
-  apiVersion: apps/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -1273,9 +1170,7 @@ objects:
             requests:
               cpu: 100m
               memory: 256Mi
-  
-
-  apiVersion: policy/v1
+- apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:
     labels:
@@ -1287,9 +1182,7 @@ objects:
     selector:
       matchLabels:
         app: public-api
-  
-
-  apiVersion: route.openshift.io/v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     labels:
@@ -1306,9 +1199,7 @@ objects:
     to:
       kind: Service
       name: ambient-api-server
-  
-
-  apiVersion: route.openshift.io/v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     labels:
@@ -1325,9 +1216,7 @@ objects:
     to:
       kind: Service
       name: ambient-api-server
-  
-
-  apiVersion: route.openshift.io/v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     labels:
@@ -1345,14 +1234,12 @@ objects:
       name: backend-service
       weight: 100
     wildcardPolicy: None
-  
-
-  apiVersion: route.openshift.io/v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     annotations:
       haproxy.router.openshift.io/balance: roundrobin
-      haproxy.router.openshift.io/disable_cookies: "true"
+      haproxy.router.openshift.io/disable_cookies: 'true'
     labels:
       app: frontend
     name: frontend-route
@@ -1368,9 +1255,7 @@ objects:
       name: frontend-service
       weight: 100
     wildcardPolicy: None
-  
-
-  apiVersion: route.openshift.io/v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     labels:
@@ -1388,5 +1273,3 @@ objects:
       name: public-api-service
       weight: 100
     wildcardPolicy: None
-  
-

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -327,7 +327,7 @@ objects:
         volumes:
         - name: db-secrets
           secret:
-            secretName: ambient-api-server-db
+            secretName: ambient-code-rds
         - name: app-secrets
           secret:
             secretName: ambient-api-server

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -82,23 +82,6 @@ objects:
     sentry.key: ''
   type: Opaque
 - apiVersion: v1
-  kind: Secret
-  metadata:
-    annotations:
-      qontract.recycle: 'true'
-    labels:
-      app: ambient-api-server
-      component: database
-    name: ambient-api-server-db
-    namespace: ambient-code
-  stringData:
-    db.host: VAULT_INJECTED
-    db.name: ambient_code
-    db.password: VAULT_INJECTED
-    db.port: '5432'
-    db.user: VAULT_INJECTED
-  type: Opaque
-- apiVersion: v1
   kind: Service
   metadata:
     annotations:
@@ -129,24 +112,6 @@ objects:
     selector:
       app: ambient-api-server
       component: api
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: ambient-api-server
-      component: database
-    name: ambient-api-server-db
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: postgresql
-      port: 5432
-      protocol: TCP
-      targetPort: 5432
-    selector:
-      app: ambient-api-server
-      component: database
-    type: ClusterIP
 - apiVersion: v1
   kind: Service
   metadata:
@@ -183,42 +148,6 @@ objects:
   kind: Service
   metadata:
     labels:
-      app: minio
-    name: minio
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: api
-      port: 9000
-      protocol: TCP
-      targetPort: 9000
-    - name: console
-      port: 9001
-      protocol: TCP
-      targetPort: 9001
-    selector:
-      app: minio
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: postgresql
-      app.kubernetes.io/name: postgresql
-    name: postgresql
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: postgresql
-      port: 5432
-      targetPort: postgresql
-    selector:
-      app: postgresql
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
       app: public-api
     name: public-api-service
     namespace: ambient-code
@@ -230,22 +159,6 @@ objects:
       targetPort: http
     selector:
       app: public-api
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: unleash
-      app.kubernetes.io/name: unleash
-    name: unleash
-    namespace: ambient-code
-  spec:
-    ports:
-    - name: http
-      port: 4242
-      targetPort: 4242
-    selector:
-      app: unleash
     type: ClusterIP
 - apiVersion: v1
   kind: LimitRange
@@ -268,20 +181,6 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     labels:
-      app: ambient-api-server
-      component: database
-    name: ambient-api-server-db-data
-    namespace: ambient-code
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    labels:
       app: backend-api
       component: state-storage
     name: backend-state-pvc
@@ -292,34 +191,6 @@ objects:
     resources:
       requests:
         storage: 5Gi
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    labels:
-      app: minio
-    name: minio-data
-    namespace: ambient-code
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 500Gi
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    labels:
-      app: postgresql
-      app.kubernetes.io/component: database
-      app.kubernetes.io/name: postgresql
-    name: postgresql-data
-    namespace: ambient-code
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 10Gi
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -463,77 +334,6 @@ objects:
         - configMap:
             name: ambient-api-server-auth
           name: auth-config
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: ambient-api-server
-      component: database
-    name: ambient-api-server-db
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: ambient-api-server
-        component: database
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          app: ambient-api-server
-          component: database
-      spec:
-        containers:
-        - env:
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                key: db.user
-                name: ambient-api-server-db
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: db.password
-                name: ambient-api-server-db
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                key: db.name
-                name: ambient-api-server-db
-          - name: PGDATA
-            value: /var/lib/postgresql/data/pgdata
-          image: postgres:16
-          livenessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
-          name: postgresql
-          ports:
-          - containerPort: 5432
-            name: postgresql
-          readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-          volumeMounts:
-          - mountPath: /var/lib/postgresql/data
-            name: ambient-api-server-db-data
-        volumes:
-        - name: ambient-api-server-db-data
-          persistentVolumeClaim:
-            claimName: ambient-api-server-db-data
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -878,157 +678,6 @@ objects:
   kind: Deployment
   metadata:
     labels:
-      app: minio
-    name: minio
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: minio
-    template:
-      metadata:
-        labels:
-          app: minio
-      spec:
-        containers:
-        - args:
-          - server
-          - /data
-          - --console-address
-          - :9001
-          env:
-          - name: MINIO_ROOT_USER
-            valueFrom:
-              secretKeyRef:
-                key: root-user
-                name: minio-credentials
-          - name: MINIO_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: root-password
-                name: minio-credentials
-          image: quay.io/minio/minio:latest
-          livenessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /minio/health/live
-              port: 9000
-            initialDelaySeconds: 60
-            periodSeconds: 15
-            timeoutSeconds: 5
-          name: minio
-          ports:
-          - containerPort: 9000
-            name: api
-            protocol: TCP
-          - containerPort: 9001
-            name: console
-            protocol: TCP
-          readinessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /minio/health/ready
-              port: 9000
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 6000m
-              memory: 12Gi
-            requests:
-              cpu: 3000m
-              memory: 6Gi
-          volumeMounts:
-          - mountPath: /data
-            name: data
-        volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: minio-data
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: postgresql
-      app.kubernetes.io/component: database
-      app.kubernetes.io/name: postgresql
-    name: postgresql
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: postgresql
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          app: postgresql
-          app.kubernetes.io/name: postgresql
-      spec:
-        containers:
-        - env:
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                key: db.user
-                name: postgresql-credentials
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: db.password
-                name: postgresql-credentials
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                key: db.name
-                name: postgresql-credentials
-          - name: PGDATA
-            value: /var/lib/postgresql/data/pgdata
-          image: postgres:16
-          livenessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
-          name: postgresql
-          ports:
-          - containerPort: 5432
-            name: postgresql
-          readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - pg_isready -U "$POSTGRES_USER"
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
-          volumeMounts:
-          - mountPath: /var/lib/postgresql/data
-            name: data
-        volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: postgresql-data
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
       app: public-api
     name: public-api
     namespace: ambient-code
@@ -1090,86 +739,6 @@ objects:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
         serviceAccountName: public-api
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: unleash
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: unleash
-    name: unleash
-    namespace: ambient-code
-  spec:
-    replicas: 0
-    selector:
-      matchLabels:
-        app: unleash
-    template:
-      metadata:
-        labels:
-          app: unleash
-          app.kubernetes.io/name: unleash
-      spec:
-        containers:
-        - env:
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                key: database-url
-                name: unleash-credentials
-          - name: DATABASE_SSL
-            valueFrom:
-              secretKeyRef:
-                key: database-ssl
-                name: unleash-credentials
-          - name: LOG_LEVEL
-            value: info
-          - name: INIT_ADMIN_API_TOKENS
-            valueFrom:
-              secretKeyRef:
-                key: admin-api-token
-                name: unleash-credentials
-          - name: INIT_CLIENT_API_TOKENS
-            valueFrom:
-              secretKeyRef:
-                key: client-api-token
-                name: unleash-credentials
-          - name: INIT_FRONTEND_API_TOKENS
-            valueFrom:
-              secretKeyRef:
-                key: frontend-api-token
-                name: unleash-credentials
-          - name: UNLEASH_DEFAULT_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: default-admin-password
-                name: unleash-credentials
-          image: unleashorg/unleash-server:5.11.3
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 4242
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 5
-          name: unleash
-          ports:
-          - containerPort: 4242
-            name: http
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 4242
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
 - apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -3,24 +3,27 @@ kind: Template
 metadata:
   name: ambient-code-services
   annotations:
-    description: Ambient Code Platform - Application Services
-    tags: ambient-code,services
+    description: Ambient Code Platform - Services
 parameters:
 - name: IMAGE_TAG
-  description: Image tag to deploy (auto-generated from git commit)
+  description: Image tag
   required: true
 - name: IMAGE_BACKEND
-  description: Backend API image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-backend-main
 - name: IMAGE_FRONTEND
-  description: Frontend image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-frontend-main
 - name: IMAGE_PUBLIC_API
-  description: Public API image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-public-api-main
 - name: IMAGE_AMBIENT_API_SERVER
-  description: Ambient API Server image
   value: quay.io/redhat-services-prod/hcm-eng-prod-tenant/ambient-code-main/ambient-code-ambient-api-server-main
+- name: OAUTH_PROXY_IMAGE_NAME
+  value: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9
+- name: OAUTH_PROXY_IMAGE_TAG
+  value: v4.18.0-202506230505.p0.gcbd44ad.assembly.stream.el9
+- name: NAMESPACE
+  value: ambient-code
+- name: UPSTREAM_TIMEOUT
+  value: 5m
 objects:
 - apiVersion: v1
   kind: Namespace
@@ -112,7 +115,7 @@ objects:
   kind: Service
   metadata:
     annotations:
-      service.beta.openshift.io/serving-cert-secret-name: dashboard-proxy-tls
+      service.alpha.openshift.io/serving-cert-secret-name: frontend-proxy-tls
     labels:
       app: frontend
     name: frontend-service
@@ -690,27 +693,26 @@ objects:
               cpu: 200m
               memory: 512Mi
         - args:
-          - --http-address=:8443
-          - --https-address=
+          - --https-address=:8443
           - --provider=openshift
+          - --openshift-service-account=frontend
           - --upstream=http://localhost:3000
-          - --client-id=ambient-frontend
-          - --client-secret-file=/etc/oauth/config/client-secret
-          - --cookie-secret-file=/etc/oauth/config/cookie_secret
-          - --cookie-expire=23h0m0s
-          - --pass-access-token
-          - --scope=user:full
-          - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
+          - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
+          - --tls-cert=/etc/tls/private/tls.crt
+          - --tls-key=/etc/tls/private/tls.key
+          - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
-          image: quay.io/openshift/origin-oauth-proxy:4.14
+          image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /oauth/healthz
               port: dashboard-ui
-              scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 5
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           name: oauth-proxy
@@ -722,31 +724,26 @@ objects:
             httpGet:
               path: /oauth/healthz
               port: dashboard-ui
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 5
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           resources:
             limits:
               cpu: 200m
-              memory: 512Mi
+              memory: 200Mi
             requests:
-              cpu: 50m
-              memory: 256Mi
+              cpu: 10m
+              memory: 50Mi
           volumeMounts:
-          - mountPath: /etc/oauth/config
-            name: oauth-config
           - mountPath: /etc/tls/private
-            name: proxy-tls
+            name: frontend-proxy-tls
         serviceAccountName: frontend
         volumes:
-        - name: oauth-config
+        - name: frontend-proxy-tls
           secret:
-            secretName: frontend-oauth-config
-        - name: proxy-tls
-          secret:
-            secretName: dashboard-proxy-tls
+            secretName: frontend-proxy-tls
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -47,23 +47,6 @@ objects:
     sentry.key: ''
   type: Opaque
 - apiVersion: v1
-  kind: Secret
-  metadata:
-    annotations:
-      qontract.recycle: 'true'
-    labels:
-      app: ambient-api-server
-      component: database
-    name: ambient-code-rds
-    namespace: ambient-code
-  stringData:
-    db.host: VAULT_INJECTED
-    db.name: ambient_code
-    db.password: VAULT_INJECTED
-    db.port: '5432'
-    db.user: VAULT_INJECTED
-  type: Opaque
-- apiVersion: v1
   kind: Service
   metadata:
     annotations:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -687,6 +687,7 @@ objects:
           - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
+          - --pass-user-bearer-token
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -680,7 +680,7 @@ objects:
           - --https-address=
           - --provider=openshift
           - --openshift-service-account=frontend
-          - --upstream=http://localhost:3000
+          - --upstream=http://frontend-service:3000
           - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -871,7 +871,7 @@ objects:
       targetPort: dashboard-ui
     tls:
       insecureEdgeTerminationPolicy: Redirect
-      termination: edge
+      termination: reencrypt
     to:
       kind: Service
       name: frontend-service

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -684,7 +684,9 @@ objects:
           - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
-          - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - --cookie-secret-file=/etc/oauth-cookie/cookie_secret
+          - --pass-access-token
+          - --scope=user:full
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
@@ -723,11 +725,16 @@ objects:
           volumeMounts:
           - mountPath: /etc/tls/private
             name: frontend-proxy-tls
+          - mountPath: /etc/oauth-cookie
+            name: oauth-cookie-secret
         serviceAccountName: frontend
         volumes:
         - name: frontend-proxy-tls
           secret:
             secretName: frontend-proxy-tls
+        - name: oauth-cookie-secret
+          secret:
+            secretName: stage-cookie-secret
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -681,6 +681,7 @@ objects:
           - --provider=openshift
           - --openshift-service-account=frontend
           - --upstream=http://localhost:3000
+          - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/oauth-cookie/cookie_secret

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -683,7 +683,6 @@ objects:
           - --client-secret-file=/etc/oauth-client/client_secret
           - --upstream=http://backend-service:8080/api/
           - --upstream=http://localhost:3000
-          - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"list"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/oauth-cookie/cookie_secret

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -681,6 +681,7 @@ objects:
           - --provider=openshift
           - --client-id=ambient-code
           - --client-secret-file=/etc/oauth-client/client_secret
+          - --upstream=http://backend-service:8080/api/
           - --upstream=http://localhost:3000
           - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"list"}}
           - --tls-cert=/etc/tls/private/tls.crt

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -679,13 +679,15 @@ objects:
           - --http-address=:8443
           - --https-address=
           - --provider=openshift
-          - --openshift-service-account=frontend
+          - --client-id=ambient-code
+          - --client-secret-file=/etc/oauth-client/client_secret
           - --upstream=http://localhost:3000
           - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"list"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/oauth-cookie/cookie_secret
           - --pass-access-token
+          - --scope=user:full
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
@@ -726,6 +728,8 @@ objects:
             name: frontend-proxy-tls
           - mountPath: /etc/oauth-cookie
             name: oauth-cookie-secret
+          - mountPath: /etc/oauth-client
+            name: oauth-client-secret
         serviceAccountName: frontend
         volumes:
         - name: frontend-proxy-tls
@@ -734,6 +738,9 @@ objects:
         - name: oauth-cookie-secret
           secret:
             secretName: stage-cookie-secret
+        - name: oauth-client-secret
+          secret:
+            secretName: stage-sso-client
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -687,7 +687,6 @@ objects:
           - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
-          - --set-authorization-header=true
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -676,7 +676,8 @@ objects:
               cpu: 200m
               memory: 512Mi
         - args:
-          - --https-address=:8443
+          - --http-address=:8443
+          - --https-address=
           - --provider=openshift
           - --openshift-service-account=frontend
           - --upstream=http://localhost:3000

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -597,7 +597,7 @@ objects:
         - name: vertex-credentials
           secret:
             optional: true
-            secretName: ambient-vertex
+            secretName: stage-gcp-creds
         - configMap:
             name: ambient-models
             optional: true

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -247,7 +247,7 @@ objects:
           - -v=4
           env:
           - name: AMBIENT_ENV
-            value: stage
+            value: production
           image: ${IMAGE_AMBIENT_API_SERVER}:${IMAGE_TAG}
           imagePullPolicy: Always
           livenessProbe:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -687,6 +687,7 @@ objects:
           - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
+          - --request-logging
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -687,7 +687,6 @@ objects:
           - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
-          - --pass-user-bearer-token
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -686,7 +686,6 @@ objects:
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/oauth-cookie/cookie_secret
           - --pass-access-token
-          - --scope=user:full
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -687,7 +687,7 @@ objects:
           - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
-          - --pass-access-token=true
+          - --set-authorization-header=true
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -680,14 +680,14 @@ objects:
           - --https-address=
           - --provider=openshift
           - --openshift-service-account=frontend
-          - --upstream=http://frontend-service:3000
+          - --upstream=http://localhost:3000
           - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - --upstream-timeout=5m
           - --skip-auth-regex=^/metrics
-          - --request-logging
+          - --pass-access-token=true
           image: ${OAUTH_PROXY_IMAGE_NAME}:${OAUTH_PROXY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -681,7 +681,6 @@ objects:
           - --provider=openshift
           - --openshift-service-account=frontend
           - --upstream=http://localhost:3000
-          - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/oauth-cookie/cookie_secret

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -681,7 +681,7 @@ objects:
           - --provider=openshift
           - --openshift-service-account=frontend
           - --upstream=http://localhost:3000
-          - --openshift-delegate-urls={"/api":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"},"/federate":{"resource":"namespaces","verb":"get","name":"ambient-code","namespace":"ambient-code"}}
+          - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/oauth-cookie/cookie_secret

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -681,7 +681,7 @@ objects:
           - --provider=openshift
           - --openshift-service-account=frontend
           - --upstream=http://localhost:3000
-          - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
+          - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"list"}}
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret-file=/etc/oauth-cookie/cookie_secret

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -872,7 +872,7 @@ objects:
       targetPort: dashboard-ui
     tls:
       insecureEdgeTerminationPolicy: Redirect
-      termination: reencrypt
+      termination: edge
     to:
       kind: Service
       name: frontend-service

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -694,7 +694,7 @@ objects:
             httpGet:
               path: /oauth/healthz
               port: dashboard-ui
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
@@ -708,7 +708,7 @@ objects:
             httpGet:
               path: /oauth/healthz
               port: dashboard-ui
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1

--- a/components/manifests/templates/validate.sh
+++ b/components/manifests/templates/validate.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Validate OpenShift templates
+
+set -e
+
+echo "Validating OpenShift templates..."
+
+cd "$(dirname "$0")"
+
+for template in template-operator.yaml template-services.yaml; do
+  echo "  Checking $template..."
+  oc process -f "$template" --param=IMAGE_TAG=validation-test --local > /dev/null
+  echo "    ✓ Valid"
+done
+
+echo "✓ All templates valid"

--- a/components/operator/internal/controller/otel_metrics.go
+++ b/components/operator/internal/controller/otel_metrics.go
@@ -53,6 +53,14 @@ func InitMetrics(ctx context.Context) (func(), error) {
 	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	if endpoint == "" {
 		log.Println("OTEL_EXPORTER_OTLP_ENDPOINT not set, metrics export disabled")
+
+		// Initialize no-op meter to prevent nil pointer panics
+		meter = otel.GetMeterProvider().Meter("ambient-code-operator-noop")
+		if err := initInstruments(); err != nil {
+			return nil, fmt.Errorf("failed to initialize no-op instruments: %w", err)
+		}
+		log.Println("OpenTelemetry metrics initialized with no-op provider (metrics not exported)")
+
 		return func() {}, nil
 	}
 

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -1045,6 +1045,28 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 
 			VolumeMounts: runnerVolumeMounts,
 
+			// Health probes to prevent Service routing before FastAPI is ready
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/health",
+						Port: intstr.FromInt32(runnerPort),
+					},
+				},
+				InitialDelaySeconds: 3,
+				PeriodSeconds:       5,
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/health",
+						Port: intstr.FromInt32(runnerPort),
+					},
+				},
+				InitialDelaySeconds: 20,
+				PeriodSeconds:       30,
+			},
+
 			// Lifecycle hook to copy Google credentials from read-only secret mount to writable workspace
 			Lifecycle: &corev1.Lifecycle{
 				PostStart: &corev1.LifecycleHandler{

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -1113,6 +1113,7 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 				// Core session env vars
 				base = append(base,
 					corev1.EnvVar{Name: "INITIAL_PROMPT", Value: prompt},
+					corev1.EnvVar{Name: "INITIAL_PROMPT_DELAY_SECONDS", Value: "10"},
 					corev1.EnvVar{Name: "LLM_MODEL", Value: model},
 					corev1.EnvVar{Name: "LLM_TEMPERATURE", Value: fmt.Sprintf("%.2f", temperature)},
 					corev1.EnvVar{Name: "LLM_MAX_TOKENS", Value: fmt.Sprintf("%d", maxTokens)},

--- a/components/runners/ambient-runner/ambient_runner/app.py
+++ b/components/runners/ambient-runner/ambient_runner/app.py
@@ -554,7 +554,7 @@ async def _push_initial_prompt_via_http(prompt: str, session_id: str) -> None:
         except Exception as e:
             logger.warning(
                 f"INITIAL_PROMPT attempt {attempt}/{_AUTO_PROMPT_MAX_RETRIES} "
-                f"error: {e}, retrying in {backoff:.0f}s"
+                f"error: {type(e).__name__}: {e}, retrying in {backoff:.0f}s"
             )
 
         await asyncio.sleep(backoff)


### PR DESCRIPTION
## Summary

Add NetworkPolicy to deploy templates allowing ingress traffic from runner pods to backend-api. This resolves connectivity issues where runner pods in user namespaces cannot reach backend-service due to default-deny NetworkPolicies.

## Changes

- Added NetworkPolicy resource to `template-operator.yaml`
- Targets `backend-api` pods specifically (more restrictive than upstream)
- Allows ingress from `ambient-code-runner` pods across all namespaces
- Uses `${NAMESPACE}` template parameter for proper scoping

## Based on upstream PR

This implements the fix from [ambient-code/platform#1553](https://github.com/ambient-code/platform/pull/1553) with improvements:

1. **More restrictive podSelector**: Targets only `app: backend-api` pods instead of all pods in the namespace
2. **Template parameterization**: Uses `${NAMESPACE}` for consistency with OpenShift template patterns

## Testing

- ✅ Template validation passed (`./validate.sh`)
- ✅ YAML syntax validated
- ✅ Conventional commit format verified

## Fixes

Resolves `INITIAL_PROMPT TimeoutError` during session startup when runner pods in user namespaces cannot reach backend-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous integration pipelines for multiple application components.
  * Added service routes for external access to API, frontend, backend, and public API endpoints.
  * Added health monitoring for runner services.

* **Chores**
  * Updated database secret references and naming conventions.
  * Enhanced OpenTelemetry metrics handling with no-op support.
  * Updated OAuth proxy configuration for improved security.
  * Added database SSL/TLS requirements for external connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->