### PR TITLE
fix(ambient-ui): fix standalone output path in Dockerfile

### DIFF
--- a/components/ambient-ui/Dockerfile
+++ b/components/ambient-ui/Dockerfile
@@ -36,11 +36,10 @@ RUN npm run build
 
 # Prepare standalone output with OpenShift-compatible permissions in the builder
 # (the hardened runner image is distroless — no shell or chmod available)
-# outputFileTracingRoot is set to ../.. (monorepo root), so standalone output
-# nests files under components/ambient-ui/ within .next/standalone/
+# outputFileTracingRoot is ../.. which resolves to / in Docker (WORKDIR /app),
+# so standalone nests files under app/ (i.e. .next/standalone/app/server.js).
 RUN mkdir -p /app-output/public /app-output/.next/static && \
-    cp -r .next/standalone/components/ambient-ui/. /app-output/ && \
-    cp -r .next/standalone/node_modules /app-output/node_modules 2>/dev/null || true && \
+    cp -r .next/standalone/app/. /app-output/ && \
     cp -r .next/static/. /app-output/.next/static/ && \
     cp -r public/. /app-output/public/ && \
     chmod -R g=u /app-output && \


### PR DESCRIPTION
## Summary

- Fix `Cannot find module '/app/server.js'` crash at container startup
- `outputFileTracingRoot` resolves `../..` to `/` in Docker (WORKDIR `/app`), so standalone output nests under `app/` (`.next/standalone/app/server.js`), not `components/ambient-ui/`
- Use correct hardcoded path: `cp -r .next/standalone/app/. /app-output/`

## Verification

Tested locally with podman:
- `server.js` present at `/app/server.js`
- Container starts, Next.js returns 200

## Test plan

- [ ] CI Docker build passes
- [ ] Container starts without `MODULE_NOT_FOUND`
- [ ] Ambient UI accessible via route

🤖 Generated with [Claude Code](https://claude.com/claude-code)