### PR TITLE
fix: correct COPY paths in credential sidecar Dockerfiles for CI build context

### DIFF
--- a/components/credential-sidecars/github/Dockerfile
+++ b/components/credential-sidecars/github/Dockerfile
@@ -4,8 +4,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 
 USER 0
 WORKDIR /build
-COPY components/credential-sidecars/entrypoint/ ./entrypoint/
-COPY components/ambient-mcp/ ./ambient-mcp/
+COPY credential-sidecars/entrypoint/ ./entrypoint/
+COPY ambient-mcp/ ./ambient-mcp/
 
 WORKDIR /build/entrypoint
 RUN go mod edit -replace github.com/ambient-code/platform/components/ambient-mcp=../ambient-mcp && \

--- a/components/credential-sidecars/google/Dockerfile
+++ b/components/credential-sidecars/google/Dockerfile
@@ -2,8 +2,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 
 USER 0
 WORKDIR /build
-COPY components/credential-sidecars/entrypoint/ ./entrypoint/
-COPY components/ambient-mcp/ ./ambient-mcp/
+COPY credential-sidecars/entrypoint/ ./entrypoint/
+COPY ambient-mcp/ ./ambient-mcp/
 
 WORKDIR /build/entrypoint
 RUN go mod edit -replace github.com/ambient-code/platform/components/ambient-mcp=../ambient-mcp && \

--- a/components/credential-sidecars/jira/Dockerfile
+++ b/components/credential-sidecars/jira/Dockerfile
@@ -2,8 +2,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 
 USER 0
 WORKDIR /build
-COPY components/credential-sidecars/entrypoint/ ./entrypoint/
-COPY components/ambient-mcp/ ./ambient-mcp/
+COPY credential-sidecars/entrypoint/ ./entrypoint/
+COPY ambient-mcp/ ./ambient-mcp/
 
 WORKDIR /build/entrypoint
 RUN go mod edit -replace github.com/ambient-code/platform/components/ambient-mcp=../ambient-mcp && \

--- a/components/credential-sidecars/k8s/Dockerfile
+++ b/components/credential-sidecars/k8s/Dockerfile
@@ -2,8 +2,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 
 USER 0
 WORKDIR /build
-COPY components/credential-sidecars/entrypoint/ ./entrypoint/
-COPY components/ambient-mcp/ ./ambient-mcp/
+COPY credential-sidecars/entrypoint/ ./entrypoint/
+COPY ambient-mcp/ ./ambient-mcp/
 
 WORKDIR /build/entrypoint
 RUN go mod edit -replace github.com/ambient-code/platform/components/ambient-mcp=../ambient-mcp && \


### PR DESCRIPTION
## Summary

- All 4 credential sidecar Dockerfiles (github, jira, k8s, google) used `COPY components/...` paths, but the CI workflow sets the Docker build context to `./components`, causing paths to resolve to the non-existent `./components/components/...`
- Removed the `components/` prefix so COPY paths are relative to the `./components` build context, matching the pattern used by `ambient-control-plane` and `ambient-ui` Dockerfiles
- This fixes the broken credential sidecar builds on main introduced in #1623

## Test plan
- [ ] CI credential sidecar builds pass (github, jira, k8s, google)
- [ ] Verify built images start correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for credential sidecar services to adjust source paths during the build process. No changes to runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->