### PR TITLE
fix(manifests): remove GITHUB_CALLBACK_URL from kustomize base

### DIFF
--- a/components/manifests/base/core/frontend-deployment.yaml
+++ b/components/manifests/base/core/frontend-deployment.yaml
@@ -44,12 +44,6 @@ spec:
               name: unleash-credentials
               key: client-api-token
               optional: true
-        - name: GITHUB_CALLBACK_URL
-          valueFrom:
-            configMapKeyRef:
-              name: frontend-config
-              key: github-callback-url
-              optional: true
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Summary

Follow-up to #1613.

The deploy workflow sets `GITHUB_CALLBACK_URL` imperatively via `oc set env` **after** `oc apply -k`, writing a plain `value=` into the live Deployment outside kustomize's last-applied annotation. PR #1613 added the var to the base manifest with `valueFrom`, which made things worse — on the next apply, the 3-way merge produced an object with both `value` and `valueFrom` set simultaneously, which Kubernetes rejects.

Fix: remove `GITHUB_CALLBACK_URL` from the kustomize manifests entirely. The `oc set env` step in the workflow owns this value exclusively, so no merge conflict can occur.

## Test plan
- [ ] `kustomize build components/manifests/overlays/production` produces no errors and `GITHUB_CALLBACK_URL` does not appear in output
- [ ] `deploy-to-openshift` job passes — `oc apply -k` succeeds, then `oc set env` sets the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)