### PR TITLE
fix(runner): write Google credentials as {email}.json with timezone-naive expiry

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
@@ -19,6 +19,9 @@ from ambient_runner.platform.utils import get_bot_token
 
 logger = logging.getLogger(__name__)
 
+_WORKSPACE_CREDS_DIR = Path("/workspace/.google_workspace_mcp/credentials")
+_SECRET_CREDS_DIR = Path("/app/.google_workspace_mcp/credentials")
+
 
 DEFAULT_ALLOWED_TOOLS = [
     "Read",
@@ -169,19 +172,16 @@ def log_auth_status(mcp_servers: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _read_google_credentials(
-    workspace_path: Path, secret_path: Path
-) -> dict[str, Any] | None:
-    cred_path = workspace_path if workspace_path.exists() else secret_path
-    if not cred_path.exists():
+def _load_credential_file(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
         return None
     try:
-        if cred_path.stat().st_size == 0:
+        if path.stat().st_size == 0:
             return None
-        with open(cred_path, "r") as f:
+        with open(path, "r") as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError) as e:
-        logger.warning(f"Failed to read Google credentials: {e}")
+        logger.warning(f"Failed to read Google credentials from {path.name}: {e}")
         return None
 
 
@@ -226,11 +226,17 @@ def _validate_google_token(
 def check_mcp_authentication(server_name: str) -> tuple[bool | None, str | None]:
     """Check if credentials are available and valid for known MCP servers."""
     if server_name == "google-workspace":
-        workspace_path = Path(
-            "/workspace/.google_workspace_mcp/credentials/credentials.json"
-        )
-        secret_path = Path("/app/.google_workspace_mcp/credentials/credentials.json")
-        creds = _read_google_credentials(workspace_path, secret_path)
+        creds = None
+        for creds_dir in (_WORKSPACE_CREDS_DIR, _SECRET_CREDS_DIR):
+            if creds_dir.is_dir():
+                for json_file in sorted(creds_dir.glob("*.json")):
+                    candidate = _load_credential_file(json_file)
+                    if candidate is not None:
+                        logger.debug("Using Google credentials from %s", json_file)
+                        creds = candidate
+                        break
+            if creds is not None:
+                break
         if creds is None:
             return (
                 False,

--- a/components/runners/ambient-runner/ambient_runner/platform/auth.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/auth.py
@@ -30,10 +30,11 @@ _credential_expiry: dict[str, float] = {}
 # How many seconds before expiry to trigger a proactive refresh.
 _EXPIRY_BUFFER_SEC = 5 * 60
 
-# Hardcoded path for Google Workspace MCP credentials (must match populate and clear).
-_GOOGLE_WORKSPACE_CREDS_FILE = Path(
-    "/workspace/.google_workspace_mcp/credentials/credentials.json"
+_GOOGLE_WORKSPACE_CREDS_DIR = Path(
+    "/workspace/.google_workspace_mcp/credentials"
 )
+
+_GOOGLE_WORKSPACE_LEGACY_CREDS_FILE = _GOOGLE_WORKSPACE_CREDS_DIR / "credentials.json"
 
 # Token files written on every credential refresh so the git credential helper
 # can read the latest token even after the CLI subprocess has already been spawned.
@@ -423,8 +424,10 @@ async def populate_runtime_credentials(context: RunnerContext) -> None:
     elif google_creds.get("token") or google_creds.get("accessToken"):
         try:
             if google_creds.get("accessToken"):
-                creds_dir = _GOOGLE_WORKSPACE_CREDS_FILE.parent
-                creds_dir.mkdir(parents=True, exist_ok=True)
+                _GOOGLE_WORKSPACE_CREDS_DIR.mkdir(parents=True, exist_ok=True)
+                expiry_raw = google_creds.get("expiresAt", "")
+                if isinstance(expiry_raw, str) and expiry_raw.endswith("Z"):
+                    expiry_raw = expiry_raw[:-1]
                 creds_data = {
                     "token": google_creds.get("accessToken"),
                     "refresh_token": google_creds.get("refreshToken", ""),
@@ -432,19 +435,28 @@ async def populate_runtime_credentials(context: RunnerContext) -> None:
                     "client_id": os.getenv("GOOGLE_OAUTH_CLIENT_ID", ""),
                     "client_secret": os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", ""),
                     "scopes": google_creds.get("scopes", []),
-                    "expiry": google_creds.get("expiresAt", ""),
+                    "expiry": expiry_raw,
                 }
-                with open(_GOOGLE_WORKSPACE_CREDS_FILE, "w") as f:
+                user_email = google_creds.get("email", "")
+                if user_email and user_email != _PLACEHOLDER_EMAIL:
+                    creds_filename = f"{user_email}.json"
+                else:
+                    creds_filename = "credentials.json"
+                creds_file = _GOOGLE_WORKSPACE_CREDS_DIR / creds_filename
+                if _GOOGLE_WORKSPACE_LEGACY_CREDS_FILE.exists() and creds_filename != "credentials.json":
+                    _GOOGLE_WORKSPACE_LEGACY_CREDS_FILE.unlink(missing_ok=True)
+                    logger.info("Removed legacy credentials.json in favor of %s", creds_filename)
+                with open(creds_file, "w") as f:
                     _json.dump(creds_data, f, indent=2)
-                _GOOGLE_WORKSPACE_CREDS_FILE.chmod(0o600)
-                logger.info("Updated Google credentials file for workspace-mcp")
+                creds_file.chmod(0o600)
+                logger.info("Updated Google credentials file for workspace-mcp: %s", creds_filename)
             else:
                 sa_json = google_creds["token"]
                 gac_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
                 if gac_path:
                     creds_path = Path(gac_path)
                 else:
-                    creds_path = _GOOGLE_WORKSPACE_CREDS_FILE
+                    creds_path = _GOOGLE_WORKSPACE_LEGACY_CREDS_FILE
                 creds_path.parent.mkdir(parents=True, exist_ok=True)
                 creds_path.write_text(sa_json)
                 creds_path.chmod(0o600)

--- a/components/runners/ambient-runner/tests/test_mcp_auth.py
+++ b/components/runners/ambient-runner/tests/test_mcp_auth.py
@@ -3,8 +3,6 @@
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import patch
-
 
 from ambient_runner.bridges.claude.mcp import check_mcp_authentication
 
@@ -12,16 +10,23 @@ from ambient_runner.bridges.claude.mcp import check_mcp_authentication
 class TestGoogleWorkspaceAuth:
     """Test check_mcp_authentication for google-workspace."""
 
-    def test_no_credentials_file(self, tmp_path):
-        with patch.object(Path, "exists", return_value=False):
-            is_auth, msg = check_mcp_authentication("google-workspace")
+    def test_no_credentials_file(self, tmp_path, monkeypatch):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._WORKSPACE_CREDS_DIR", empty_dir
+        )
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._SECRET_CREDS_DIR", empty_dir
+        )
+        is_auth, msg = check_mcp_authentication("google-workspace")
         assert is_auth is False
         assert "not configured" in msg
 
     def test_valid_credentials(self, tmp_path, monkeypatch):
-        creds_dir = tmp_path / ".google_workspace_mcp" / "credentials"
+        creds_dir = tmp_path / "workspace_creds"
         creds_dir.mkdir(parents=True)
-        creds_file = creds_dir / "credentials.json"
+        creds_file = creds_dir / "user@example.org.json"
 
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         creds_file.write_text(
@@ -35,46 +40,80 @@ class TestGoogleWorkspaceAuth:
         )
 
         monkeypatch.setenv("USER_GOOGLE_EMAIL", "user@example.org")
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._WORKSPACE_CREDS_DIR", creds_dir
+        )
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._SECRET_CREDS_DIR", empty_dir
+        )
 
-        with patch(
-            "ambient_runner.bridges.claude.mcp._read_google_credentials",
-            return_value=json.loads(creds_file.read_text()),
-        ):
-            is_auth, msg = check_mcp_authentication("google-workspace")
+        is_auth, msg = check_mcp_authentication("google-workspace")
         assert is_auth is True
         assert "user@example.org" in msg
 
-    def test_placeholder_email_rejected(self, monkeypatch):
-        monkeypatch.setenv("USER_GOOGLE_EMAIL", "user@example.com")
+    def test_placeholder_email_rejected(self, tmp_path, monkeypatch):
+        creds_dir = tmp_path / "workspace_creds"
+        creds_dir.mkdir(parents=True)
+        creds_file = creds_dir / "credentials.json"
+        creds_file.write_text(json.dumps({"token": "t", "refresh_token": "r"}))
 
-        with patch(
-            "ambient_runner.bridges.claude.mcp._read_google_credentials",
-            return_value={"token": "t", "refresh_token": "r"},
-        ):
-            is_auth, msg = check_mcp_authentication("google-workspace")
+        monkeypatch.setenv("USER_GOOGLE_EMAIL", "user@example.com")
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._WORKSPACE_CREDS_DIR", creds_dir
+        )
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._SECRET_CREDS_DIR", empty_dir
+        )
+
+        is_auth, msg = check_mcp_authentication("google-workspace")
         assert is_auth is False
         assert "USER_GOOGLE_EMAIL" in msg
 
-    def test_missing_tokens(self, monkeypatch):
-        monkeypatch.setenv("USER_GOOGLE_EMAIL", "real@user.com")
+    def test_missing_tokens(self, tmp_path, monkeypatch):
+        creds_dir = tmp_path / "workspace_creds"
+        creds_dir.mkdir(parents=True)
+        creds_file = creds_dir / "real@user.com.json"
+        creds_file.write_text(json.dumps({"token": "", "refresh_token": ""}))
 
-        with patch(
-            "ambient_runner.bridges.claude.mcp._read_google_credentials",
-            return_value={"token": "", "refresh_token": ""},
-        ):
-            is_auth, msg = check_mcp_authentication("google-workspace")
+        monkeypatch.setenv("USER_GOOGLE_EMAIL", "real@user.com")
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._WORKSPACE_CREDS_DIR", creds_dir
+        )
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._SECRET_CREDS_DIR", empty_dir
+        )
+
+        is_auth, msg = check_mcp_authentication("google-workspace")
         assert is_auth is False
         assert "incomplete" in msg.lower()
 
-    def test_expired_token_with_refresh(self, monkeypatch):
-        monkeypatch.setenv("USER_GOOGLE_EMAIL", "user@corp.com")
+    def test_expired_token_with_refresh(self, tmp_path, monkeypatch):
+        creds_dir = tmp_path / "workspace_creds"
+        creds_dir.mkdir(parents=True)
+        creds_file = creds_dir / "user@corp.com.json"
 
         past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-        with patch(
-            "ambient_runner.bridges.claude.mcp._read_google_credentials",
-            return_value={"token": "t", "refresh_token": "r", "expiry": past},
-        ):
-            is_auth, msg = check_mcp_authentication("google-workspace")
+        creds_file.write_text(
+            json.dumps({"token": "t", "refresh_token": "r", "expiry": past})
+        )
+
+        monkeypatch.setenv("USER_GOOGLE_EMAIL", "user@corp.com")
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._WORKSPACE_CREDS_DIR", creds_dir
+        )
+        monkeypatch.setattr(
+            "ambient_runner.bridges.claude.mcp._SECRET_CREDS_DIR", empty_dir
+        )
+
+        is_auth, msg = check_mcp_authentication("google-workspace")
         # Should be None (needs refresh) not False
         assert is_auth is None
         assert "refresh" in msg.lower()

--- a/components/runners/ambient-runner/tests/test_shared_session_credentials.py
+++ b/components/runners/ambient-runner/tests/test_shared_session_credentials.py
@@ -153,7 +153,7 @@ class TestClearRuntimeCredentials:
         fake_cred_file = tmp_path / "credentials.json"
         fake_cred_file.write_text('{"token": "test-access-token"}')
         monkeypatch.setattr(
-            "ambient_runner.platform.auth._GOOGLE_WORKSPACE_CREDS_FILE",
+            "ambient_runner.platform.auth._GOOGLE_WORKSPACE_LEGACY_CREDS_FILE",
             fake_cred_file,
         )
 
@@ -611,7 +611,7 @@ class TestPopulateCredentialsResponseFormats:
                     body = {
                         "accessToken": "ya29.access",
                         "refreshToken": "1//refresh",
-                        "email": "u@example.com",
+                        "email": "test-google@example.com",
                         "scopes": ["drive"],
                         "expiresAt": "2099-01-01T00:00:00Z",
                     }
@@ -635,7 +635,7 @@ class TestPopulateCredentialsResponseFormats:
 
         import tempfile
 
-        tmp_creds = Path(tempfile.mkdtemp()) / "credentials.json"
+        tmp_creds_dir = Path(tempfile.mkdtemp())
 
         try:
             with (
@@ -653,23 +653,29 @@ class TestPopulateCredentialsResponseFormats:
                     return_value="bot-tok",
                 ),
                 patch(
-                    "ambient_runner.platform.auth._GOOGLE_WORKSPACE_CREDS_FILE",
-                    tmp_creds,
+                    "ambient_runner.platform.auth._GOOGLE_WORKSPACE_CREDS_DIR",
+                    tmp_creds_dir,
+                ),
+                patch(
+                    "ambient_runner.platform.auth._GOOGLE_WORKSPACE_LEGACY_CREDS_FILE",
+                    tmp_creds_dir / "credentials.json",
                 ),
             ):
                 os.environ.pop("CREDENTIAL_IDS", None)
                 ctx = _make_context(session_id="s1")
                 await populate_runtime_credentials(ctx)
 
-                assert tmp_creds.exists()
-                written = json.loads(tmp_creds.read_text())
+                creds_file = tmp_creds_dir / "test-google@example.com.json"
+                assert creds_file.exists(), f"Expected {creds_file} to exist"
+                written = json.loads(creds_file.read_text())
                 assert written["token"] == "ya29.access"
                 assert written["refresh_token"] == "1//refresh"
+                assert written["expiry"] == "2099-01-01T00:00:00"
         finally:
             server.server_close()
             thread.join(timeout=2)
-            tmp_creds.unlink(missing_ok=True)
-            tmp_creds.parent.rmdir()
+            import shutil
+            shutil.rmtree(tmp_creds_dir, ignore_errors=True)
             clear_runtime_credentials()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Strip trailing `Z` from `expiresAt`** before writing to credential file — workspace-mcp's `datetime.fromisoformat()` fails on Python 3.10 with the `Z` suffix, causing it to treat the expiry as `None` and the token as invalid
- **Write credential file as `{email}.json`** instead of `credentials.json` — workspace-mcp expects this naming convention for proper user identification in single-user mode
- **Scan credentials directory for any `.json` file** in `check_mcp_authentication` instead of hardcoding `credentials.json`

Fixes the UAT Google OAuth failure where workspace-mcp rejected valid pre-fetched credentials and fell back to its own inaccessible OAuth flow (PKCE mismatch with backend callback).

## Root Cause

Two issues caused workspace-mcp to reject valid pre-fetched Google OAuth credentials:

1. **Expiry format**: Backend returns `expiresAt` in RFC3339 (`2026-05-11T19:58:05Z`), but workspace-mcp parses it via `datetime.fromisoformat()` which fails on Python 3.10 with the trailing `Z`. workspace-mcp then falls back to its own OAuth flow.

2. **Credential filename**: Runner wrote `credentials.json`, but workspace-mcp's `list_users()` expects `{email}.json`. In single-user mode it finds and loads any `.json` file, but the user identifier becomes `credentials` instead of the actual email.

When workspace-mcp falls back to its own OAuth flow, it generates PKCE `code_challenge` + hex `state`, but the backend's `/oauth2callback` doesn't have the matching `code_verifier`, causing Google to return `"Missing code verifier"`.

## Test plan

- [x] All 681 runner tests pass (0 failures)
- [x] `test_google_oauth_access_token_format` verifies email-based filename and Z-stripped expiry
- [x] `test_mcp_auth.py` Google workspace auth tests updated for directory scanning
- [ ] Deploy to UAT and verify Google Drive works in a new session

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Google Workspace MCP authentication to support multiple credential configurations and per-user OAuth token storage.
  * Added support for reading credentials from directory-based structures with fallback options.

* **Bug Fixes**
  * Improved credential file handling and token expiration management with better error logging.

* **Tests**
  * Refactored authentication tests to use real temporary credential directories for more accurate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->