### PR TITLE
feat(sessions): improve display name reliability and add creator to RECENTS tooltip

### DIFF
--- a/components/ambient-mcp/server.go
+++ b/components/ambient-mcp/server.go
@@ -62,7 +62,7 @@ func registerSessionTools(s *server.MCPServer, c *client.Client, transport strin
 			mcp.WithString("agent_id", mcp.Description("Agent ID to execute the session.")),
 			mcp.WithString("model", mcp.Description("LLM model override (e.g. 'claude-sonnet-4-6').")),
 			mcp.WithString("parent_session_id", mcp.Description("Calling session ID for agent-to-agent delegation.")),
-			mcp.WithString("name", mcp.Description("Human-readable session name.")),
+			mcp.WithString("name", mcp.Description("Human-readable session name (max 50 chars). Provide a concise, descriptive title, e.g. 'Debug auth middleware'. Auto-generated from prompt if omitted.")),
 		),
 		tools.CreateSession(c),
 	)

--- a/components/backend/handlers/display_name.go
+++ b/components/backend/handlers/display_name.go
@@ -55,6 +55,29 @@ func sanitizeDisplayName(name string) string {
 	return name
 }
 
+// generateFallbackDisplayName creates a display name from the user's message
+// when AI generation is unavailable. Extracts the first sentence or truncates.
+func generateFallbackDisplayName(userMessage string) string {
+	msg := strings.TrimSpace(userMessage)
+	if msg == "" {
+		return ""
+	}
+
+	// Find first sentence boundary
+	for _, sep := range []string{". ", "! ", "? ", "\n"} {
+		if idx := strings.Index(msg, sep); idx > 0 && idx <= maxDisplayNameLength {
+			msg = msg[:idx]
+			break
+		}
+	}
+
+	runes := []rune(msg)
+	if len(runes) > maxDisplayNameLength {
+		msg = string(runes[:maxDisplayNameLength-3]) + "..."
+	}
+	return sanitizeDisplayName(msg)
+}
+
 // ValidateDisplayName validates a display name for the HTTP handler
 // Returns an error message if invalid, empty string if valid
 func ValidateDisplayName(name string) string {
@@ -99,26 +122,32 @@ func generateAndUpdateDisplayName(projectName, sessionName, userMessage string, 
 	defer cancel()
 
 	// Get Anthropic client (Vertex or API key)
+	var displayName string
 	client, isVertex, err := getAnthropicClient(ctx, projectName)
 	if err != nil {
-		return fmt.Errorf("failed to get Anthropic client: %w", err)
-	}
+		log.Printf("DisplayNameGen: Client init failed for %s/%s, using fallback: %v", projectName, sessionName, err)
+		displayName = generateFallbackDisplayName(userMessage)
+	} else {
+		// Build prompt with context
+		prompt := buildDisplayNamePrompt(userMessage, sessionCtx)
 
-	// Build prompt with context
-	prompt := buildDisplayNamePrompt(userMessage, sessionCtx)
-
-	// Call Claude Haiku with appropriate model name
-	modelName := haiku3Model
-	if isVertex {
-		modelName = haiku3ModelVertex
-	}
-	displayName, err := callClaudeForDisplayName(ctx, client, prompt, modelName)
-	if err != nil {
-		return fmt.Errorf("failed to call Claude: %w", err)
+		// Call Claude Haiku with appropriate model name
+		modelName := haiku3Model
+		if isVertex {
+			modelName = haiku3ModelVertex
+		}
+		displayName, err = callClaudeForDisplayName(ctx, client, prompt, modelName)
+		if err != nil {
+			log.Printf("DisplayNameGen: AI generation failed for %s/%s, using fallback: %v", projectName, sessionName, err)
+			displayName = generateFallbackDisplayName(userMessage)
+		}
 	}
 
 	// Sanitize and validate display name
 	displayName = sanitizeDisplayName(displayName)
+	if displayName == "" {
+		return fmt.Errorf("both AI and fallback generation produced empty display name")
+	}
 
 	// Truncate if too long (using runes for proper Unicode handling)
 	if utf8.RuneCountInString(displayName) > maxDisplayNameLength {

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/sessions-sidebar.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/components/sessions-sidebar.tsx
@@ -496,6 +496,10 @@ export function SessionsSidebar({
                                   <span>{formatDistanceToNow(new Date(activityTime), { addSuffix: true })}</span>
                                 </div>
                               )}
+                              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                <User className="h-3 w-3" />
+                                <span>{session.spec.userContext?.displayName || session.spec.userContext?.userId || '—'}</span>
+                              </div>
                               {session.spec.initialPrompt && (
                                 <div className="flex items-start gap-1.5 text-xs text-muted-foreground pt-1">
                                   <MessageSquare className="h-3 w-3 mt-0.5 shrink-0" />

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/backend_tools.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/backend_tools.py
@@ -189,7 +189,7 @@ def create_backend_mcp_tools(
                 },
                 "display_name": {
                     "type": "string",
-                    "description": "Human-readable display name",
+                    "description": "Human-readable display name for the session (max 50 chars). Provide a concise, descriptive title based on the task, e.g. 'Debug auth middleware', 'Add user dashboard'. Auto-generated from initial_prompt if omitted.",
                 },
                 "repos": {
                     "type": "string",


### PR DESCRIPTION
## Summary
- **Display name fallback**: When AI-powered display name generation fails (API key misconfigured, timeout, network issues), the system now falls back to extracting the first sentence from the initial prompt instead of silently leaving sessions showing as `session-UUID`
- **RECENTS tooltip creator**: The sidebar RECENTS panel tooltip now shows the session creator name (matching the existing /sessions page tooltip behavior)
- **MCP tool descriptions**: Improved `display_name`/`name` parameter descriptions to encourage agents to always provide meaningful session titles

## Changes
| File | Change |
|------|--------|
| `components/backend/handlers/display_name.go` | Add `generateFallbackDisplayName()`, use it when Claude API client init or API call fails |
| `components/frontend/src/.../sessions-sidebar.tsx` | Add User icon + creator name to RECENTS sidebar tooltip |
| `components/runners/ambient-runner/.../backend_tools.py` | Improve `display_name` MCP tool parameter description |
| `components/ambient-mcp/server.go` | Improve `name` MCP tool parameter description |

## Test plan
- [ ] Create a session with an initial prompt — verify display name appears
- [ ] Simulate API key failure — verify fallback name from prompt appears instead of `session-UUID`
- [ ] Hover over a session in the RECENTS sidebar — verify creator name shows
- [ ] Compare RECENTS tooltip with /sessions page tooltip — both show creator
- [ ] `cd components/backend && go build ./handlers/...` passes
- [ ] `cd components/frontend && tsc --noEmit` passes
- [ ] `cd components/ambient-mcp && go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)