### PR TITLE
fix(ambient-ui): fix Docker build for standalone output

### DIFF
--- a/components/ambient-ui/Dockerfile
+++ b/components/ambient-ui/Dockerfile
@@ -36,8 +36,11 @@ RUN npm run build
 
 # Prepare standalone output with OpenShift-compatible permissions in the builder
 # (the hardened runner image is distroless — no shell or chmod available)
+# outputFileTracingRoot is set to ../.. (monorepo root), so standalone output
+# nests files under components/ambient-ui/ within .next/standalone/
 RUN mkdir -p /app-output/public /app-output/.next/static && \
-    cp -r .next/standalone/. /app-output/ && \
+    cp -r .next/standalone/components/ambient-ui/. /app-output/ && \
+    cp -r .next/standalone/node_modules /app-output/node_modules 2>/dev/null || true && \
     cp -r .next/static/. /app-output/.next/static/ && \
     cp -r public/. /app-output/public/ && \
     chmod -R g=u /app-output && \


### PR DESCRIPTION
## Summary

- Build SDK `dist/` in Docker (ts-sdk `dist/` is gitignored, CI has no pre-built output)
- Copy standalone output from correct nested path (`outputFileTracingRoot` nests files under `components/ambient-ui/`)
- Use webpack for production build (Turbopack can't resolve `file:` linked dependencies)

Fixes the `Cannot find module '/app/server.js'` crash at container startup and the `Module not found: Can't resolve 'ambient-sdk'` build failure.

## Test plan

- [x] `npm run build` passes locally with webpack
- [x] `server.js` confirmed at `.next/standalone/components/ambient-ui/server.js`
- [x] 167 tests pass
- [ ] CI Docker build passes and pushes to quay.io
- [ ] Container starts without `MODULE_NOT_FOUND` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized application packaging in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->