### PR TITLE
fix(backend): include thread_id in between-run listener events URL

### DIFF
--- a/components/backend/websocket/agui_proxy.go
+++ b/components/backend/websocket/agui_proxy.go
@@ -1171,7 +1171,7 @@ func listenBetweenRunEvents(projectName, sessionName string) {
 
 	for attempt := 0; attempt < betweenRunMaxRetries; attempt++ {
 		runnerURL := getRunnerEndpoint(projectName, sessionName)
-		eventsURL := strings.TrimSuffix(runnerURL, "/") + "/events"
+		eventsURL := strings.TrimSuffix(runnerURL, "/") + "/events/" + sessionName
 
 		req, err := http.NewRequest("GET", eventsURL, nil)
 		if err != nil {


### PR DESCRIPTION
## Summary
- The between-run listener (`listenBetweenRunEvents`) was constructing the runner SSE URL as `GET /events` without the required `{thread_id}` path parameter, causing 404 errors from the runner pod
- Fixed by appending `sessionName` (which is the thread_id convention) to the events URL: `/events/{sessionName}`

## Root Cause
The runner's SSE tap endpoint is `GET /events/{thread_id}` (`components/runners/ambient-runner/ambient_runner/endpoints/events.py:45`). Without the path parameter, FastAPI returns 404.

## Test plan
- [ ] Deploy to UAT and verify runner pod logs no longer show `GET /events HTTP/1.1 404`
- [ ] Verify between-run events (e.g., background task completions) are captured and displayed in the frontend
- [ ] Verify existing run-initiated SSE streaming continues to work normally

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session event handling reliability by implementing session-specific event routing on the backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->