### PR TITLE
fix(runner): restore acp backend MCP tools as fallback when sidecar is absent

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/mcp.py
@@ -62,6 +62,7 @@ def build_mcp_servers(
         load_rubric_content,
     )
     from ambient_runner.bridges.claude.corrections import create_correction_mcp_tool
+    from ambient_runner.bridges.claude.backend_tools import create_backend_mcp_tools
 
     mcp_servers = load_mcp_config(context, cwd_path) or {}
 
@@ -116,6 +117,20 @@ def build_mcp_servers(
         )
         mcp_servers["corrections"] = correction_server
         logger.info("Added corrections feedback MCP tool (log_correction)")
+
+    # Backend API tools (session management) — fallback when ambient MCP sidecar is absent
+    if not ambient_mcp_url:
+        backend_tools = create_backend_mcp_tools(sdk_tool_decorator=sdk_tool)
+        if backend_tools:
+            backend_server = create_sdk_mcp_server(
+                name="acp", version="1.0.0", tools=backend_tools
+            )
+            mcp_servers["acp"] = backend_server
+            logger.info(
+                "Added backend API MCP tools (%d): %s",
+                len(backend_tools),
+                ", ".join(t.name for t in backend_tools),
+            )
 
     # Credential-aware MCP servers (dynamically configured per bound credentials)
     credential_mcp_servers = build_credential_mcp_servers()

--- a/e2e/cypress/e2e/scheduled-sessions.cy.ts
+++ b/e2e/cypress/e2e/scheduled-sessions.cy.ts
@@ -411,8 +411,28 @@ describe('Scheduled Sessions', () => {
         expect(resp.status).to.be.oneOf([200, 201])
         const scheduleName = resp.body.name
 
+        // Stub the OOTB workflows API so the test doesn't depend on live GitHub access
+        cy.intercept('GET', `/api/workflows/ootb*`, {
+          statusCode: 200,
+          body: {
+            workflows: [
+              {
+                id: 'bugfix',
+                name: 'Fix a bug',
+                description: 'Systematic workflow for analyzing, fixing, and verifying software bugs.',
+                gitUrl: 'https://github.com/ambient-code/workflows.git',
+                branch: 'main',
+                path: 'workflows/bugfix',
+                enabled: true,
+              },
+            ],
+          },
+        }).as('ootbWorkflows')
+
         // Navigate to edit page
         cy.visit(`/projects/${workspaceSlug}/scheduled-sessions/${scheduleName}/edit`)
+
+        cy.wait('@ootbWorkflows')
 
         // The workflow select should show the OOTB workflow name, not "Custom workflow..."
         cy.get('[data-testid="workflow-select"]', { timeout: 10000 })


### PR DESCRIPTION
## Summary

- PR #1593 removed the `acp` backend MCP server (9 session management tools: `acp_list_sessions`, `acp_get_session`, `acp_create_session`, `acp_stop_session`, `acp_send_message`, `acp_get_session_status`, `acp_restart_session`, `acp_list_workflows`, `acp_get_api_reference`) when adding dynamic credential-aware MCP servers
- The ambient MCP sidecar only provides equivalents for 5 of those 9 tools — `stop_session`, `restart_session`, `list_workflows`, and `get_api_reference` have no sidecar equivalent
- Sessions without the sidecar (e.g. older CPs, missing `MCP_IMAGE` config, or `CP_TOKEN_URL`/`CPTokenPublicKey` not configured) lost **all** session management tooling
- This re-registers the `acp` backend tools as a fallback when `AMBIENT_MCP_URL` is not set. When the sidecar IS present, its tools take precedence

## Test plan

- [x] 549/549 runner tests pass (1 pre-existing mlflow skip)
- [x] 66/66 MCP + backend_tools tests pass
- [ ] Deploy to staging and verify `acp_*` tools appear when sidecar is absent
- [ ] Verify tools are NOT registered when sidecar IS present (no duplicates)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend API tools are now automatically available in more deployment configurations, expanding functionality and flexibility.
  * Improved logging now surfaces discovered backend tools and their availability.

* **Tests**
  * End-to-end scheduled-session test now uses a stubbed workflow API to stabilize editing assertions and ensure OOTB workflow display and custom-field hiding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->