### PR TITLE
fix: update mcp-proxy invocation for CLI breaking change in credential sidecars

### DIFF
--- a/components/credential-sidecars/github/Dockerfile
+++ b/components/credential-sidecars/github/Dockerfile
@@ -27,5 +27,5 @@ USER 1001
 
 EXPOSE 8091
 
-ENTRYPOINT ["credential-entrypoint", "mcp-proxy", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "--port", "8091", "--"]
+ENTRYPOINT ["credential-entrypoint", "mcp-proxy", "--pass-environment", "--port", "8091", "--"]
 CMD ["github-mcp-server", "stdio"]

--- a/components/credential-sidecars/google/Dockerfile
+++ b/components/credential-sidecars/google/Dockerfile
@@ -24,5 +24,5 @@ USER 1001
 
 EXPOSE 8094
 
-ENTRYPOINT ["credential-entrypoint", "mcp-proxy", "-e", "GOOGLE_ACCESS_TOKEN", "--port", "8094", "--"]
+ENTRYPOINT ["credential-entrypoint", "mcp-proxy", "--pass-environment", "--port", "8094", "--"]
 CMD ["python", "-m", "workspace_mcp", "--permissions", "gmail:send", "drive:full"]


### PR DESCRIPTION
## Summary

- `mcp-proxy`'s `-e` flag changed from `-e KEY` (single arg) to `-e KEY VALUE` (two args)
- The old `-e GITHUB_PERSONAL_ACCESS_TOKEN` consumed `--port` as the VALUE, making `8091` the positional `command_or_url` arg, causing `FileNotFoundError: '8091'` at runtime
- This crashed the credential-github sidecar container, making the pod 4/5 ready, which caused 502 Bad Gateway on session event streams
- Replace `-e <KEY>` with `--pass-environment` in github and google sidecars since `credential-entrypoint` already sets the env vars before exec

## Test plan
- [ ] CI credential sidecar builds pass
- [ ] credential-github container starts without FileNotFoundError
- [ ] credential-google container starts without FileNotFoundError
- [ ] Session with GitHub credential sidecar reaches 5/5 ready pods

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker runtime configurations for credential sidecars to use improved environment variable handling mechanisms in containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->