### PR TITLE
feat(api-server): credential token encryption at rest

### DIFF
--- a/components/ambient-api-server/cmd/ambient-api-server/main.go
+++ b/components/ambient-api-server/cmd/ambient-api-server/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/golang/glog"
 
 	localapi "github.com/ambient-code/platform/components/ambient-api-server/pkg/api"
+	localcmd "github.com/ambient-code/platform/components/ambient-api-server/pkg/cmd"
 	pkgcmd "github.com/openshift-online/rh-trex-ai/pkg/cmd"
 
 	_ "github.com/ambient-code/platform/components/ambient-api-server/cmd/ambient-api-server/environments"
@@ -34,6 +35,7 @@ func main() {
 	rootCmd.AddCommand(
 		pkgcmd.NewMigrateCommand("ambient-api-server"),
 		pkgcmd.NewServeCommand(localapi.GetOpenAPISpec),
+		localcmd.NewEncryptCredentialsCommand(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/components/ambient-api-server/pkg/cmd/encrypt_credentials.go
+++ b/components/ambient-api-server/pkg/cmd/encrypt_credentials.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/crypto"
+	"github.com/openshift-online/rh-trex-ai/pkg/config"
+	"github.com/openshift-online/rh-trex-ai/pkg/db/db_session"
+	"gorm.io/gorm"
+)
+
+type credentialRow struct {
+	ID    string  `gorm:"column:id"`
+	Token *string `gorm:"column:token"`
+}
+
+func (credentialRow) TableName() string { return "credentials" }
+
+func NewEncryptCredentialsCommand() *cobra.Command {
+	dbConfig := config.NewDatabaseConfig()
+	var decrypt bool
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "encrypt-credentials",
+		Short: "Encrypt or re-encrypt credential tokens at rest",
+		Long:  "Bulk encrypt plaintext tokens, re-encrypt tokens to the current key version, or decrypt all tokens to plaintext (--decrypt).",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := dbConfig.ReadFiles(); err != nil {
+				glog.Fatal(err)
+			}
+
+			keyringRaw := os.Getenv("CREDENTIAL_ENCRYPTION_KEYRING")
+			versionStr := os.Getenv("CREDENTIAL_ENCRYPTION_KEY_VERSION")
+
+			if keyringRaw == "" || versionStr == "" {
+				glog.Fatal("CREDENTIAL_ENCRYPTION_KEYRING and CREDENTIAL_ENCRYPTION_KEY_VERSION must be set")
+			}
+
+			activeVersion, err := strconv.Atoi(versionStr)
+			if err != nil {
+				glog.Fatalf("CREDENTIAL_ENCRYPTION_KEY_VERSION must be an integer: %v", err)
+			}
+
+			keyring, err := crypto.ParseKeyringEnv(keyringRaw, activeVersion)
+			if err != nil {
+				glog.Fatalf("Failed to parse keyring: %v", err)
+			}
+
+			connection := db_session.NewProdFactory(dbConfig)
+			db := connection.New(context.Background())
+
+			if decrypt {
+				runDecrypt(db, keyring, dryRun)
+			} else {
+				runEncrypt(db, keyring, activeVersion, dryRun)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&decrypt, "decrypt", false, "Decrypt all tokens to plaintext (rollback)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report what would be done without modifying data")
+
+	dbConfig.AddFlags(cmd.PersistentFlags())
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	return cmd
+}
+
+func runEncrypt(db *gorm.DB, keyring *crypto.Keyring, activeVersion int, dryRun bool) {
+	var rows []credentialRow
+	if err := db.Where("token IS NOT NULL AND token != ''").Find(&rows).Error; err != nil {
+		glog.Fatalf("Failed to query credentials: %v", err)
+	}
+
+	var plaintext, reencrypt, current, failed int
+	var failedIDs []string
+
+	for _, row := range rows {
+		if row.Token == nil || *row.Token == "" {
+			continue
+		}
+
+		token := *row.Token
+
+		if !crypto.IsEncrypted(token) {
+			plaintext++
+			if dryRun {
+				continue
+			}
+			encrypted, err := keyring.Encrypt(token, row.ID)
+			if err != nil {
+				failed++
+				failedIDs = append(failedIDs, row.ID)
+				fmt.Fprintf(os.Stderr, "ERROR: encrypt %s: %v\n", row.ID, err)
+				continue
+			}
+			if err := db.Model(&credentialRow{}).Where("id = ?", row.ID).Update("token", encrypted).Error; err != nil {
+				failed++
+				failedIDs = append(failedIDs, row.ID)
+				fmt.Fprintf(os.Stderr, "ERROR: update %s: %v\n", row.ID, err)
+				continue
+			}
+		} else {
+			v, _ := crypto.TokenVersion(token)
+			if v == activeVersion {
+				current++
+				continue
+			}
+			reencrypt++
+			if dryRun {
+				continue
+			}
+			decrypted, err := keyring.Decrypt(token, row.ID)
+			if err != nil {
+				failed++
+				failedIDs = append(failedIDs, row.ID)
+				fmt.Fprintf(os.Stderr, "ERROR: decrypt %s for re-encryption: %v\n", row.ID, err)
+				continue
+			}
+			encrypted, err := keyring.Encrypt(decrypted, row.ID)
+			if err != nil {
+				failed++
+				failedIDs = append(failedIDs, row.ID)
+				fmt.Fprintf(os.Stderr, "ERROR: re-encrypt %s: %v\n", row.ID, err)
+				continue
+			}
+			if err := db.Model(&credentialRow{}).Where("id = ?", row.ID).Update("token", encrypted).Error; err != nil {
+				failed++
+				failedIDs = append(failedIDs, row.ID)
+				fmt.Fprintf(os.Stderr, "ERROR: update %s: %v\n", row.ID, err)
+				continue
+			}
+		}
+	}
+
+	if dryRun {
+		fmt.Printf("Would encrypt: %d plaintext, Would re-encrypt: %d (→ v%d), Already current: %d\n", plaintext, reencrypt, activeVersion, current)
+		return
+	}
+
+	if plaintext+reencrypt == 0 && failed == 0 {
+		fmt.Println("0 credentials need encryption. All up to date.")
+		return
+	}
+
+	if plaintext > 0 {
+		fmt.Printf("%d credentials encrypted (plaintext → v%d)\n", plaintext-failed, activeVersion)
+	}
+	if reencrypt > 0 {
+		fmt.Printf("%d credentials re-encrypted to v%d\n", reencrypt, activeVersion)
+	}
+	if failed > 0 {
+		fmt.Fprintf(os.Stderr, "%d credentials failed: %v\n", failed, failedIDs)
+		os.Exit(1)
+	}
+}
+
+func runDecrypt(db *gorm.DB, keyring *crypto.Keyring, dryRun bool) {
+	var rows []credentialRow
+	if err := db.Where("token IS NOT NULL AND token != ''").Find(&rows).Error; err != nil {
+		glog.Fatalf("Failed to query credentials: %v", err)
+	}
+
+	var decrypted, skipped, failed int
+	var failedIDs []string
+
+	for _, row := range rows {
+		if row.Token == nil || *row.Token == "" {
+			continue
+		}
+
+		token := *row.Token
+		if !crypto.IsEncrypted(token) {
+			skipped++
+			continue
+		}
+
+		decrypted++
+		if dryRun {
+			continue
+		}
+
+		plaintext, err := keyring.Decrypt(token, row.ID)
+		if err != nil {
+			failed++
+			failedIDs = append(failedIDs, row.ID)
+			fmt.Fprintf(os.Stderr, "ERROR: decrypt %s: %v\n", row.ID, err)
+			continue
+		}
+		if err := db.Model(&credentialRow{}).Where("id = ?", row.ID).Update("token", plaintext).Error; err != nil {
+			failed++
+			failedIDs = append(failedIDs, row.ID)
+			fmt.Fprintf(os.Stderr, "ERROR: update %s: %v\n", row.ID, err)
+			continue
+		}
+	}
+
+	if dryRun {
+		fmt.Printf("Would decrypt: %d encrypted, Already plaintext: %d\n", decrypted, skipped)
+		return
+	}
+
+	if decrypted == 0 {
+		fmt.Println("0 credentials need decryption. All plaintext.")
+		return
+	}
+
+	fmt.Printf("%d credentials decrypted to plaintext\n", decrypted-failed)
+	if failed > 0 {
+		fmt.Fprintf(os.Stderr, "%d credentials failed: %v\n", failed, failedIDs)
+		os.Exit(1)
+	}
+}

--- a/components/ambient-api-server/pkg/crypto/encrypt.go
+++ b/components/ambient-api-server/pkg/crypto/encrypt.go
@@ -1,0 +1,161 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const (
+	nonceSize  = 12
+	minPayload = nonceSize + 16 // nonce + GCM tag minimum
+)
+
+type Keyring struct {
+	keys          map[int]cipher.AEAD
+	activeVersion int
+}
+
+func NewKeyring(keys map[string]string, activeVersion int) (*Keyring, error) {
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("keyring must contain at least one key")
+	}
+
+	aeadMap := make(map[int]cipher.AEAD, len(keys))
+	for vStr, encoded := range keys {
+		v, err := strconv.Atoi(vStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid key version %q: %w", vStr, err)
+		}
+		raw, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("key version %d: invalid base64: %w", v, err)
+		}
+		if len(raw) != 32 {
+			return nil, fmt.Errorf("key version %d: expected 32 bytes, got %d", v, len(raw))
+		}
+		block, err := aes.NewCipher(raw)
+		if err != nil {
+			return nil, fmt.Errorf("key version %d: %w", v, err)
+		}
+		aead, err := cipher.NewGCM(block)
+		if err != nil {
+			return nil, fmt.Errorf("key version %d: %w", v, err)
+		}
+		aeadMap[v] = aead
+	}
+
+	if _, ok := aeadMap[activeVersion]; !ok {
+		return nil, fmt.Errorf("active version %d not found in keyring", activeVersion)
+	}
+
+	return &Keyring{keys: aeadMap, activeVersion: activeVersion}, nil
+}
+
+func ParseKeyringEnv(raw string, activeVersion int) (*Keyring, error) {
+	var keys map[string]string
+	if err := json.Unmarshal([]byte(raw), &keys); err != nil {
+		return nil, fmt.Errorf("parse keyring JSON: %w", err)
+	}
+	return NewKeyring(keys, activeVersion)
+}
+
+func (kr *Keyring) ActiveVersion() int {
+	return kr.activeVersion
+}
+
+func (kr *Keyring) Versions() []int {
+	versions := make([]int, 0, len(kr.keys))
+	for v := range kr.keys {
+		versions = append(versions, v)
+	}
+	return versions
+}
+
+func (kr *Keyring) Encrypt(plaintext, credentialID string) (string, error) {
+	aead := kr.keys[kr.activeVersion]
+	nonce := make([]byte, nonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+
+	aad := []byte(credentialID)
+	ciphertext := aead.Seal(nonce, nonce, []byte(plaintext), aad)
+	encoded := base64.StdEncoding.EncodeToString(ciphertext)
+	return fmt.Sprintf("enc:v%d:%s", kr.activeVersion, encoded), nil
+}
+
+func (kr *Keyring) Decrypt(envelope, credentialID string) (string, error) {
+	version, payload, err := parseEnvelope(envelope)
+	if err != nil {
+		return "", err
+	}
+
+	aead, ok := kr.keys[version]
+	if !ok {
+		return "", fmt.Errorf("key version %d not found in keyring", version)
+	}
+
+	if len(payload) < minPayload {
+		return "", fmt.Errorf("ciphertext too short: %d bytes", len(payload))
+	}
+
+	nonce := payload[:nonceSize]
+	ciphertext := payload[nonceSize:]
+	aad := []byte(credentialID)
+
+	plaintext, err := aead.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return "", fmt.Errorf("decryption failed: %w", err)
+	}
+
+	return string(plaintext), nil
+}
+
+func parseEnvelope(s string) (int, []byte, error) {
+	if !strings.HasPrefix(s, "enc:v") {
+		return 0, nil, fmt.Errorf("not an encrypted envelope: missing enc:v prefix")
+	}
+
+	rest := s[len("enc:v"):]
+	colonIdx := strings.IndexByte(rest, ':')
+	if colonIdx < 1 {
+		return 0, nil, fmt.Errorf("invalid envelope: missing version delimiter")
+	}
+
+	version, err := strconv.Atoi(rest[:colonIdx])
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid envelope: non-integer version %q", rest[:colonIdx])
+	}
+
+	b64 := rest[colonIdx+1:]
+	payload, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid envelope: base64 decode failed: %w", err)
+	}
+
+	if len(payload) < minPayload {
+		return 0, nil, fmt.Errorf("invalid envelope: payload too short (%d bytes, minimum %d)", len(payload), minPayload)
+	}
+
+	return version, payload, nil
+}
+
+func IsEncrypted(s string) bool {
+	_, _, err := parseEnvelope(s)
+	return err == nil
+}
+
+func TokenVersion(s string) (int, bool) {
+	v, _, err := parseEnvelope(s)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/components/ambient-api-server/pkg/crypto/encrypt_test.go
+++ b/components/ambient-api-server/pkg/crypto/encrypt_test.go
@@ -1,0 +1,297 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func testKey() []byte {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	return key
+}
+
+func testKeyring(t *testing.T) *Keyring {
+	t.Helper()
+	key := base64.StdEncoding.EncodeToString(testKey())
+	kr, err := NewKeyring(map[string]string{"1": key}, 1)
+	if err != nil {
+		t.Fatalf("NewKeyring: %v", err)
+	}
+	return kr
+}
+
+func TestNewKeyring_Valid(t *testing.T) {
+	key := base64.StdEncoding.EncodeToString(testKey())
+	kr, err := NewKeyring(map[string]string{"1": key}, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kr.ActiveVersion() != 1 {
+		t.Fatalf("expected active version 1, got %d", kr.ActiveVersion())
+	}
+}
+
+func TestNewKeyring_InvalidKeyLength(t *testing.T) {
+	short := base64.StdEncoding.EncodeToString([]byte("tooshort"))
+	_, err := NewKeyring(map[string]string{"1": short}, 1)
+	if err == nil {
+		t.Fatal("expected error for short key")
+	}
+}
+
+func TestNewKeyring_InvalidBase64(t *testing.T) {
+	_, err := NewKeyring(map[string]string{"1": "not-valid-base64!!!"}, 1)
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func TestNewKeyring_MissingActiveVersion(t *testing.T) {
+	key := base64.StdEncoding.EncodeToString(testKey())
+	_, err := NewKeyring(map[string]string{"1": key}, 2)
+	if err == nil {
+		t.Fatal("expected error for missing active version")
+	}
+}
+
+func TestNewKeyring_EmptyKeys(t *testing.T) {
+	_, err := NewKeyring(map[string]string{}, 1)
+	if err == nil {
+		t.Fatal("expected error for empty keyring")
+	}
+}
+
+func TestParseKeyringEnv(t *testing.T) {
+	key := base64.StdEncoding.EncodeToString(testKey())
+	raw := `{"1":"` + key + `"}`
+	kr, err := ParseKeyringEnv(raw, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kr.ActiveVersion() != 1 {
+		t.Fatalf("expected active version 1, got %d", kr.ActiveVersion())
+	}
+}
+
+func TestParseKeyringEnv_InvalidJSON(t *testing.T) {
+	_, err := ParseKeyringEnv("{invalid", 1)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestEncryptDecrypt_Roundtrip(t *testing.T) {
+	kr := testKeyring(t)
+	plaintext := "ghp_abc123_my_secret_token"
+	credentialID := "cred-001"
+
+	ciphertext, err := kr.Encrypt(plaintext, credentialID)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if !strings.HasPrefix(ciphertext, "enc:v1:") {
+		t.Fatalf("expected enc:v1: prefix, got %q", ciphertext[:20])
+	}
+
+	decrypted, err := kr.Decrypt(ciphertext, credentialID)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+
+	if decrypted != plaintext {
+		t.Fatalf("roundtrip failed: got %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestEncrypt_DifferentNonce(t *testing.T) {
+	kr := testKeyring(t)
+	plaintext := "same_value"
+	credentialID := "cred-001"
+
+	ct1, _ := kr.Encrypt(plaintext, credentialID)
+	ct2, _ := kr.Encrypt(plaintext, credentialID)
+
+	if ct1 == ct2 {
+		t.Fatal("two encryptions of the same plaintext must produce different ciphertexts (random nonce)")
+	}
+}
+
+func TestDecrypt_WrongCredentialID(t *testing.T) {
+	kr := testKeyring(t)
+	ciphertext, _ := kr.Encrypt("secret", "cred-001")
+
+	_, err := kr.Decrypt(ciphertext, "cred-002")
+	if err == nil {
+		t.Fatal("expected error when decrypting with wrong credential ID (AAD mismatch)")
+	}
+}
+
+func TestDecrypt_TamperedCiphertext(t *testing.T) {
+	kr := testKeyring(t)
+	ciphertext, _ := kr.Encrypt("secret", "cred-001")
+
+	parts := strings.SplitN(ciphertext, ":", 3)
+	decoded, _ := base64.StdEncoding.DecodeString(parts[2])
+	decoded[len(decoded)-1] ^= 0xFF
+	parts[2] = base64.StdEncoding.EncodeToString(decoded)
+	tampered := strings.Join(parts, ":")
+
+	_, err := kr.Decrypt(tampered, "cred-001")
+	if err == nil {
+		t.Fatal("expected error for tampered ciphertext")
+	}
+}
+
+func TestDecrypt_InvalidEnvelopePrefix(t *testing.T) {
+	kr := testKeyring(t)
+	_, err := kr.Decrypt("notenc:v1:data", "cred-001")
+	if err == nil {
+		t.Fatal("expected error for non-enc prefix")
+	}
+}
+
+func TestDecrypt_InvalidVersionFormat(t *testing.T) {
+	kr := testKeyring(t)
+	_, err := kr.Decrypt("enc:vX:data", "cred-001")
+	if err == nil {
+		t.Fatal("expected error for non-integer version")
+	}
+}
+
+func TestDecrypt_MissingKeyVersion(t *testing.T) {
+	kr := testKeyring(t)
+	key2 := make([]byte, 32)
+	for i := range key2 {
+		key2[i] = byte(i + 100)
+	}
+
+	kr2, _ := NewKeyring(map[string]string{
+		"2": base64.StdEncoding.EncodeToString(key2),
+	}, 2)
+
+	ciphertext, _ := kr2.Encrypt("secret", "cred-001")
+
+	_, err := kr.Decrypt(ciphertext, "cred-001")
+	if err == nil {
+		t.Fatal("expected error for missing key version")
+	}
+}
+
+func TestDecrypt_InvalidBase64Payload(t *testing.T) {
+	kr := testKeyring(t)
+	_, err := kr.Decrypt("enc:v1:not-valid-base64!!!", "cred-001")
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func TestDecrypt_PayloadTooShort(t *testing.T) {
+	kr := testKeyring(t)
+	short := base64.StdEncoding.EncodeToString([]byte("tiny"))
+	_, err := kr.Decrypt("enc:v1:"+short, "cred-001")
+	if err == nil {
+		t.Fatal("expected error for payload shorter than nonce + tag")
+	}
+}
+
+func TestIsEncrypted(t *testing.T) {
+	kr := testKeyring(t)
+	ct, _ := kr.Encrypt("secret", "cred-001")
+
+	if !IsEncrypted(ct) {
+		t.Fatal("expected IsEncrypted=true for valid ciphertext")
+	}
+	if IsEncrypted("ghp_abc123") {
+		t.Fatal("expected IsEncrypted=false for plaintext")
+	}
+	if IsEncrypted("") {
+		t.Fatal("expected IsEncrypted=false for empty string")
+	}
+	if IsEncrypted("enc:vX:bad") {
+		t.Fatal("expected IsEncrypted=false for non-integer version")
+	}
+	if IsEncrypted("enc:v1") {
+		t.Fatal("expected IsEncrypted=false for missing payload")
+	}
+}
+
+func TestMultiVersionKeyring(t *testing.T) {
+	key1 := testKey()
+	key2 := make([]byte, 32)
+	for i := range key2 {
+		key2[i] = byte(i + 50)
+	}
+
+	kr, err := NewKeyring(map[string]string{
+		"1": base64.StdEncoding.EncodeToString(key1),
+		"2": base64.StdEncoding.EncodeToString(key2),
+	}, 2)
+	if err != nil {
+		t.Fatalf("NewKeyring: %v", err)
+	}
+
+	ct, err := kr.Encrypt("secret", "cred-001")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if !strings.HasPrefix(ct, "enc:v2:") {
+		t.Fatalf("expected v2 prefix, got %q", ct[:10])
+	}
+
+	// Can decrypt v2
+	decrypted, err := kr.Decrypt(ct, "cred-001")
+	if err != nil {
+		t.Fatalf("Decrypt v2: %v", err)
+	}
+	if decrypted != "secret" {
+		t.Fatalf("v2 roundtrip failed")
+	}
+
+	// Create a v1 ciphertext using a v1-only keyring and verify the multi-keyring can decrypt it
+	kr1, _ := NewKeyring(map[string]string{"1": base64.StdEncoding.EncodeToString(key1)}, 1)
+	ctV1, _ := kr1.Encrypt("old_secret", "cred-002")
+
+	decryptedV1, err := kr.Decrypt(ctV1, "cred-002")
+	if err != nil {
+		t.Fatalf("Decrypt v1 with multi-keyring: %v", err)
+	}
+	if decryptedV1 != "old_secret" {
+		t.Fatalf("v1 decrypt failed")
+	}
+}
+
+func TestEncrypt_EmptyPlaintext(t *testing.T) {
+	kr := testKeyring(t)
+	ct, err := kr.Encrypt("", "cred-001")
+	if err != nil {
+		t.Fatalf("Encrypt empty: %v", err)
+	}
+	dec, err := kr.Decrypt(ct, "cred-001")
+	if err != nil {
+		t.Fatalf("Decrypt empty: %v", err)
+	}
+	if dec != "" {
+		t.Fatalf("expected empty string, got %q", dec)
+	}
+}
+
+func TestEncrypt_LargePayload(t *testing.T) {
+	kr := testKeyring(t)
+	large := strings.Repeat("a]kubeconfig-content-here[", 1000)
+	ct, err := kr.Encrypt(large, "cred-001")
+	if err != nil {
+		t.Fatalf("Encrypt large: %v", err)
+	}
+	dec, err := kr.Decrypt(ct, "cred-001")
+	if err != nil {
+		t.Fatalf("Decrypt large: %v", err)
+	}
+	if dec != large {
+		t.Fatal("large payload roundtrip failed")
+	}
+}

--- a/components/ambient-api-server/plugins/credentials/encryption.go
+++ b/components/ambient-api-server/plugins/credentials/encryption.go
@@ -1,0 +1,47 @@
+package credentials
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/crypto"
+)
+
+const (
+	envKeyring        = "CREDENTIAL_ENCRYPTION_KEYRING"
+	envKeyVersion     = "CREDENTIAL_ENCRYPTION_KEY_VERSION"
+	envAllowPlaintext = "CREDENTIAL_ENCRYPTION_ALLOW_PLAINTEXT"
+)
+
+func LoadKeyring() *crypto.Keyring {
+	raw := os.Getenv(envKeyring)
+	if raw == "" {
+		return nil
+	}
+
+	versionStr := os.Getenv(envKeyVersion)
+	if versionStr == "" {
+		fmt.Fprintf(os.Stderr, "FATAL: %s is set but %s is missing\n", envKeyring, envKeyVersion)
+		os.Exit(1)
+	}
+
+	version, err := strconv.Atoi(versionStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: %s must be an integer, got %q\n", envKeyVersion, versionStr)
+		os.Exit(1)
+	}
+
+	kr, err := crypto.ParseKeyringEnv(raw, version)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: failed to parse %s: %v\n", envKeyring, err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "INFO: credential encryption enabled, using key v%d, keyring contains versions: %v\n", version, kr.Versions())
+	return kr
+}
+
+func IsPlaintextAllowed() bool {
+	return os.Getenv(envAllowPlaintext) == "true"
+}

--- a/components/ambient-api-server/plugins/credentials/encryption.go
+++ b/components/ambient-api-server/plugins/credentials/encryption.go
@@ -1,11 +1,13 @@
 package credentials
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/ambient-code/platform/components/ambient-api-server/pkg/crypto"
+	"gorm.io/gorm"
 )
 
 const (
@@ -17,6 +19,11 @@ const (
 func LoadKeyring() *crypto.Keyring {
 	raw := os.Getenv(envKeyring)
 	if raw == "" {
+		if !IsPlaintextAllowed() {
+			fmt.Fprintf(os.Stderr, "FATAL: credential encryption disabled — set %s or set %s=true to override\n", envKeyring, envAllowPlaintext)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "WARNING: credential encryption disabled — running in plaintext mode\n")
 		return nil
 	}
 
@@ -43,5 +50,45 @@ func LoadKeyring() *crypto.Keyring {
 }
 
 func IsPlaintextAllowed() bool {
-	return os.Getenv(envAllowPlaintext) == "true"
+	if os.Getenv(envAllowPlaintext) == "true" {
+		return true
+	}
+	env := os.Getenv("AMBIENT_ENV")
+	return env == "integration_testing" || env == "development"
+}
+
+func ValidateEncryptionStartup(db *gorm.DB, keyring *crypto.Keyring) {
+	if keyring != nil {
+		return
+	}
+
+	var count int64
+	if err := db.Table("credentials").Where("token LIKE 'enc:v%'").Count(&count).Error; err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: could not check for encrypted tokens: %v\n", err)
+		return
+	}
+
+	if count > 0 {
+		fmt.Fprintf(os.Stderr, "FATAL: %d encrypted credential tokens found but no keyring configured — set %s\n", count, envKeyring)
+		os.Exit(1)
+	}
+}
+
+func ValidateEncryptionStartupFromDAO(ctx context.Context, dao CredentialDao, keyring *crypto.Keyring) {
+	if keyring != nil {
+		return
+	}
+
+	all, err := dao.All(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: could not check for encrypted tokens: %v\n", err)
+		return
+	}
+
+	for _, c := range all {
+		if c.Token != nil && crypto.IsEncrypted(*c.Token) {
+			fmt.Fprintf(os.Stderr, "FATAL: encrypted credential tokens found but no keyring configured — set %s\n", envKeyring)
+			os.Exit(1)
+		}
+	}
 }

--- a/components/ambient-api-server/plugins/credentials/encryption_integration_test.go
+++ b/components/ambient-api-server/plugins/credentials/encryption_integration_test.go
@@ -1,0 +1,216 @@
+package credentials_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"gopkg.in/resty.v1"
+
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/crypto"
+	"github.com/ambient-code/platform/components/ambient-api-server/plugins/credentials"
+	"github.com/ambient-code/platform/components/ambient-api-server/test"
+	"github.com/openshift-online/rh-trex-ai/pkg/environments"
+)
+
+func testKeyring(t *testing.T) *crypto.Keyring {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 42)
+	}
+	kr, err := crypto.NewKeyring(map[string]string{
+		"1": base64.StdEncoding.EncodeToString(key),
+	}, 1)
+	if err != nil {
+		t.Fatalf("NewKeyring: %v", err)
+	}
+	return kr
+}
+
+func newEncryptedCredential(t *testing.T, name string, token string) *credentials.Credential {
+	t.Helper()
+	kr := testKeyring(t)
+	svc := credentials.NewCredentialService(
+		nil,
+		credentials.NewCredentialDao(&environments.Environment().Database.SessionFactory),
+		nil,
+		kr,
+	)
+
+	// Advisory locks need the lock factory; use a simpler approach via DAO directly
+	// since we just need to test encrypt/decrypt roundtrip through the service
+	credential := &credentials.Credential{
+		Name:     name,
+		Provider: "github",
+		Token:    &token,
+	}
+
+	created, err := svc.Create(context.Background(), credential)
+	if err != nil {
+		t.Fatalf("Create encrypted credential: %v", err)
+	}
+	return created
+}
+
+func TestEncryptedCredentialRoundtrip(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+	_ = h
+
+	plaintext := "ghp_superSecretToken123"
+	created := newEncryptedCredential(t, h.NewID(), plaintext)
+
+	// Read raw DB value to verify it's ciphertext
+	dao := credentials.NewCredentialDao(&environments.Environment().Database.SessionFactory)
+	raw, err := dao.Get(context.Background(), created.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(raw.Token).NotTo(BeNil())
+	Expect(*raw.Token).To(HavePrefix("enc:v1:"), "DB should contain encrypted token")
+	Expect(*raw.Token).NotTo(Equal(plaintext), "DB must not contain plaintext")
+
+	// Read through service (which decrypts)
+	kr := testKeyring(t)
+	svc := credentials.NewCredentialService(
+		nil,
+		dao,
+		nil,
+		kr,
+	)
+	decrypted, svcErr := svc.Get(context.Background(), created.ID)
+	Expect(svcErr).NotTo(HaveOccurred())
+	Expect(*decrypted.Token).To(Equal(plaintext), "Service.Get must return decrypted plaintext")
+}
+
+func TestEncryptedCredentialViaAPI(t *testing.T) {
+	h, client := test.RegisterIntegration(t)
+
+	account := h.NewRandAccount()
+	ctx := h.NewAuthenticatedContext(account)
+
+	credentialInput := openapi.Credential{
+		ProjectId: openapi.PtrString(testProjectID),
+		Name:      h.NewID(),
+		Provider:  "github",
+		Token:     openapi.PtrString("ghp_apiTestToken456"),
+	}
+
+	credentialOutput, resp, err := client.DefaultAPI.ApiAmbientV1ProjectsIdCredentialsPost(ctx, testProjectID).Credential(credentialInput).Execute()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+	Expect(credentialOutput.Token).To(BeNil(), "POST response must never return the token value")
+
+	// Fetch token via API
+	jwtToken := ctx.Value(openapi.ContextAccessToken)
+	restyResp, restyErr := resty.R().
+		SetHeader("Authorization", fmt.Sprintf("Bearer %s", jwtToken)).
+		Get(h.RestURL(fmt.Sprintf("/credentials/%s/token", *credentialOutput.Id)))
+	Expect(restyErr).NotTo(HaveOccurred())
+	Expect(restyResp.StatusCode()).To(Equal(http.StatusOK))
+
+	// API returns plaintext (encryption is transparent)
+	body := restyResp.String()
+	Expect(body).To(ContainSubstring(`"token"`))
+	Expect(body).NotTo(ContainSubstring("enc:v1:"), "API must not return ciphertext")
+}
+
+func TestPlaintextTokenPassthrough(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+	_ = h
+
+	// Create a credential WITHOUT encryption (nil keyring = plaintext mode)
+	svc := credentials.NewCredentialService(
+		nil,
+		credentials.NewCredentialDao(&environments.Environment().Database.SessionFactory),
+		nil,
+		nil,
+	)
+
+	plaintext := "ghp_plaintext_no_encryption"
+	credential := &credentials.Credential{
+		Name:     h.NewID(),
+		Provider: "github",
+		Token:    &plaintext,
+	}
+
+	created, err := svc.Create(context.Background(), credential)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Read through a service WITH encryption enabled — should return plaintext as-is
+	kr := testKeyring(t)
+	encSvc := credentials.NewCredentialService(
+		nil,
+		credentials.NewCredentialDao(&environments.Environment().Database.SessionFactory),
+		nil,
+		kr,
+	)
+
+	got, svcErr := encSvc.Get(context.Background(), created.ID)
+	Expect(svcErr).NotTo(HaveOccurred())
+	Expect(*got.Token).To(Equal(plaintext), "plaintext tokens must pass through without decryption")
+}
+
+func TestTokenVersionDetection(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+	_ = h
+
+	created := newEncryptedCredential(t, h.NewID(), "secret123")
+
+	dao := credentials.NewCredentialDao(&environments.Environment().Database.SessionFactory)
+	raw, err := dao.Get(context.Background(), created.ID)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(crypto.IsEncrypted(*raw.Token)).To(BeTrue())
+	v, ok := crypto.TokenVersion(*raw.Token)
+	Expect(ok).To(BeTrue())
+	Expect(v).To(Equal(1))
+}
+
+func TestAADPreventsRowSwap(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+	_ = h
+
+	cred1 := newEncryptedCredential(t, h.NewID(), "secret_A")
+	cred2 := newEncryptedCredential(t, h.NewID(), "secret_B")
+
+	dao := credentials.NewCredentialDao(&environments.Environment().Database.SessionFactory)
+	raw1, _ := dao.Get(context.Background(), cred1.ID)
+	raw2, _ := dao.Get(context.Background(), cred2.ID)
+
+	// Swap ciphertexts
+	kr := testKeyring(t)
+	_, err1 := kr.Decrypt(*raw1.Token, cred2.ID)
+	Expect(err1).To(HaveOccurred(), "decrypting cred1's token with cred2's ID must fail (AAD mismatch)")
+
+	_, err2 := kr.Decrypt(*raw2.Token, cred1.ID)
+	Expect(err2).To(HaveOccurred(), "decrypting cred2's token with cred1's ID must fail (AAD mismatch)")
+
+	// But correct IDs work
+	dec1, err := kr.Decrypt(*raw1.Token, cred1.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(dec1).To(Equal("secret_A"))
+
+	dec2, err := kr.Decrypt(*raw2.Token, cred2.ID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(dec2).To(Equal("secret_B"))
+}
+
+func TestEncryptedLargeKubeconfig(t *testing.T) {
+	h, _ := test.RegisterIntegration(t)
+	_ = h
+
+	kubeconfig := strings.Repeat("apiVersion: v1\nkind: Config\nclusters:\n", 100)
+	created := newEncryptedCredential(t, h.NewID(), kubeconfig)
+
+	kr := testKeyring(t)
+	dao := credentials.NewCredentialDao(&environments.Environment().Database.SessionFactory)
+
+	svc := credentials.NewCredentialService(nil, dao, nil, kr)
+	got, svcErr := svc.Get(context.Background(), created.ID)
+	Expect(svcErr).NotTo(HaveOccurred())
+	Expect(*got.Token).To(Equal(kubeconfig))
+}

--- a/components/ambient-api-server/plugins/credentials/model.go
+++ b/components/ambient-api-server/plugins/credentials/model.go
@@ -29,7 +29,9 @@ func (l CredentialList) Index() CredentialIndex {
 }
 
 func (d *Credential) BeforeCreate(tx *gorm.DB) error {
-	d.ID = api.NewID()
+	if d.ID == "" {
+		d.ID = api.NewID()
+	}
 	return nil
 }
 

--- a/components/ambient-api-server/plugins/credentials/plugin.go
+++ b/components/ambient-api-server/plugins/credentials/plugin.go
@@ -25,6 +25,7 @@ func NewServiceLocator(env *environments.Env) ServiceLocator {
 			db.NewAdvisoryLockFactory(env.Database.SessionFactory),
 			NewCredentialDao(&env.Database.SessionFactory),
 			events.Service(&env.Services),
+			LoadKeyring(),
 		)
 	}
 }

--- a/components/ambient-api-server/plugins/credentials/service.go
+++ b/components/ambient-api-server/plugins/credentials/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/crypto"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/db"
 	"github.com/openshift-online/rh-trex-ai/pkg/errors"
@@ -31,11 +32,12 @@ type CredentialService interface {
 	OnDelete(ctx context.Context, id string) error
 }
 
-func NewCredentialService(lockFactory db.LockFactory, credentialDao CredentialDao, events services.EventService) CredentialService {
+func NewCredentialService(lockFactory db.LockFactory, credentialDao CredentialDao, events services.EventService, keyring *crypto.Keyring) CredentialService {
 	return &sqlCredentialService{
 		lockFactory:   lockFactory,
 		credentialDao: credentialDao,
 		events:        events,
+		keyring:       keyring,
 	}
 }
 
@@ -45,6 +47,43 @@ type sqlCredentialService struct {
 	lockFactory   db.LockFactory
 	credentialDao CredentialDao
 	events        services.EventService
+	keyring       *crypto.Keyring
+}
+
+func (s *sqlCredentialService) encryptToken(credential *Credential) *errors.ServiceError {
+	if s.keyring == nil || credential.Token == nil || *credential.Token == "" {
+		return nil
+	}
+	ciphertext, err := s.keyring.Encrypt(*credential.Token, credential.ID)
+	if err != nil {
+		return errors.GeneralError("encrypt credential token: %v", err)
+	}
+	credential.Token = &ciphertext
+	return nil
+}
+
+func (s *sqlCredentialService) decryptToken(credential *Credential) *errors.ServiceError {
+	if s.keyring == nil || credential.Token == nil || *credential.Token == "" {
+		return nil
+	}
+	if !crypto.IsEncrypted(*credential.Token) {
+		return nil
+	}
+	plaintext, err := s.keyring.Decrypt(*credential.Token, credential.ID)
+	if err != nil {
+		return errors.GeneralError("decrypt credential token: %v", err)
+	}
+	credential.Token = &plaintext
+	return nil
+}
+
+func (s *sqlCredentialService) decryptList(credentials CredentialList) *errors.ServiceError {
+	for _, c := range credentials {
+		if err := s.decryptToken(c); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *sqlCredentialService) OnUpsert(ctx context.Context, id string) error {
@@ -71,10 +110,16 @@ func (s *sqlCredentialService) Get(ctx context.Context, id string) (*Credential,
 	if err != nil {
 		return nil, services.HandleGetError("Credential", "id", id, err)
 	}
+	if svcErr := s.decryptToken(credential); svcErr != nil {
+		return nil, svcErr
+	}
 	return credential, nil
 }
 
 func (s *sqlCredentialService) Create(ctx context.Context, credential *Credential) (*Credential, *errors.ServiceError) {
+	if svcErr := s.encryptToken(credential); svcErr != nil {
+		return nil, svcErr
+	}
 	credential, err := s.credentialDao.Create(ctx, credential)
 	if err != nil {
 		return nil, services.HandleCreateError("Credential", err)
@@ -112,6 +157,9 @@ func (s *sqlCredentialService) Replace(ctx context.Context, credential *Credenti
 		}
 	}
 
+	if svcErr := s.encryptToken(credential); svcErr != nil {
+		return nil, svcErr
+	}
 	credential, err := s.credentialDao.Replace(ctx, credential)
 	if err != nil {
 		return nil, services.HandleUpdateError("Credential", err)
@@ -150,6 +198,9 @@ func (s *sqlCredentialService) FindByIDs(ctx context.Context, ids []string) (Cre
 	if err != nil {
 		return nil, errors.GeneralError("Unable to get all credentials: %s", err)
 	}
+	if svcErr := s.decryptList(credentials); svcErr != nil {
+		return nil, svcErr
+	}
 	return credentials, nil
 }
 
@@ -157,6 +208,9 @@ func (s *sqlCredentialService) All(ctx context.Context) (CredentialList, *errors
 	credentials, err := s.credentialDao.All(ctx)
 	if err != nil {
 		return nil, errors.GeneralError("Unable to get all credentials: %s", err)
+	}
+	if svcErr := s.decryptList(credentials); svcErr != nil {
+		return nil, svcErr
 	}
 	return credentials, nil
 }

--- a/components/ambient-api-server/plugins/credentials/service.go
+++ b/components/ambient-api-server/plugins/credentials/service.go
@@ -117,6 +117,9 @@ func (s *sqlCredentialService) Get(ctx context.Context, id string) (*Credential,
 }
 
 func (s *sqlCredentialService) Create(ctx context.Context, credential *Credential) (*Credential, *errors.ServiceError) {
+	if credential.ID == "" {
+		credential.ID = api.NewID()
+	}
 	if svcErr := s.encryptToken(credential); svcErr != nil {
 		return nil, svcErr
 	}
@@ -125,13 +128,15 @@ func (s *sqlCredentialService) Create(ctx context.Context, credential *Credentia
 		return nil, services.HandleCreateError("Credential", err)
 	}
 
-	_, evErr := s.events.Create(ctx, &api.Event{
-		Source:    "Credentials",
-		SourceID:  credential.ID,
-		EventType: api.CreateEventType,
-	})
-	if evErr != nil {
-		return nil, services.HandleCreateError("Credential", evErr)
+	if s.events != nil {
+		_, evErr := s.events.Create(ctx, &api.Event{
+			Source:    "Credentials",
+			SourceID:  credential.ID,
+			EventType: api.CreateEventType,
+		})
+		if evErr != nil {
+			return nil, services.HandleCreateError("Credential", evErr)
+		}
 	}
 
 	return credential, nil


### PR DESCRIPTION
## Summary
Implements `specs/security/credential-encryption.spec.md` — AES-256-GCM encryption for credential tokens stored in PostgreSQL.

- **Encryption package** (`pkg/crypto/`): keyring with versioned keys, `enc:v{N}:{base64(nonce||ciphertext||tag)}` envelope format, credential ID as AAD to prevent ciphertext row-swapping, strict envelope validation
- **Service layer integration**: encrypt on Create/Replace, decrypt on Get/All/FindByIDs — handlers and presenters unchanged, API contract unchanged
- **CLI subcommand** (`encrypt-credentials`): bulk encrypt plaintext, re-encrypt to new key version, `--decrypt` rollback, `--dry-run` preview, idempotent, reports failed IDs for retry
- **Startup validation**: fail-closed without `CREDENTIAL_ENCRYPTION_KEYRING` unless `CREDENTIAL_ENCRYPTION_ALLOW_PLAINTEXT=true`; auto-allows plaintext in dev/test environments

## Verification
- 20 unit tests (crypto package)
- 14 integration tests (6 new encryption + 8 existing), all pass
- Kind cluster end-to-end: created credential → DB contains `enc:v1:...` ciphertext → `GET /token` returns original plaintext

## Environment variables
| Variable | Required | Description |
|----------|----------|-------------|
| `CREDENTIAL_ENCRYPTION_KEYRING` | Production | JSON `{"1":"base64key"}` version→key map |
| `CREDENTIAL_ENCRYPTION_KEY_VERSION` | With keyring | Active key version integer |
| `CREDENTIAL_ENCRYPTION_ALLOW_PLAINTEXT` | Dev only | Set `true` to allow unencrypted mode |

## Test plan
- [x] `go test ./pkg/crypto/` — 20 tests pass
- [x] `go test ./plugins/credentials/` — 14 tests pass (integration, testcontainers)
- [x] Kind cluster: create credential, verify DB ciphertext, verify API plaintext
- [x] Existing tests unbroken (plaintext passthrough with nil keyring)
- [ ] Deploy to hcmais with encryption key Secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential token encryption at rest in the database with configurable key management.
  * Added a new CLI command for bulk credential encryption and decryption operations.
  * Added startup validation to ensure encryption configuration is properly set when encrypted credentials exist.

* **Bug Fixes**
  * Fixed credential ID generation to preserve existing IDs instead of overwriting them during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->