### PR TITLE
fix(cli): improve contrast for dim phase rows in acpctl TUI

### DIFF
--- a/components/ambient-cli/cmd/acpctl/ambient/tui/views/sessions.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/tui/views/sessions.go
@@ -14,9 +14,9 @@ import (
 //
 //	pending              -> yellow (33)
 //	running / active     -> orange (214)
-//	succeeded / completed -> dim   (240)
+//	succeeded / completed -> light gray (245)
 //	failed               -> red    (31)
-//	cancelled / idle     -> dim    (240)
+//	cancelled / idle     -> light gray (245)
 func PhaseColor(phase string) lipgloss.Color {
 	switch strings.ToLower(phase) {
 	case "pending":
@@ -24,13 +24,13 @@ func PhaseColor(phase string) lipgloss.Color {
 	case "running", "active":
 		return lipgloss.Color("214") // orange
 	case "succeeded", "completed":
-		return lipgloss.Color("240") // dim
+		return lipgloss.Color("245") // light gray — readable on dark backgrounds
 	case "failed":
 		return lipgloss.Color("31") // red
 	case "cancelled", "idle":
-		return lipgloss.Color("240") // dim
+		return lipgloss.Color("245") // light gray — readable on dark backgrounds
 	default:
-		return lipgloss.Color("240") // dim
+		return lipgloss.Color("245") // light gray — readable on dark backgrounds
 	}
 }
 


### PR DESCRIPTION
## Summary
- `PhaseColor()` used color `240` (very dark gray) for idle/completed/cancelled/default phases, making entire table rows nearly invisible on dark terminal backgrounds
- Bumped to color `245` (~60% gray) which is readable while still looking subdued compared to active/running phases

## Test plan
- [ ] Run `acpctl` TUI and verify idle/completed agent and session rows are readable on dark backgrounds
- [ ] Verify active/running rows still stand out visually from idle rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated phase status colors in the terminal interface for improved visibility. Succeeded, completed, cancelled, idle, and default phase states now display with brighter coloring, enhancing readability and making status indicators more visually distinct during terminal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->