### PR TITLE
Draft: Fix runAsUser error, migration ordering, and details during session errors

### DIFF
--- a/components/ambient-api-server/Dockerfile
+++ b/components/ambient-api-server/Dockerfile
@@ -23,10 +23,15 @@ ARG GIT_COMMIT=unknown
 RUN \
     microdnf install -y \
     util-linux \
+    shadow-utils \
     && \
-    microdnf clean all
+    microdnf clean all \
+    && \
+    useradd -u 1000 -M -s /sbin/nologin -r appuser
 
 COPY --from=builder /workspace/ambient-api-server /usr/local/bin/
+
+USER 1000
 
 EXPOSE 8000
 

--- a/components/ambient-api-server/plugins/roleBindings/migration.go
+++ b/components/ambient-api-server/plugins/roleBindings/migration.go
@@ -32,7 +32,7 @@ func migration() *gormigrate.Migration {
 
 func typedFKMigration() *gormigrate.Migration {
 	return &gormigrate.Migration{
-		ID: "202505130001",
+		ID: "202605150001",
 		Migrate: func(tx *gorm.DB) error {
 			// Drop the old unique index that depends on scope_id before altering columns
 			if err := tx.Exec(`DROP INDEX IF EXISTS idx_binding_lookup`).Error; err != nil {

--- a/components/backend/handlers/sessions.go
+++ b/components/backend/handlers/sessions.go
@@ -639,7 +639,13 @@ func ListSessions(c *gin.Context) {
 	list, err := k8sDyn.Resource(gvr).Namespace(project).List(ctx, listOpts)
 	if err != nil {
 		log.Printf("Failed to list agentic sessions in project %s: %v", project, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list agentic sessions"})
+		if errors.IsUnauthorized(err) {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Token expired or invalid"})
+		} else if errors.IsForbidden(err) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Unauthorized to access project"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list agentic sessions"})
+		}
 		return
 	}
 
@@ -650,7 +656,13 @@ func ListSessions(c *gin.Context) {
 		list, err = k8sDyn.Resource(gvr).Namespace(project).List(ctx, listOpts)
 		if err != nil {
 			log.Printf("Failed to list agentic sessions (continue) in project %s: %v", project, err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list agentic sessions"})
+			if errors.IsUnauthorized(err) {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "Token expired or invalid"})
+			} else if errors.IsForbidden(err) {
+				c.JSON(http.StatusForbidden, gin.H{"error": "Unauthorized to access project"})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list agentic sessions"})
+			}
 			return
 		}
 		allItems = append(allItems, list.Items...)

--- a/components/manifests/base/core/ambient-api-server-service.yml
+++ b/components/manifests/base/core/ambient-api-server-service.yml
@@ -34,6 +34,7 @@ spec:
       serviceAccountName: ambient-api-server
       securityContext:
         runAsNonRoot: true
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       initContainers:


### PR DESCRIPTION
## Summary

- **Fix `runAsNonRoot` compliance in ambient-api-server**: Added `shadow-utils` and a dedicated `appuser` (UID 1000) to the Dockerfile so the image satisfies `runAsNonRoot` without depending solely on the manifest override. Added `runAsUser: 1000` to the pod `securityContext` to make the UID explicit.
- **Fix migration ID ordering in `roleBindings`**: Corrected `typedFKMigration` ID from `202505130001` to `202605150001` so it sorts after the `202603100138` migration that creates the `role_bindings` table. The wrong ID caused fresh-cluster deployments to fail with "relation role_bindings does not exist".
- **Surface auth errors from K8s `ListSessions`**: Instead of masking all K8s errors as 500, the handler now returns 401 for expired/invalid tokens and 403 for insufficient permissions. Applies to both the initial list call and the paginated continue call.

## Test plan

- [ ] Deploy to a fresh cluster and verify `ambient-api-server` starts without migration errors
- [ ] Confirm `kubectl describe pod` shows the container running as UID 1000 with `runAsNonRoot: true`
- [ ] Simulate an expired token against `ListSessions` and verify the response is 401, not 500
- [ ] Simulate a token with no project access and verify the response is 403, not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)