### PR TITLE
fix(frontend): widen mock return type for useProject in tests

### DIFF
--- a/components/frontend/src/components/__tests__/session-details-modal.test.tsx
+++ b/components/frontend/src/components/__tests__/session-details-modal.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { SessionDetailsModal } from '../session-details-modal';
 import type { AgenticSession } from '@/types/agentic-session';
 
-const mockUseProject = vi.fn(() => ({ data: undefined }));
+const mockUseProject = vi.fn(() => ({ data: undefined as { displayName: string; name: string } | undefined }));
 vi.mock('@/services/queries', () => ({
   useProject: () => mockUseProject(),
 }));

--- a/components/frontend/src/components/workspace-sections/__tests__/sessions-section.test.tsx
+++ b/components/frontend/src/components/workspace-sections/__tests__/sessions-section.test.tsx
@@ -8,7 +8,7 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-const mockUseProject = vi.fn(() => ({ data: undefined }));
+const mockUseProject = vi.fn(() => ({ data: undefined as { displayName: string; name: string } | undefined }));
 vi.mock('@/services/queries', () => ({
   useSessionsPaginated: () => ({ data: { items: [], totalCount: 0, hasMore: false }, isFetching: false, refetch: vi.fn() }),
   useStopSession: () => ({ mutate: vi.fn(), isPending: false }),


### PR DESCRIPTION
## Summary

- Fix TypeScript type error in two test files introduced by #1544
- The `mockUseProject` mock was initialized with `{ data: undefined }`, which locked the inferred type so that `.mockReturnValue()` calls with actual project data (`{ displayName, name }`) failed `tsc --noEmit`
- This has been breaking `Frontend Lint and Type Check` CI on every PR since #1544 merged (e.g. #1564)

## Changes

One-line fix in each file — widen the type via `as` cast on the initial `undefined`:

```ts
// Before
const mockUseProject = vi.fn(() => ({ data: undefined }));

// After
const mockUseProject = vi.fn(() => ({ data: undefined as { displayName: string; name: string } | undefined }));
```

**Files:**
- `components/frontend/src/components/__tests__/session-details-modal.test.tsx`
- `components/frontend/src/components/workspace-sections/__tests__/sessions-section.test.tsx`

## Test plan

- [x] `npx tsc --noEmit` passes locally (was failing before)
- [x] No logic changes — only type narrowing fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test mock type definitions to better validate component behavior under various data conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->