### PR TITLE
fix(operator): attach X-Ambient-Session-Token on all operator→runner calls

### DIFF
--- a/components/operator/internal/handlers/helpers.go
+++ b/components/operator/internal/handlers/helpers.go
@@ -350,6 +350,21 @@ func ensureFreshRunnerToken(ctx context.Context, session *unstructured.Unstructu
 	return nil
 }
 
+// runnerSessionToken reads the agui-token from the runner token secret.
+// This token must be sent as X-Ambient-Session-Token on all operator→runner
+// HTTP calls; the runner middleware rejects unauthenticated requests with 401.
+func runnerSessionToken(namespace, sessionName string) string {
+	secretName := fmt.Sprintf("%s%s", defaultRunnerTokenSecretPrefix, sessionName)
+	secret, err := config.K8sClient.CoreV1().Secrets(namespace).Get(
+		context.TODO(), secretName, v1.GetOptions{},
+	)
+	if err != nil {
+		log.Printf("[Runner] Warning: could not read agui-token for session %s/%s: %v", namespace, sessionName, err)
+		return ""
+	}
+	return strings.TrimSpace(string(secret.Data["agui-token"]))
+}
+
 var vertexDeprecationOnce sync.Once
 
 // IsVertexEnabled checks whether Vertex AI is enabled via environment variables.

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -1812,6 +1812,7 @@ func reconcileSpecReposWithPatch(sessionNamespace, sessionName string, spec map[
 	// AG-UI pattern: Call runner's REST endpoints to update configuration
 	// Runner will restart Claude SDK client with new repo configuration
 	runnerBaseURL := fmt.Sprintf("http://session-%s.%s.svc.cluster.local:%d", sessionName, sessionNamespace, getRunnerPort(sessionNamespace, sessionName))
+	aguiToken := runnerSessionToken(sessionNamespace, sessionName)
 
 	// Add new repos
 	for _, repo := range toAdd {
@@ -1830,6 +1831,9 @@ func reconcileSpecReposWithPatch(sessionNamespace, sessionName string, spec map[
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if aguiToken != "" {
+			req.Header.Set("X-Ambient-Session-Token", aguiToken)
+		}
 
 		client := &http.Client{Timeout: 10 * time.Second}
 		resp, err := client.Do(req)
@@ -1862,6 +1866,9 @@ func reconcileSpecReposWithPatch(sessionNamespace, sessionName string, spec map[
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if aguiToken != "" {
+			req.Header.Set("X-Ambient-Session-Token", aguiToken)
+		}
 
 		client := &http.Client{Timeout: 10 * time.Second}
 		resp, err := client.Do(req)
@@ -1891,6 +1898,9 @@ func reconcileSpecReposWithPatch(sessionNamespace, sessionName string, spec map[
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if aguiToken != "" {
+			req.Header.Set("X-Ambient-Session-Token", aguiToken)
+		}
 
 		client := &http.Client{Timeout: 10 * time.Second}
 		resp, err := client.Do(req)
@@ -1983,6 +1993,9 @@ func reconcileActiveWorkflowWithPatch(sessionNamespace, sessionName string, spec
 		return fmt.Errorf("failed to create workflow request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if tok := runnerSessionToken(sessionNamespace, sessionName); tok != "" {
+		req.Header.Set("X-Ambient-Session-Token", tok)
+	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)


### PR DESCRIPTION
## Summary

- Fixes the `WorkflowReconciled=False / Runner returned 401` regression introduced by #1378
- Adds `runnerSessionToken()` helper that reads `agui-token` from the `ambient-runner-token-<session>` Secret
- Attaches `X-Ambient-Session-Token` on all four operator→runner HTTP call sites: `/workflow`, `/repos/add` (×2), `/repos/remove`

## Root cause

PR #1378 added per-session AGUI token auth to the runner middleware but the operator's own direct calls to runner endpoints were never updated to include the required header. The comment at the injection site even called this out ("The backend reads this from the same secret…") but the operator itself didn't follow through.

## Test plan

- [ ] Create a session with `activeWorkflow` set — confirm `WorkflowReconciled` condition becomes `True`
- [ ] Add/remove a repo on a running session — confirm no 401 in operator logs
- [ ] Confirm `runnerSessionToken()` gracefully returns `""` (and logs a warning) if the secret is missing

Fixes: https://github.com/ambient-code/platform/issues/1555

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented per-session authentication tokens for runner operations
  * Session credentials automatically applied to repository management (add, branch changes, removal) and workflow updates
  * Enhanced security through improved session isolation for concurrent operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->